### PR TITLE
fix: skip GitHub release in release-please (conflicts with GoReleaser)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "skip-github-release": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Problem
Release-please created a published GitHub Release for v0.5.0, then GoReleaser tried to create a draft release for the same tag. The repo's immutable releases setting rejected GoReleaser's upload: `Cannot upload assets to an immutable release`.

## Fix
Add `skip-github-release: true` to release-please config. Now the workflow is:
1. Release-please: creates tag + PR + CHANGELOG (no GitHub release)
2. GoReleaser: creates draft release, builds binaries + Docker images
3. Release workflow: signs images, uploads SBOM, publishes the release

Also deleted the broken v0.5.0 release/tag so it can be recreated cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)