### PR TITLE
fix: Chromium sidecar crash (UID mismatch + read-only rootfs)

### DIFF
--- a/internal/resources/deployment.go
+++ b/internal/resources/deployment.go
@@ -186,7 +186,7 @@ func buildMainContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Cont
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
-		Env: buildMainEnv(instance),
+		Env:       buildMainEnv(instance),
 		EnvFrom:   instance.Spec.EnvFrom,
 		Resources: buildResourceRequirements(instance),
 		VolumeMounts: []corev1.VolumeMount{
@@ -288,9 +288,9 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: Ptr(false),
-			ReadOnlyRootFilesystem:   Ptr(true),
+			ReadOnlyRootFilesystem:   Ptr(false), // Chromium needs writable dirs for profiles, cache, crash dumps
 			RunAsNonRoot:             Ptr(true),
-			RunAsUser:                Ptr(int64(1001)),
+			RunAsUser:                Ptr(int64(999)), // browserless built-in user (blessuser)
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -460,11 +461,11 @@ func TestBuildDeployment_WithChromium(t *testing.T) {
 	if csc == nil {
 		t.Fatal("chromium security context is nil")
 	}
-	if csc.ReadOnlyRootFilesystem == nil || !*csc.ReadOnlyRootFilesystem {
-		t.Error("chromium: readOnlyRootFilesystem should be true")
+	if csc.ReadOnlyRootFilesystem == nil || *csc.ReadOnlyRootFilesystem {
+		t.Error("chromium: readOnlyRootFilesystem should be false (Chromium needs writable dirs)")
 	}
-	if csc.RunAsUser == nil || *csc.RunAsUser != 1001 {
-		t.Errorf("chromium: runAsUser = %v, want 1001", csc.RunAsUser)
+	if csc.RunAsUser == nil || *csc.RunAsUser != 999 {
+		t.Errorf("chromium: runAsUser = %v, want 999 (browserless blessuser)", csc.RunAsUser)
 	}
 
 	// Chromium resource defaults
@@ -1474,7 +1475,7 @@ func TestEnrichConfigWithModules_PreservesAlreadyEnabledModule(t *testing.T) {
 	}
 
 	// Should return unchanged (no modification needed)
-	if string(out) != string(input) {
+	if !bytes.Equal(out, input) {
 		t.Errorf("config should not be modified when module already enabled")
 	}
 }
@@ -1486,7 +1487,7 @@ func TestEnrichConfigWithModules_NoChannels(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(out) != string(input) {
+	if !bytes.Equal(out, input) {
 		t.Errorf("config without channels should not be modified")
 	}
 }
@@ -1549,7 +1550,7 @@ func TestEnrichConfigWithModules_InvalidJSON(t *testing.T) {
 		t.Fatal("should not error on invalid JSON")
 	}
 
-	if string(out) != string(input) {
+	if !bytes.Equal(out, input) {
 		t.Errorf("invalid JSON should be returned unchanged")
 	}
 }


### PR DESCRIPTION
## Summary
- **Chromium UID fix:** Change `runAsUser` from `1001` to `999` (browserless `blessuser`). UID 1001 has no `/etc/passwd` entry in the image, causing Node.js `uv_os_get_passwd` to fail with `ENOENT` on startup.
- **Writable rootfs:** Set `readOnlyRootFilesystem: false` — Chromium needs writable directories for browser profiles, cache, and crash dumps.
- **Lint fixes:** Fix `gofmt` alignment and replace `string([]byte)` comparisons with `bytes.Equal` (gocritic) from CI failure on #13.

Closes #12

## Test plan
- [x] Unit tests updated and passing for new security context values
- [x] All existing tests pass
- [x] `gofmt` clean
- [ ] Deploy with `chromium.enabled: true` and verify CDP endpoint (port 9222) is reachable
- [ ] Verify `uv_os_get_passwd` error no longer appears in chromium container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)