### PR TITLE
fix: use PAT for release-please to trigger release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -16,3 +12,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # PAT required: tags created by GITHUB_TOKEN don't trigger
+          # downstream workflows (release.yaml). A PAT makes the tag
+          # push appear as a user action, which triggers the release.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Problem
Tags created by `GITHUB_TOKEN` don't trigger downstream workflows (GitHub security feature to prevent recursive loops). The v0.4.0 tag was created but the release workflow never ran.

## Fix
Use `RELEASE_PLEASE_TOKEN` PAT so the tag push appears as a user action and triggers `release.yaml`.

## Setup
Create a PAT (classic) with `repo` + `workflow` scopes:
```bash
gh secret set RELEASE_PLEASE_TOKEN
```
This same token is also used by the OperatorHub workflow for cross-repo PRs.

## After merging
1. Add the `RELEASE_PLEASE_TOKEN` secret
2. Delete the v0.4.0 tag and release so release-please recreates it: `gh release delete v0.4.0 -y && git push --delete origin v0.4.0`
3. Release-please will recreate the release PR, merge → tag → full release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)