### PR TITLE
fix: use RELEASE_PLEASE_TOKEN for OperatorHub submission

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Fork and submit to community-operators
         env:
-          GH_TOKEN: ${{ secrets.OPERATORHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="openclaw-operator-v${VERSION}"


### PR DESCRIPTION
## Summary
- Reuse the existing `RELEASE_PLEASE_TOKEN` (classic PAT with `repo` scope) for the OperatorHub submission workflow
- Eliminates the need for a separate `OPERATORHUB_TOKEN` secret

## Test plan
- [ ] Merge this PR
- [ ] On next release, verify the OperatorHub workflow uses the token to fork community-operators and create a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)