### PR TITLE
docs: Rewrite README for HN launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenClaw Kubernetes Operator
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Go Report Card](https://goreportcard.com/badge/github.com/openclawrocks/k8s-operator)](https://goreportcard.com/report/github.com/openclawrocks/k8s-operator)
+[![Go Report Card](https://goreportcard.com/badge/github.com/OpenClaw-rocks/k8s-operator)](https://goreportcard.com/report/github.com/OpenClaw-rocks/k8s-operator)
 [![CI](https://github.com/OpenClaw-rocks/k8s-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/OpenClaw-rocks/k8s-operator/actions/workflows/ci.yaml)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-1.28%2B-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io)
 [![Go](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go&logoColor=white)](https://go.dev)


### PR DESCRIPTION
## Summary
- Rewrites README with architecture diagram, feature table, "Why an Operator?" narrative, and structured security/observability sections
- Links openclaw.rocks in natural contexts for brand and SEO value
- Adds managed hosting CTA for visitors who don't want to self-host
- Fixes Go Report Card badge URL (used Go module path `openclawrocks` instead of GitHub org `OpenClaw-rocks`)

## Test plan
- [ ] Verify Go Report Card badge resolves correctly
- [ ] Confirm all internal doc links work (API reference, deployment guide, full example, roadmap)
- [ ] Check README renders correctly on GitHub (architecture diagram, tables, collapsible section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)