### PR TITLE
Update banner with real OpenClaw and Kubernetes logos

### DIFF
--- a/docs/images/banner.svg
+++ b/docs/images/banner.svg
@@ -9,17 +9,9 @@
       <stop offset="0%" style="stop-color:#1565C0"/>
       <stop offset="100%" style="stop-color:#0D47A1"/>
     </linearGradient>
-    <linearGradient id="crabBody" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#FF6F00"/>
-      <stop offset="100%" style="stop-color:#E65100"/>
-    </linearGradient>
-    <linearGradient id="crabBodyLight" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#FF8F00"/>
-      <stop offset="100%" style="stop-color:#FF6F00"/>
-    </linearGradient>
-    <linearGradient id="wheel" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#BBDEFB"/>
-      <stop offset="100%" style="stop-color:#90CAF9"/>
+    <linearGradient id="lobster" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f87171"/>
+      <stop offset="100%" stop-color="#dc2626"/>
     </linearGradient>
     <linearGradient id="ship" x1="0%" y1="0%" x2="0%" y2="100%">
       <stop offset="0%" style="stop-color:#5D4037"/>
@@ -77,148 +69,117 @@
   <!-- Railing -->
   <line x1="480" y1="345" x2="720" y2="345" stroke="#8D6E63" stroke-width="1.5"/>
 
-  <!-- Kubernetes-style ship wheel (behind crab) -->
-  <g transform="translate(600, 270)">
-    <!-- Outer ring -->
-    <circle cx="0" cy="0" r="65" fill="none" stroke="url(#wheel)" stroke-width="8" opacity="0.9" filter="url(#glow)"/>
-    <!-- Inner ring -->
-    <circle cx="0" cy="0" r="18" fill="none" stroke="url(#wheel)" stroke-width="6" opacity="0.9"/>
-    <!-- 7 spokes (like Kubernetes logo) -->
-    <line x1="0" y1="-18" x2="0" y2="-65" stroke="url(#wheel)" stroke-width="7" stroke-linecap="round" opacity="0.9"/>
-    <line x1="15.9" y1="-8.7" x2="57.4" y2="-31.4" stroke="url(#wheel)" stroke-width="7" stroke-linecap="round" opacity="0.9"/>
-    <line x1="17.3" y1="5.6" x2="62.4" y2="20.3" stroke="url(#wheel)" stroke-width="7" stroke-linecap="round" opacity="0.9"/>
-    <line x1="7.8" y1="16.2" x2="28.2" y2="58.6" stroke="url(#wheel)" stroke-width="7" stroke-linecap="round" opacity="0.9"/>
-    <line x1="-7.8" y1="16.2" x2="-28.2" y2="58.6" stroke="url(#wheel)" stroke-width="7" stroke-linecap="round" opacity="0.9"/>
-    <line x1="-17.3" y1="5.6" x2="-62.4" y2="20.3" stroke="url(#wheel)" stroke-width="7" stroke-linecap="round" opacity="0.9"/>
-    <line x1="-15.9" y1="-8.7" x2="-57.4" y2="-31.4" stroke="url(#wheel)" stroke-width="7" stroke-linecap="round" opacity="0.9"/>
-    <!-- Spoke end circles -->
-    <circle cx="0" cy="-65" r="9" fill="url(#wheel)" opacity="0.9"/>
-    <circle cx="57.4" cy="-31.4" r="9" fill="url(#wheel)" opacity="0.9"/>
-    <circle cx="62.4" cy="20.3" r="9" fill="url(#wheel)" opacity="0.9"/>
-    <circle cx="28.2" cy="58.6" r="9" fill="url(#wheel)" opacity="0.9"/>
-    <circle cx="-28.2" cy="58.6" r="9" fill="url(#wheel)" opacity="0.9"/>
-    <circle cx="-62.4" cy="20.3" r="9" fill="url(#wheel)" opacity="0.9"/>
-    <circle cx="-57.4" cy="-31.4" r="9" fill="url(#wheel)" opacity="0.9"/>
+  <!-- === MAIN LOBSTER (captain, at the wheel) === -->
+  <g transform="translate(540, 240) scale(1.1)">
+    <!-- Main body -->
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster)"/>
+
+    <!-- Left claw -->
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster)"/>
+
+    <!-- Right claw -->
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster)"/>
+
+    <!-- Antennae -->
+    <path d="M45 15 Q35 5 30 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <path d="M75 15 Q85 5 90 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+
+    <!-- Captain hat -->
+    <ellipse cx="60" cy="14" rx="32" ry="6" fill="#1a237e"/>
+    <rect x="36" y="-10" width="48" height="24" rx="4" fill="#1a237e"/>
+    <rect x="38" y="-2" width="44" height="4" fill="#FFD700"/>
+    <!-- Hat emblem (anchor) -->
+    <circle cx="60" cy="-6" r="4" fill="none" stroke="#FFD700" stroke-width="1.5"/>
+    <line x1="60" y1="-10" x2="60" y2="-14" stroke="#FFD700" stroke-width="1.5"/>
+    <line x1="57" y1="-13" x2="63" y2="-13" stroke="#FFD700" stroke-width="1.5"/>
+
+    <!-- Left sunglasses lens -->
+    <path d="M30 32 L52 32 L52 42 Q52 46 48 46 L34 46 Q30 46 30 42 Z" fill="#0a0a0b"/>
+    <!-- Right sunglasses lens -->
+    <path d="M68 32 L90 32 L90 42 Q90 46 86 46 L72 46 Q68 46 68 42 Z" fill="#0a0a0b"/>
+    <!-- Sunglasses bridge -->
+    <path d="M52 36 L68 36" stroke="#0a0a0b" stroke-width="3"/>
+    <!-- Lens reflections -->
+    <rect x="32" y="34" width="6" height="2" fill="#fafafa" opacity="0.3" rx="1"/>
+    <rect x="70" y="34" width="6" height="2" fill="#fafafa" opacity="0.3" rx="1"/>
+
+    <!-- Happy mouth -->
+    <path d="M48 60 Q60 70 72 60" fill="none" stroke="#991b1b" stroke-width="2" stroke-linecap="round"/>
+
   </g>
 
-  <!-- Main crab (captain) — body -->
-  <ellipse cx="600" cy="280" rx="52" ry="40" fill="url(#crabBody)"/>
-  <!-- Shell highlight -->
-  <ellipse cx="600" cy="270" rx="38" ry="25" fill="url(#crabBodyLight)" opacity="0.6"/>
-
-  <!-- Crab face -->
-  <!-- Eyes on stalks -->
-  <line x1="580" y1="255" x2="575" y2="235" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-  <line x1="620" y1="255" x2="625" y2="235" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-  <circle cx="575" cy="232" r="7" fill="#FFF"/>
-  <circle cx="625" cy="232" r="7" fill="#FFF"/>
-  <circle cx="577" cy="231" r="4" fill="#1a1a2e"/>
-  <circle cx="623" cy="231" r="4" fill="#1a1a2e"/>
-  <!-- Tiny eye highlights -->
-  <circle cx="579" cy="229" r="1.5" fill="#fff"/>
-  <circle cx="625" cy="229" r="1.5" fill="#fff"/>
-
-  <!-- Crab smile -->
-  <path d="M588 290 Q600 300 612 290" fill="none" stroke="#BF360C" stroke-width="2.5" stroke-linecap="round"/>
-
-  <!-- Captain hat -->
-  <ellipse cx="600" cy="245" rx="40" ry="8" fill="#1a237e"/>
-  <rect x="572" y="215" width="56" height="30" rx="4" fill="#1a237e"/>
-  <rect x="575" y="225" width="50" height="4" fill="#FFD700"/>
-  <!-- Hat emblem (anchor shape) -->
-  <circle cx="600" cy="220" r="5" fill="none" stroke="#FFD700" stroke-width="1.5"/>
-  <line x1="600" y1="215" x2="600" y2="210" stroke="#FFD700" stroke-width="1.5"/>
-  <line x1="596" y1="211" x2="604" y2="211" stroke="#FFD700" stroke-width="1.5"/>
-
-  <!-- Left claw arm gripping wheel -->
-  <path d="M548 280 Q510 260 490 240 Q480 230 500 225" fill="none" stroke="#E65100" stroke-width="10" stroke-linecap="round"/>
-  <!-- Left claw pincer -->
-  <path d="M500 225 L488 215 Q483 210 488 208 L500 218" fill="#FF6F00" stroke="#E65100" stroke-width="2"/>
-  <path d="M500 225 L508 212 Q512 207 508 205 L498 218" fill="#FF6F00" stroke="#E65100" stroke-width="2"/>
-
-  <!-- Right claw arm gripping wheel -->
-  <path d="M652 280 Q690 260 710 240 Q720 230 700 225" fill="none" stroke="#E65100" stroke-width="10" stroke-linecap="round"/>
-  <!-- Right claw pincer -->
-  <path d="M700 225 L712 215 Q717 210 712 208 L700 218" fill="#FF6F00" stroke="#E65100" stroke-width="2"/>
-  <path d="M700 225 L692 212 Q688 207 692 205 L702 218" fill="#FF6F00" stroke="#E65100" stroke-width="2"/>
-
-  <!-- Crab legs (3 per side) -->
-  <path d="M555 300 Q530 310 510 330 Q505 340 515 345" fill="none" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-  <path d="M555 310 Q535 325 520 350 Q518 358 525 358" fill="none" stroke="#E65100" stroke-width="4" stroke-linecap="round"/>
-  <path d="M560 318 Q545 338 540 358 Q540 365 547 363" fill="none" stroke="#E65100" stroke-width="4" stroke-linecap="round"/>
-
-  <path d="M645 300 Q670 310 690 330 Q695 340 685 345" fill="none" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-  <path d="M645 310 Q665 325 680 350 Q682 358 675 358" fill="none" stroke="#E65100" stroke-width="4" stroke-linecap="round"/>
-  <path d="M640 318 Q655 338 660 358 Q660 365 653 363" fill="none" stroke="#E65100" stroke-width="4" stroke-linecap="round"/>
-
-  <!-- Small crab 1 (port side lookout) -->
-  <g transform="translate(310, 330) scale(0.4)">
-    <ellipse cx="0" cy="0" rx="40" ry="30" fill="url(#crabBody)"/>
-    <ellipse cx="0" cy="-8" rx="28" ry="18" fill="url(#crabBodyLight)" opacity="0.5"/>
-    <line x1="-15" y1="-20" x2="-18" y2="-38" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <line x1="15" y1="-20" x2="18" y2="-38" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <circle cx="-18" cy="-40" r="6" fill="#FFF"/>
-    <circle cx="18" cy="-40" r="6" fill="#FFF"/>
-    <circle cx="-16" cy="-41" r="3.5" fill="#1a1a2e"/>
-    <circle cx="20" cy="-41" r="3.5" fill="#1a1a2e"/>
-    <circle cx="-15" cy="-42" r="1.2" fill="#fff"/>
-    <circle cx="21" cy="-42" r="1.2" fill="#fff"/>
-    <path d="M-8 8 Q0 15 8 8" fill="none" stroke="#BF360C" stroke-width="2" stroke-linecap="round"/>
-    <!-- Tiny claws raised in excitement -->
-    <path d="M-40 -5 Q-55 -20 -50 -30" fill="none" stroke="#E65100" stroke-width="6" stroke-linecap="round"/>
-    <path d="M-50 -30 L-58 -38" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
-    <path d="M-50 -30 L-44 -40" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
-    <path d="M40 -5 Q55 -20 50 -30" fill="none" stroke="#E65100" stroke-width="6" stroke-linecap="round"/>
-    <path d="M50 -30 L58 -38" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
-    <path d="M50 -30 L44 -40" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
+  <!-- Kubernetes logo (in front of lobster, held as steering wheel) -->
+  <g transform="translate(606, 330) scale(0.10) translate(-388, -367)" filter="url(#softGlow)">
+    <g transform="translate(-21.475962,-178.535)">
+      <g transform="matrix(1.0556855,0,0,1.0556855,-1.1958992,-9.9418072)">
+        <path fill="#326ce5" d="m 386.93188,178.59794 a 48.929668,48.529248 0 0 0 -18.75129,4.74509 L 112.30567,305.60274 A 48.929668,48.529248 0 0 0 85.831333,338.52385 L 22.705266,613.15006 a 48.929668,48.529248 0 0 0 6.643127,37.20805 48.929668,48.529248 0 0 0 2.781605,3.86153 L 209.23642,874.42456 a 48.929668,48.529248 0 0 0 38.25525,18.26042 l 284.01821,-0.0654 a 48.929668,48.529248 0 0 0 38.25525,-18.22769 L 746.8061,654.15419 a 48.929668,48.529248 0 0 0 9.45745,-41.06958 L 693.03931,338.4584 A 48.929668,48.529248 0 0 0 666.56498,305.53729 L 410.65734,183.34303 a 48.929668,48.529248 0 0 0 -23.72546,-4.74509 z"/>
+        <path fill="#ffffff" d="m 389.46729,272.05685 c -8.45813,8.6e-4 -15.31619,7.61928 -15.31519,17.01687 10e-6,0.14423 0.0295,0.28205 0.0327,0.42542 -0.0125,1.27691 -0.0741,2.81523 -0.0327,3.92697 0.20171,5.42027 1.38324,9.56871 2.09439,14.56252 1.28834,10.68834 2.36788,19.54832 1.70169,27.78333 -0.64789,3.10534 -2.93516,5.94534 -4.97417,7.91939 l -0.35997,6.4795 c -9.19102,0.76149 -18.44352,2.1559 -27.68515,4.25422 -39.76672,9.02908 -74.00517,29.5131 -100.07232,57.17016 -1.69145,-1.15393 -4.65062,-3.27681 -5.53054,-3.92697 -2.7344,0.36926 -5.49798,1.21295 -9.09748,-0.88357 -6.85378,-4.61354 -13.09606,-10.98183 -20.64933,-18.65311 -3.46095,-3.66956 -5.96724,-7.16386 -10.07923,-10.701 -0.9338,-0.80327 -2.35888,-1.88971 -3.40337,-2.71616 -3.21476,-2.56307 -7.00645,-3.89976 -10.66827,-4.02514 -4.70807,-0.16121 -9.24037,1.67954 -12.20634,5.39958 -5.27283,6.61342 -3.58466,16.72163 3.76335,22.58009 0.0746,0.0594 0.15396,0.10554 0.22907,0.16362 1.00973,0.81851 2.24619,1.86728 3.1743,2.55254 4.36352,3.22174 8.34948,4.87096 12.69721,7.42852 9.15979,5.65673 16.75337,10.34716 22.77644,16.00241 2.35201,2.50715 2.7631,6.925 3.07612,8.83568 l 4.90872,4.38512 c -26.27764,39.54584 -38.43915,88.39294 -31.2521,138.16395 l -6.41405,1.86531 c -1.69048,2.18299 -4.07925,5.61791 -6.57773,6.64313 -7.88026,2.48206 -16.74905,3.39352 -27.45608,4.51601 -5.02684,0.41799 -9.36418,0.16855 -14.69342,1.17809 -1.17293,0.2222 -2.80722,0.64798 -4.09059,0.94902 -0.0446,0.009 -0.0863,0.0226 -0.1309,0.0327 -0.07,0.0162 -0.16185,0.0502 -0.22907,0.0654 -9.02695,2.18109 -14.82588,10.47821 -12.95901,18.65312 1.86731,8.17682 10.68465,13.14935 19.76576,11.19187 0.0656,-0.015 0.16074,-0.0175 0.22907,-0.0327 0.10252,-0.0235 0.19278,-0.0732 0.29452,-0.0981 1.2659,-0.27788 2.85232,-0.58705 3.9597,-0.88357 5.23946,-1.40285 9.03407,-3.46407 13.7444,-5.26868 10.13362,-3.63457 18.52665,-6.67085 26.70341,-7.85395 3.41508,-0.26747 7.01316,2.10712 8.80296,3.10886 l 6.67585,-1.14537 c 15.3625,47.62926 47.55736,86.12636 88.32413,110.28245 l -2.7816,6.67585 c 1.0026,2.59224 2.10843,6.09958 1.36158,8.65957 -2.97265,7.70859 -8.0644,15.84504 -13.86244,24.91604 -2.80737,4.19078 -5.68053,7.44303 -8.21392,12.23906 -0.60622,1.14761 -1.37829,2.91048 -1.96348,4.12332 -3.93623,8.4219 -1.04891,18.12187 6.51223,21.76197 7.60863,3.66295 17.05297,-0.20037 21.14019,-8.63934 0.006,-0.0119 0.0269,-0.0207 0.0327,-0.0327 0.004,-0.009 -0.004,-0.0236 0,-0.0327 0.58217,-1.19647 1.40694,-2.76916 1.89804,-3.89424 2.16992,-4.97105 2.89194,-9.23107 4.41784,-14.03893 4.05224,-10.17885 6.27862,-20.85905 11.85692,-27.51404 1.52752,-1.82236 4.01788,-2.52321 6.59985,-3.21451 l 3.46882,-6.28315 c 35.53987,13.64156 75.32106,17.30219 115.06027,8.27936 9.06551,-2.05833 17.81739,-4.72226 26.27798,-7.91939 0.97492,1.72926 2.78672,5.05344 3.27248,5.89046 2.62384,0.85365 5.48775,1.29447 7.82122,4.74509 4.17347,7.13031 7.0276,15.56563 10.50465,25.75439 1.52615,4.80777 2.28038,9.06798 4.45057,14.03892 0.49463,1.13301 1.31527,2.72779 1.89803,3.92697 4.07863,8.46638 13.55289,12.34291 21.17292,8.67206 7.56021,-3.64203 10.45071,-13.34112 6.51223,-21.76196 -0.58526,-1.2128 -1.38994,-2.97575 -1.99621,-4.12332 -2.53364,-4.79589 -5.40634,-8.01572 -8.21392,-12.20634 -5.79852,-9.0707 -10.60772,-16.60606 -13.58077,-24.3145 -1.24313,-3.97574 0.20973,-6.44834 1.17809,-9.03203 -0.57991,-0.66473 -1.82087,-4.41925 -2.55253,-6.18498 42.36668,-25.0155 73.61612,-64.94823 88.29141,-111.06785 1.9817,0.31146 5.42607,0.92086 6.54495,1.14537 2.30334,-1.51916 4.42118,-3.50131 8.57389,-3.1743 8.17681,1.18266 16.5696,4.2199 26.7034,7.85394 4.71043,1.80438 8.50488,3.89883 13.7444,5.30141 1.1074,0.29645 2.69378,0.57303 3.9597,0.85085 0.10179,0.0249 0.19195,0.0748 0.29452,0.0981 0.0684,0.0153 0.16352,0.0177 0.22908,0.0327 9.08163,1.95506 17.90054,-3.01456 19.76575,-11.19187 1.86478,-8.17539 -3.93147,-16.47444 -12.959,-18.65311 -1.31311,-0.29859 -3.17535,-0.80569 -4.45057,-1.0472 -5.32929,-1.00926 -9.66655,-0.76036 -14.69342,-1.17809 -10.70708,-1.12194 -19.57569,-2.03437 -27.45607,-4.51601 -3.21306,-1.24646 -5.49884,-5.06971 -6.61046,-6.64313 l -6.18498,-1.79986 c 3.20678,-23.19994 2.3421,-47.34497 -3.20703,-71.50361 -5.60079,-24.38357 -15.49883,-46.68472 -28.69961,-66.33309 1.58655,-1.44229 4.58271,-4.09548 5.43231,-4.87599 0.24835,-2.74801 0.035,-5.62922 2.87978,-8.67206 6.02276,-5.65557 13.61694,-10.3452 22.77643,-16.00241 4.3476,-2.55779 8.36659,-4.20655 12.72993,-7.42852 0.98672,-0.7286 2.33409,-1.88243 3.37065,-2.71616 7.34646,-5.86043 9.03788,-15.96803 3.76335,-22.58009 -5.27453,-6.61205 -15.49543,-7.23487 -22.84188,-1.37444 -1.04569,0.82818 -2.4646,1.90853 -3.40338,2.71616 -4.1118,3.53737 -6.65119,7.03126 -10.11195,10.701 -7.55286,7.67168 -13.79578,14.07193 -20.64932,18.68584 -2.96985,1.72897 -7.31984,1.13073 -9.29389,1.01446 l -5.82501,4.15605 C 500.27311,376.86318 455.0492,354.59475 406.3533,350.26897 c -0.1362,-2.04069 -0.31463,-5.72937 -0.35997,-6.83948 -1.99355,-1.90762 -4.40179,-3.53622 -5.00689,-7.65759 -0.66619,-8.23501 0.44607,-17.09499 1.73441,-27.78333 0.71115,-4.99381 1.89268,-9.14225 2.09439,-14.56252 0.0459,-1.23215 -0.0277,-3.02011 -0.0327,-4.35239 -10e-4,-9.39759 -6.85705,-17.01772 -15.31518,-17.01687 z m -19.17671,118.79088 -4.54874,80.33929 -0.32725,0.16363 c -0.30509,7.18725 -6.22028,12.92628 -13.4826,12.92628 -2.97487,0 -5.72075,-0.95534 -7.95212,-2.58526 l -0.1309,0.0654 -65.87494,-46.69823 c 20.24605,-19.90834 46.14234,-34.62059 75.9869,-41.39683 5.45167,-1.23781 10.90091,-2.15627 16.32965,-2.81433 z m 38.38615,0 c 34.84372,4.28545 67.06745,20.06297 91.76023,44.24388 l -65.44952,46.40371 -0.22908,-0.0981 c -5.80924,4.2429 -13.99408,3.19016 -18.52221,-2.48708 -1.85491,-2.32577 -2.82817,-5.06044 -2.94523,-7.82122 l -0.0655,-0.0327 z m -154.59178,74.21976 60.14811,53.79951 -0.0654,0.32725 c 5.42904,4.71967 6.22963,12.90973 1.70169,18.58767 -1.85478,2.32586 -4.33755,3.88585 -7.0031,4.61419 l -0.0654,0.2618 -77.09954,22.25283 c -3.92412,-35.88222 4.53283,-70.7626 22.38374,-99.84325 z m 270.33926,0.0327 c 8.93685,14.48535 15.70428,30.66403 19.73304,48.20357 3.98044,17.32923 4.97939,34.62748 3.33792,51.34515 l -77.49224,-22.31828 -0.0654,-0.32725 c -6.93922,-1.89651 -11.20383,-8.95519 -9.58835,-16.03514 0.66186,-2.90032 2.20143,-5.35391 4.28694,-7.16672 l -0.0327,-0.16362 59.82087,-53.53771 z M 377.13006,523.023 h 24.64174 l 15.31519,19.14398 -5.49776,23.88908 -22.12194,10.63555 -22.18739,-10.66828 -5.49776,-23.88907 z m 78.99757,65.51497 c 1.04717,-0.0529 2.08976,0.0415 3.10886,0.22907 l 0.1309,-0.16362 79.75024,13.4826 c -11.67148,32.79084 -34.00528,61.19811 -63.84601,80.20839 l -30.95762,-74.77608 0.0981,-0.1309 c -2.84377,-6.60777 0.002,-14.35654 6.54495,-17.50774 1.67514,-0.80677 3.42525,-1.2535 5.17051,-1.34172 z m -133.94245,0.32725 c 6.08601,0.0853 11.5449,4.30946 12.95901,10.50465 0.66202,2.90028 0.33981,5.77395 -0.75267,8.31209 l 0.22907,0.29452 -30.63038,74.02341 C 275.35248,663.62313 252.54242,636.1077 240.34055,602.34787 l 79.06303,-13.41715 0.1309,0.16362 c 0.88436,-0.16274 1.78127,-0.24127 2.6507,-0.22907 z m 66.79124,32.43029 c 2.11999,-0.0779 4.27113,0.35707 6.31588,1.34172 2.6803,1.29069 4.75083,3.32294 6.05408,5.75955 h 0.29452 l 38.9752,70.42369 c -5.05825,1.69565 -10.25839,3.1448 -15.57699,4.3524 -29.80784,6.7679 -59.52097,4.71725 -86.4261,-4.45057 l 38.87702,-70.29279 h 0.0654 c 2.3328,-4.36094 6.75698,-6.96265 11.42094,-7.134 z"/>
+      </g>
+    </g>
   </g>
 
-  <!-- Small crab 2 (starboard side, peeking over railing) -->
-  <g transform="translate(850, 335) scale(0.35)">
-    <ellipse cx="0" cy="0" rx="40" ry="30" fill="url(#crabBody)"/>
-    <ellipse cx="0" cy="-8" rx="28" ry="18" fill="url(#crabBodyLight)" opacity="0.5"/>
-    <line x1="-15" y1="-20" x2="-20" y2="-40" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <line x1="15" y1="-20" x2="20" y2="-40" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <circle cx="-20" cy="-42" r="6" fill="#FFF"/>
-    <circle cx="20" cy="-42" r="6" fill="#FFF"/>
-    <circle cx="-22" cy="-43" r="3.5" fill="#1a1a2e"/>
-    <circle cx="18" cy="-43" r="3.5" fill="#1a1a2e"/>
-    <circle cx="-23" cy="-44" r="1.2" fill="#fff"/>
-    <circle cx="17" cy="-44" r="1.2" fill="#fff"/>
-    <path d="M-8 8 Q0 15 8 8" fill="none" stroke="#BF360C" stroke-width="2" stroke-linecap="round"/>
-    <!-- Waving claw -->
-    <path d="M-40 -5 Q-60 -15 -55 -35" fill="none" stroke="#E65100" stroke-width="6" stroke-linecap="round"/>
-    <path d="M-55 -35 L-62 -42" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
-    <path d="M-55 -35 L-48 -44" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
-    <path d="M40 -5 Q55 5 60 -5" fill="none" stroke="#E65100" stroke-width="6" stroke-linecap="round"/>
-    <path d="M60 -5 L68 -12" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
-    <path d="M60 -5 L65 4" fill="none" stroke="#FF6F00" stroke-width="4" stroke-linecap="round"/>
+  <!-- === Small lobster 1 (port side lookout) === -->
+  <g transform="translate(310, 330) scale(0.35)">
+    <!-- Body -->
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster)"/>
+    <!-- Claws raised -->
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster)"/>
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster)"/>
+    <!-- Antennae -->
+    <path d="M45 15 Q35 5 30 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <path d="M75 15 Q85 5 90 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <!-- Sunglasses -->
+    <path d="M30 32 L52 32 L52 42 Q52 46 48 46 L34 46 Q30 46 30 42 Z" fill="#0a0a0b"/>
+    <path d="M68 32 L90 32 L90 42 Q90 46 86 46 L72 46 Q68 46 68 42 Z" fill="#0a0a0b"/>
+    <path d="M52 36 L68 36" stroke="#0a0a0b" stroke-width="3"/>
+    <rect x="32" y="34" width="6" height="2" fill="#fafafa" opacity="0.3" rx="1"/>
+    <rect x="70" y="34" width="6" height="2" fill="#fafafa" opacity="0.3" rx="1"/>
+    <!-- Smile -->
+    <path d="M48 60 Q60 70 72 60" fill="none" stroke="#991b1b" stroke-width="2" stroke-linecap="round"/>
   </g>
 
-  <!-- Small crab 3 (in the water, swimming alongside) -->
-  <g transform="translate(200, 395) scale(0.3)">
-    <ellipse cx="0" cy="0" rx="35" ry="25" fill="#FF6F00" opacity="0.8"/>
-    <line x1="-12" y1="-18" x2="-15" y2="-33" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <line x1="12" y1="-18" x2="15" y2="-33" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <circle cx="-15" cy="-35" r="5" fill="#FFF" opacity="0.9"/>
-    <circle cx="15" cy="-35" r="5" fill="#FFF" opacity="0.9"/>
-    <circle cx="-14" cy="-36" r="3" fill="#1a1a2e"/>
-    <circle cx="16" cy="-36" r="3" fill="#1a1a2e"/>
-    <path d="M-35 0 Q-50 -15 -45 -25" fill="none" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <path d="M35 0 Q50 -15 45 -25" fill="none" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
+  <!-- === Small lobster 2 (starboard side, peeking over railing) === -->
+  <g transform="translate(830, 325) scale(0.3)">
+    <!-- Body -->
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster)"/>
+    <!-- Claws -->
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster)"/>
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster)"/>
+    <!-- Antennae -->
+    <path d="M45 15 Q35 5 30 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <path d="M75 15 Q85 5 90 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <!-- Sunglasses -->
+    <path d="M30 32 L52 32 L52 42 Q52 46 48 46 L34 46 Q30 46 30 42 Z" fill="#0a0a0b"/>
+    <path d="M68 32 L90 32 L90 42 Q90 46 86 46 L72 46 Q68 46 68 42 Z" fill="#0a0a0b"/>
+    <path d="M52 36 L68 36" stroke="#0a0a0b" stroke-width="3"/>
+    <rect x="32" y="34" width="6" height="2" fill="#fafafa" opacity="0.3" rx="1"/>
+    <rect x="70" y="34" width="6" height="2" fill="#fafafa" opacity="0.3" rx="1"/>
+    <!-- Smile -->
+    <path d="M48 60 Q60 70 72 60" fill="none" stroke="#991b1b" stroke-width="2" stroke-linecap="round"/>
   </g>
 
-  <!-- Small crab 4 (in the water on the right) -->
-  <g transform="translate(1000, 405) scale(0.25)">
-    <ellipse cx="0" cy="0" rx="35" ry="25" fill="#FF6F00" opacity="0.7"/>
-    <line x1="-12" y1="-18" x2="-14" y2="-32" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <line x1="12" y1="-18" x2="14" y2="-32" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <circle cx="-14" cy="-34" r="5" fill="#FFF" opacity="0.8"/>
-    <circle cx="14" cy="-34" r="5" fill="#FFF" opacity="0.8"/>
-    <circle cx="-13" cy="-35" r="3" fill="#1a1a2e"/>
-    <circle cx="15" cy="-35" r="3" fill="#1a1a2e"/>
-    <path d="M-35 0 Q-48 -10 -42 -22" fill="none" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
-    <path d="M35 0 Q48 -10 42 -22" fill="none" stroke="#E65100" stroke-width="5" stroke-linecap="round"/>
+  <!-- === Small lobster 3 (in the water, swimming alongside) === -->
+  <g transform="translate(180, 385) scale(0.25)">
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster)" opacity="0.8"/>
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster)" opacity="0.8"/>
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster)" opacity="0.8"/>
+    <path d="M45 15 Q35 5 30 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <path d="M75 15 Q85 5 90 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <path d="M30 32 L52 32 L52 42 Q52 46 48 46 L34 46 Q30 46 30 42 Z" fill="#0a0a0b"/>
+    <path d="M68 32 L90 32 L90 42 Q90 46 86 46 L72 46 Q68 46 68 42 Z" fill="#0a0a0b"/>
+    <path d="M52 36 L68 36" stroke="#0a0a0b" stroke-width="3"/>
+  </g>
+
+  <!-- === Small lobster 4 (in the water on the right) === -->
+  <g transform="translate(980, 395) scale(0.22)">
+    <path d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z" fill="url(#lobster)" opacity="0.7"/>
+    <path d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z" fill="url(#lobster)" opacity="0.7"/>
+    <path d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z" fill="url(#lobster)" opacity="0.7"/>
+    <path d="M45 15 Q35 5 30 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <path d="M75 15 Q85 5 90 8" stroke="#f87171" stroke-width="2" stroke-linecap="round"/>
+    <path d="M30 32 L52 32 L52 42 Q52 46 48 46 L34 46 Q30 46 30 42 Z" fill="#0a0a0b"/>
+    <path d="M68 32 L90 32 L90 42 Q90 46 86 46 L72 46 Q68 46 68 42 Z" fill="#0a0a0b"/>
+    <path d="M52 36 L68 36" stroke="#0a0a0b" stroke-width="3"/>
   </g>
 
   <!-- Moon reflection on water -->


### PR DESCRIPTION
## Summary
- Replace generic crabs with the actual OpenClaw lobster design (red gradient, sunglasses, antennae)
- Replace approximated helm wheel with the official Kubernetes logo SVG
- Lobster captain now holds the K8s logo as a steering wheel
- Cleaned up side legs and arm sticks for a cleaner look

Closes #35

## Test plan
- [x] SVG renders correctly in browser
- [x] Banner displays properly at 1200x500

🤖 Generated with [Claude Code](https://claude.com/claude-code)