### PR TITLE
feat: Inject CHROMIUM_URL env var when sidecar is enabled

### DIFF
--- a/internal/resources/deployment.go
+++ b/internal/resources/deployment.go
@@ -184,9 +184,7 @@ func buildMainContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Cont
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Env: append([]corev1.EnvVar{
-			{Name: "HOME", Value: "/home/openclaw"},
-		}, instance.Spec.Env...),
+		Env: buildMainEnv(instance),
 		EnvFrom:   instance.Spec.EnvFrom,
 		Resources: buildResourceRequirements(instance),
 		VolumeMounts: []corev1.VolumeMount{
@@ -222,6 +220,22 @@ func buildMainContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Cont
 	container.StartupProbe = buildStartupProbe(instance)
 
 	return container
+}
+
+// buildMainEnv creates the environment variables for the main container
+func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance) []corev1.EnvVar {
+	env := []corev1.EnvVar{
+		{Name: "HOME", Value: "/home/openclaw"},
+	}
+
+	if instance.Spec.Chromium.Enabled {
+		env = append(env, corev1.EnvVar{
+			Name:  "CHROMIUM_URL",
+			Value: "ws://localhost:9222",
+		})
+	}
+
+	return append(env, instance.Spec.Env...)
 }
 
 // buildChromiumContainer creates the Chromium sidecar container

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -422,6 +422,22 @@ func TestBuildDeployment_WithChromium(t *testing.T) {
 		t.Fatal("chromium container not found")
 	}
 
+	// Main container should have CHROMIUM_URL env var
+	mainContainer := containers[0]
+	foundChromiumURL := false
+	for _, env := range mainContainer.Env {
+		if env.Name == "CHROMIUM_URL" {
+			foundChromiumURL = true
+			if env.Value != "ws://localhost:9222" {
+				t.Errorf("CHROMIUM_URL = %q, want %q", env.Value, "ws://localhost:9222")
+			}
+			break
+		}
+	}
+	if !foundChromiumURL {
+		t.Error("main container should have CHROMIUM_URL env var when chromium is enabled")
+	}
+
 	// Chromium image defaults
 	if chromium.Image != "ghcr.io/browserless/chromium:latest" {
 		t.Errorf("chromium image = %q, want default", chromium.Image)


### PR DESCRIPTION
## Summary
- Injects `CHROMIUM_URL=ws://localhost:9222` into the main OpenClaw container when `spec.chromium.enabled` is true
- Extracted env var building into `buildMainEnv()` for cleaner conditional logic
- Added test coverage verifying the env var is present with correct value

## Test plan
- [x] All existing resource builder tests pass
- [x] `TestBuildDeployment_WithChromium` verifies `CHROMIUM_URL` is injected
- [x] `TestBuildDeployment_Defaults` confirms no `CHROMIUM_URL` when chromium is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)