### PR TITLE
Fix banner alt text: crabs -> OpenClaws

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/images/banner.svg" alt="OpenClaw Kubernetes Operator — crabs sailing the Kubernetes seas" width="100%">
+  <img src="docs/images/banner.svg" alt="OpenClaw Kubernetes Operator — OpenClaws sailing the Kubernetes seas" width="100%">
 </p>
 
 # OpenClaw Kubernetes Operator


### PR DESCRIPTION
## Summary
- Update banner alt text to say "OpenClaws" instead of "crabs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)