### PR TITLE
fix: Update Chart.yaml appVersion and make Helm chart publicly accessible

### DIFF
--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openclaw-operator
 description: A Kubernetes operator for deploying and managing OpenClaw AI assistant instances
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.4
+appVersion: "v0.2.4"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Summary
- Updates `Chart.yaml` version/appVersion from `0.1.0` to `v0.2.4` to match the latest release
- This fixes the image pull issue for users installing directly from the git repo (e.g. via ArgoCD `repoURL: git`)

## Root cause analysis (401 error)
The OCI Helm chart **was successfully published** to `ghcr.io/openclaw-rocks/charts/openclaw-operator:0.2.4` during the v0.2.4 release, but the GHCR package visibility is set to **private**. This causes the `401 unauthorized` error when users try to pull it.

**Manual action required:** An org admin needs to change the package visibility to public:
1. Go to https://github.com/orgs/openclaw-rocks/packages/container/charts%2Fopenclaw-operator/settings
2. Under "Danger Zone", change visibility from Private to Public

## Root cause analysis (wrong image tag)
The committed `Chart.yaml` had `appVersion: "0.1.0"`, but the Helm template uses `{{ .Chart.AppVersion }}` as the default image tag. Since there's no `v0.1.0` image, the deployment would fail with `ImagePullBackOff`.

The release workflow already overrides these values at tag time for OCI publishes, but users consuming the chart directly from git (the ArgoCD workaround) get the stale values.

## Test plan
- [ ] Verify `helm template` renders the correct image tag `ghcr.io/openclaw-rocks/openclaw-operator:v0.2.4`
- [ ] After making the GHCR package public, verify `helm install` from OCI works without auth

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)