### PR TITLE
fix: bump Helm chart version/appVersion to v0.4.0

### DIFF
--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openclaw-operator
 description: A Kubernetes operator for deploying and managing OpenClaw AI assistant instances
 type: application
-version: 0.2.4
-appVersion: "v0.2.4"
+version: 0.4.0
+appVersion: "v0.4.0"
 keywords:
   - kubernetes
   - operator
@@ -60,7 +60,13 @@ annotations:
             size: 10Gi
   artifacthub.io/images: |
     - name: openclaw-operator
-      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.2.4
+      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.4.0
   artifacthub.io/changes: |
+    - kind: fixed
+      description: Prevent endless Deployment reconciliation loop
+    - kind: fixed
+      description: Apply CreateOrUpdate pattern to ServiceMonitor reconciler
     - kind: added
-      description: Initial ArtifactHub listing with full operator metadata
+      description: CI reconcile guard to prevent unconditional Update regression
+    - kind: added
+      description: Support for custom sidecar containers


### PR DESCRIPTION
## Summary
- Bumps Helm chart `version` and `appVersion` from `0.2.4`/`v0.2.4` to `0.4.0`/`v0.4.0`
- Updates ArtifactHub image tag and changelog to reflect recent fixes
- The reconciliation loop fix (PR #29) was merged after v0.3.0 was tagged, so no released image contains the fix yet

## Context
Reported in #39 — a user cannot test the reconciliation fix because:
1. v0.3.0 was tagged before the fix landed
2. The Helm chart still pointed to v0.2.4
3. No image with the fix exists

After merging this PR, tagging `v0.4.0` will build and publish the image with all pending fixes.

Closes #39

## Test plan
- [ ] Verify chart renders correctly: `helm template openclaw charts/openclaw-operator/`
- [ ] After tagging v0.4.0, verify image is published to GHCR
- [ ] User @SamSpiri confirms the reconciliation loop is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)