### PR TITLE
fix: Apply same CreateOrUpdate pattern to ServiceMonitor reconciler

### DIFF
--- a/internal/resources/servicemonitor.go
+++ b/internal/resources/servicemonitor.go
@@ -18,9 +18,19 @@ package resources
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	openclawv1alpha1 "github.com/openclawrocks/k8s-operator/api/v1alpha1"
 )
+
+// ServiceMonitorGVK returns the GroupVersionKind for ServiceMonitor
+func ServiceMonitorGVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   "monitoring.coreos.com",
+		Version: "v1",
+		Kind:    "ServiceMonitor",
+	}
+}
 
 // ServiceMonitorName returns the name of the ServiceMonitor
 func ServiceMonitorName(instance *openclawv1alpha1.OpenClawInstance) string {


### PR DESCRIPTION
## Summary

Follow-up to #29 — the ServiceMonitor reconciler was the only remaining reconciler still using the unconditional `r.Update()` pattern that caused the endless reconciliation loop in #28.

- Switch ServiceMonitor to `controllerutil.CreateOrUpdate` with a mutate function
- Extract `ServiceMonitorGVK()` helper for reuse

## Test plan
- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] All resource unit tests pass
- [x] No remaining `r.Update` calls on managed resources (only on the CR itself for finalizer management)

🤖 Generated with [Claude Code](https://claude.com/claude-code)