### PR TITLE
fix: Link OpenClaw to openclaw.ai

### DIFF
--- a/bundle/manifests/openclaw-operator.v0.2.4.clusterserviceversion.yaml
+++ b/bundle/manifests/openclaw-operator.v0.2.4.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ spec:
     ## OpenClaw Kubernetes Operator
 
     A production-grade Kubernetes operator for deploying and managing
-    [OpenClaw](https://openclaw.rocks) AI agent instances.
+    [OpenClaw](https://openclaw.ai) AI agent instances.
 
     ### Features
 


### PR DESCRIPTION
## Summary
- Fixes the OpenClaw link in the OLM CSV description to point to `openclaw.ai` (the project) instead of `openclaw.rocks` (the hosting service)

OpenClaw the software lives at openclaw.ai. OpenClaw.rocks is the managed hosting service built on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)