### PR TITLE
fix: Remove chart-releaser, keep OCI-only Helm distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,17 +111,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Lowercase owner name
         id: owner
         run: echo "name=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -146,10 +139,3 @@ jobs:
         run: |
           helm package charts/openclaw-operator
           helm push openclaw-operator-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ steps.owner.outputs.name }}/charts
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        with:
-          charts_dir: charts
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Remove `helm/chart-releaser-action` which fails due to repository immutable releases rule (can't upload assets after release creation)
- Keep OCI registry push (`helm push`) which already works — users install via `helm install openclaw-operator oci://ghcr.io/openclaw-rocks/charts/openclaw-operator`
- Remove `Configure Git` step and `fetch-depth: 0` that were only needed for chart-releaser's gh-pages operations

## Test plan
- [x] Helm OCI push already verified working in v0.2.0 release
- [ ] Tag a release after merge to confirm clean workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)