### PR TITLE
ci: fix release-please token and automate OperatorHub submission

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Fork and submit to community-operators
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPERATORHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="openclaw-operator-v${VERSION}"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -12,4 +16,3 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds automated OperatorHub submission workflow (runs on each published release)
- Reverts release-please to use `GITHUB_TOKEN` (better practice than PAT)

## Setup required

### 1. Enable org setting for release-please
Go to **Organization Settings → Actions → General → Workflow permissions** and enable:
- ✅ "Allow GitHub Actions to create and approve pull requests"

This lets `GITHUB_TOKEN` create release-please PRs without a PAT. The token is auto-scoped to this repo and ephemeral — more secure than a PAT.

### 2. Create PAT for OperatorHub (cross-repo PRs)
The OperatorHub workflow needs to fork and create PRs on `k8s-operatorhub/community-operators`, which requires a PAT with `public_repo` scope:
```bash
gh secret set OPERATORHUB_TOKEN
```

## How OperatorHub automation works
1. Release is published (release-please tag → GoReleaser → signing → publish)
2. `operatorhub.yaml` triggers on the `release: published` event
3. Prepares versioned bundle (updates CSV version, image tag, timestamp)
4. Forks `k8s-operatorhub/community-operators`
5. Creates PR with standard format `operator openclaw-operator (x.y.z)`

## Files changed
| File | Change |
|------|--------|
| `.github/workflows/release-please.yaml` | Revert to `GITHUB_TOKEN` with explicit permissions |
| `.github/workflows/operatorhub.yaml` | New workflow for auto-submitting to OperatorHub |

## Test plan
- [ ] Enable org setting for PR creation
- [ ] Create `OPERATORHUB_TOKEN` PAT secret
- [ ] Merge → release-please creates release PR
- [ ] After release, OperatorHub PR is auto-submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)