### PR TITLE
fix: Set HOME env var to match config mount path

### DIFF
--- a/internal/resources/deployment.go
+++ b/internal/resources/deployment.go
@@ -184,7 +184,9 @@ func buildMainContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Cont
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Env:       instance.Spec.Env,
+		Env: append([]corev1.EnvVar{
+			{Name: "HOME", Value: "/home/openclaw"},
+		}, instance.Spec.Env...),
 		EnvFrom:   instance.Spec.EnvFrom,
 		Resources: buildResourceRequirements(instance),
 		VolumeMounts: []corev1.VolumeMount{

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -317,6 +317,11 @@ func TestBuildDeployment_Defaults(t *testing.T) {
 		t.Error("container security context: seccomp profile should be RuntimeDefault")
 	}
 
+	// HOME env var must be set to match the mount path
+	if len(main.Env) < 1 || main.Env[0].Name != "HOME" || main.Env[0].Value != "/home/openclaw" {
+		t.Error("HOME env var should be set to /home/openclaw")
+	}
+
 	// Ports
 	if len(main.Ports) != 2 {
 		t.Fatalf("expected 2 ports, got %d", len(main.Ports))
@@ -840,8 +845,8 @@ func TestBuildDeployment_EnvAndEnvFrom(t *testing.T) {
 	dep := BuildDeployment(instance)
 	main := dep.Spec.Template.Spec.Containers[0]
 
-	if len(main.Env) != 1 || main.Env[0].Name != "MY_VAR" {
-		t.Error("env vars not passed through")
+	if len(main.Env) != 2 || main.Env[0].Name != "HOME" || main.Env[1].Name != "MY_VAR" {
+		t.Error("env vars should include HOME followed by user-defined vars")
 	}
 	if len(main.EnvFrom) != 1 || main.EnvFrom[0].SecretRef.Name != "api-keys" {
 		t.Error("envFrom not passed through")


### PR DESCRIPTION
## Summary
- Injects `HOME=/home/openclaw` into the operator-generated container spec so the OpenClaw binary finds its config at `$HOME/.openclaw/openclaw.json`
- The container image defaults to `HOME=/home/node`, but the operator mounts config at `/home/openclaw/.openclaw` — this mismatch causes the binary to crash on startup
- Users can still override `HOME` via `spec.env` since operator-set vars are prepended

Fixes #4

## Test plan
- [x] `TestBuildDeployment_Defaults` verifies HOME env var is set
- [x] `TestBuildDeployment_EnvAndEnvFrom` verifies HOME is prepended before user vars
- [ ] Deploy operator and verify OpenClaw container starts without the workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)