### PR TITLE
ci: Add reconcile guard to prevent unconditional Update regression

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,31 @@ jobs:
           install-mode: goinstall
           args: --timeout=5m
 
+  reconcile-guard:
+    name: Reconcile Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for unconditional Update on managed resources
+        run: |
+          # Detect bare r.Update/r.Create calls in the controller that bypass
+          # controllerutil.CreateOrUpdate. Only r.Update(ctx, instance) and
+          # r.Status().Update(ctx, instance) are allowed (CR-level updates).
+          # See: https://github.com/openclaw-rocks/k8s-operator/issues/28
+          VIOLATIONS=$(grep -n 'r\.Update(ctx,' internal/controller/openclawinstance_controller.go \
+            | grep -v 'instance)' \
+            | grep -v '// reconcile-guard:allow' || true)
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::Found bare r.Update() calls on managed resources. Use controllerutil.CreateOrUpdate instead."
+            echo "Violations:"
+            echo "$VIOLATIONS"
+            echo ""
+            echo "If this is intentional, add '// reconcile-guard:allow' to the line."
+            exit 1
+          fi
+          echo "No unconditional Update calls on managed resources found."
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a CI check that prevents reintroduction of the bare `r.Update()` pattern on managed resources that caused the endless reconciliation loop in #28.

**How it works:**
- Greps `internal/controller/openclawinstance_controller.go` for `r.Update(ctx,` calls
- Allows `r.Update(ctx, instance)` (CR-level finalizer updates are legitimate)
- Fails if any other target is found (e.g. `r.Update(ctx, obj)`, `r.Update(ctx, sm)`)
- Escape hatch: add `// reconcile-guard:allow` to any line that needs an exception

**New CI job:** `Reconcile Guard` — runs in parallel with Lint/Test/Security Scan, no dependencies, completes in seconds.

## Test plan
- [x] Verified locally: current code passes the check
- [x] Verified locally: old bug pattern (`r.Update(ctx, obj)`) is caught
- [x] Verified locally: escape hatch comment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)