### PR TITLE
feat: add workflow_dispatch trigger for OperatorHub submissions

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -3,21 +3,30 @@ name: OperatorHub Submission
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.6.0)'
+        required: true
 
 jobs:
   submit:
     name: Submit to OperatorHub
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Extract version
+      - name: Resolve tag
         id: version
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          # workflow_dispatch passes tag as input; release event uses GITHUB_REF
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=$GITHUB_REF_NAME" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.tag }}
 
       - name: Prepare bundle
         run: |


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the OperatorHub workflow so submissions can be triggered manually for a specific tag
- Useful when the automatic `release:published` trigger was missed (e.g. v0.6.0)
- Checkout uses the tag ref so the bundle matches the released code

## Usage
```bash
gh workflow run "OperatorHub Submission" -f tag=v0.6.0
```

## Test plan
- [ ] Merge this PR
- [ ] Trigger manually for v0.6.0 to verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)