### PR TITLE
fix: Bump chromium /dev/shm from 256Mi to 1Gi

### DIFF
--- a/internal/resources/deployment.go
+++ b/internal/resources/deployment.go
@@ -359,7 +359,7 @@ func buildVolumes(instance *openclawv1alpha1.OpenClawInstance) []corev1.Volume {
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{
 						Medium:    corev1.StorageMediumMemory,
-						SizeLimit: resource.NewQuantity(256*1024*1024, resource.BinarySI), // 256Mi
+						SizeLimit: resource.NewQuantity(1024*1024*1024, resource.BinarySI), // 1Gi
 					},
 				},
 			},

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -500,12 +500,12 @@ func TestBuildDeployment_WithChromium(t *testing.T) {
 	if shmVol.EmptyDir.Medium != corev1.StorageMediumMemory {
 		t.Errorf("chromium-shm medium = %v, want Memory", shmVol.EmptyDir.Medium)
 	}
-	expectedShmSize := resource.NewQuantity(256*1024*1024, resource.BinarySI) // 256Mi
+	expectedShmSize := resource.NewQuantity(1024*1024*1024, resource.BinarySI) // 1Gi
 	if shmVol.EmptyDir.SizeLimit == nil {
 		t.Fatal("chromium-shm sizeLimit is nil")
 	}
 	if shmVol.EmptyDir.SizeLimit.Cmp(*expectedShmSize) != 0 {
-		t.Errorf("chromium-shm sizeLimit = %v, want 256Mi", shmVol.EmptyDir.SizeLimit.String())
+		t.Errorf("chromium-shm sizeLimit = %v, want 1Gi", shmVol.EmptyDir.SizeLimit.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Increased chromium sidecar `/dev/shm` sizeLimit from 256Mi to 1Gi
- 256Mi can be insufficient for heavy pages, causing crashes or hangs
- Updated test assertion to match

## Test plan
- [x] `TestBuildDeployment_WithChromium` passes with updated 1Gi expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)