### PR TITLE
feat: Replace manual release steps with GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,6 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Lowercase image name
-        id: image
-        run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -45,59 +41,64 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Sign the container image
+          version: '~> v2'
+          args: release --clean
         env:
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-          TAGS: ${{ steps.meta.outputs.tags }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker image name
+        id: docker-image
         run: |
-          images=""
-          for tag in ${TAGS}; do
-            images+="${tag}@${DIGEST} "
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "name=${{ env.REGISTRY }}/${OWNER}/openclaw-operator" >> $GITHUB_OUTPUT
+
+      - name: Sign container images
+        run: |
+          IMAGE="${{ steps.docker-image.outputs.name }}"
+          # Extract major.minor matching goreleaser's {{ .Major }}.{{ .Minor }}
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          TAGS=("latest" "${{ github.ref_name }}" "${MAJOR}.${MINOR}")
+
+          for tag in "${TAGS[@]}"; do
+            echo "Signing ${IMAGE}:${tag}..."
+            DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${tag}" --format '{{json .Manifest}}' | jq -r '.digest')
+            if [ -n "$DIGEST" ] && [ "$DIGEST" != "null" ]; then
+              cosign sign --yes "${IMAGE}:${tag}@${DIGEST}"
+            else
+              echo "Warning: could not resolve digest for ${IMAGE}:${tag}, skipping"
+            fi
           done
-          cosign sign --yes ${images}
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ steps.build-and-push.outputs.digest }}
+          image: ${{ steps.docker-image.outputs.name }}:${{ github.ref_name }}
           format: spdx-json
           output-file: sbom.spdx.json
           upload-release-assets: false
 
       - name: Attest SBOM
         run: |
+          IMAGE="${{ steps.docker-image.outputs.name }}"
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${{ github.ref_name }}" --format '{{json .Manifest}}' | jq -r '.digest')
           cosign attest --yes --predicate sbom.spdx.json --type spdxjson \
-            ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}@${{ steps.build-and-push.outputs.digest }}
+            "${IMAGE}@${DIGEST}"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          files: |
-            sbom.spdx.json
+      - name: Upload SBOM to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" sbom.spdx.json --clobber
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false
 
   helm-release:
     name: Helm Chart Release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,73 @@
+version: 2
+
+project_name: openclaw-operator
+
+builds:
+  - id: manager
+    main: ./cmd/main.go
+    binary: manager
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+dockers_v2:
+  - id: openclaw-operator
+    dockerfile: Dockerfile
+    ids:
+      - manager
+    images:
+      - "ghcr.io/openclaw-rocks/openclaw-operator"
+    tags:
+      - "{{ .Tag }}"
+      - "{{ .Major }}.{{ .Minor }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.title": "{{ .ProjectName }}"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.created": "{{ .Date }}"
+      "org.opencontainers.image.source": "{{ .GitURL }}"
+    build_args:
+      PREBUILT_BINARY: "manager"
+    extra_files:
+      - cmd/
+      - api/
+      - internal/
+      - go.mod
+      - go.sum
+
+archives:
+  - id: binaries
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  draft: true
+  github:
+    owner: openclaw-rocks
+    name: k8s-operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,26 @@ FROM golang:1.24-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG TARGETPLATFORM
+# When set, skip compilation and use the pre-built binary instead (used by GoReleaser)
+ARG PREBUILT_BINARY
 
 WORKDIR /workspace
 
-# Copy go mod files
+# Copy dependency files first for caching
 COPY go.mod go.sum ./
-RUN go mod download
+RUN if [ -z "$PREBUILT_BINARY" ]; then go mod download; fi
 
-# Copy source code
-COPY cmd/ cmd/
-COPY api/ api/
-COPY internal/ internal/
+# Copy everything else (source code, and GoReleaser platform dirs if present)
+COPY . .
 
-# Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager cmd/main.go
+# Use pre-built binary if available, otherwise build from source.
+# GoReleaser (dockers_v2) places binaries under $TARGETPLATFORM/ (e.g., linux/amd64/manager).
+RUN if [ -n "$PREBUILT_BINARY" ] && [ -f "${TARGETPLATFORM}/${PREBUILT_BINARY}" ]; then \
+      cp "${TARGETPLATFORM}/${PREBUILT_BINARY}" manager; \
+    else \
+      CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -a -o manager cmd/main.go; \
+    fi
 
 # Runtime stage - use distroless for minimal attack surface
 FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
## Summary
- Add `.goreleaser.yaml` with `dockers_v2` for multi-arch Docker images (`linux/amd64`, `linux/arm64`), cross-compiled binaries, checksums, and auto-generated changelog
- Replace manual Docker build/push/sign/release workflow steps with `goreleaser-action`, keeping Cosign signing and SBOM attestation as post-build steps
- Use draft release workflow so SBOM can be uploaded before publishing (required by repository immutable release rules)
- Update `Dockerfile` to accept a pre-built binary from GoReleaser (via `PREBUILT_BINARY` build arg), avoiding double-compilation while preserving standalone `docker build` support

## Verified
- [x] `goreleaser check` passes
- [x] Full CI pipeline passes (`v0.1.0-rc.4`): binaries, Docker images, Cosign signatures, SBOM attestation, GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)