### PR TITLE
fix: Use correct GitHub org name in all references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Default owners for everything in the repo
-* @openclawrocks/maintainers
+* @OpenClaw-rocks/maintainers
 
 # API changes require additional review
-/api/ @openclawrocks/maintainers
+/api/ @OpenClaw-rocks/maintainers
 
 # Security-related changes
-/internal/webhook/ @openclawrocks/maintainers
-/internal/security/ @openclawrocks/maintainers
+/internal/webhook/ @OpenClaw-rocks/maintainers
+/internal/security/ @OpenClaw-rocks/maintainers

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/openclawrocks/openclaw-operator:latest
+IMG ?= ghcr.io/openclaw-rocks/openclaw-operator:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The operator reconciles this into a fully managed stack of 9+ Kubernetes resourc
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclawrocks/charts/openclaw-operator \
+  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
   --namespace openclaw-operator-system \
   --create-namespace
 ```
@@ -105,7 +105,7 @@ helm install openclaw-operator \
 make install
 
 # Deploy the operator
-make deploy IMG=ghcr.io/openclawrocks/openclaw-operator:latest
+make deploy IMG=ghcr.io/openclaw-rocks/openclaw-operator:latest
 ```
 
 </details>

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -10,10 +10,10 @@ keywords:
   - openclaw
   - ai
   - assistant
-home: https://github.com/openclawrocks/k8s-operator
+home: https://github.com/OpenClaw-rocks/k8s-operator
 sources:
-  - https://github.com/openclawrocks/k8s-operator
+  - https://github.com/OpenClaw-rocks/k8s-operator
 maintainers:
   - name: OpenClaw Community
-    url: https://github.com/openclawrocks
+    url: https://github.com/OpenClaw-rocks
 kubeVersion: ">=1.28.0-0"

--- a/charts/openclaw-operator/templates/NOTES.txt
+++ b/charts/openclaw-operator/templates/NOTES.txt
@@ -39,9 +39,9 @@ To learn more about the release, try:
 ## Documentation
 
 For more information, visit:
-https://github.com/openclawrocks/k8s-operator
+https://github.com/OpenClaw-rocks/k8s-operator
 
 ## Getting Help
 
 If you encounter any issues, please file an issue at:
-https://github.com/openclawrocks/k8s-operator/issues
+https://github.com/OpenClaw-rocks/k8s-operator/issues

--- a/charts/openclaw-operator/values.yaml
+++ b/charts/openclaw-operator/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 # Operator image configuration
 image:
-  repository: ghcr.io/openclawrocks/openclaw-operator
+  repository: ghcr.io/openclaw-rocks/openclaw-operator
   pullPolicy: IfNotPresent
   tag: ""  # Defaults to chart appVersion
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: controller
-    newName: ghcr.io/openclawrocks/openclaw-operator
+    newName: ghcr.io/openclaw-rocks/openclaw-operator
     newTag: latest

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -146,7 +146,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclawrocks/charts/openclaw-operator \
+  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -263,7 +263,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclawrocks/charts/openclaw-operator \
+  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -383,7 +383,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclawrocks/charts/openclaw-operator \
+  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -458,7 +458,7 @@ kubectl get storageclass
 ```bash
 # Add the OCI registry (no separate repo add needed for OCI)
 helm install openclaw-operator \
-  oci://ghcr.io/openclawrocks/charts/openclaw-operator \
+  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -467,14 +467,14 @@ helm install openclaw-operator \
 
 ```bash
 # Clone the repository
-git clone https://github.com/openclawrocks/k8s-operator.git
+git clone https://github.com/OpenClaw-rocks/k8s-operator.git
 cd k8s-operator
 
 # Install CRDs
 make install
 
 # Deploy the operator
-make deploy IMG=ghcr.io/openclawrocks/openclaw-operator:v0.1.0
+make deploy IMG=ghcr.io/openclaw-rocks/openclaw-operator:v0.1.0
 ```
 
 ### 4. Create an Instance


### PR DESCRIPTION
## Summary
- Fixes all `openclawrocks` (no hyphen) references to the correct `openclaw-rocks` / `OpenClaw-rocks` (with hyphen)
- The GitHub org is `OpenClaw-rocks`; GHCR namespace is `openclaw-rocks`. The old references pointed to a non-existent org, which would cause image pulls and Helm installs to fail
- `.goreleaser.yaml` already had the correct name; this aligns everything else

### Files changed
| File | What changed |
|------|-------------|
| `Makefile` | GHCR image default |
| `config/manager/kustomization.yaml` | Kustomize image override |
| `charts/openclaw-operator/Chart.yaml` | home, sources, maintainer URLs |
| `charts/openclaw-operator/values.yaml` | Default image repository |
| `charts/openclaw-operator/templates/NOTES.txt` | Docs and issues URLs |
| `docs/deployment.md` | All Helm OCI, GHCR image, and GitHub URLs |
| `README.md` | Helm OCI and Kustomize deploy instructions |
| `.github/CODEOWNERS` | Team references |

### Not changed (intentionally)
- `go.mod`, Go source imports, `PROJECT`, `.golangci.yaml`: these reference the Go module path (`github.com/openclawrocks/k8s-operator`) which is a separate concern; changing it would be a breaking change

## Test plan
- [ ] `helm template` renders correct image: `ghcr.io/openclaw-rocks/openclaw-operator`
- [ ] Verify CODEOWNERS resolves to the correct org team

🤖 Generated with [Claude Code](https://claude.com/claude-code)