### PR TITLE
fix: create operator directory for first-time OperatorHub submission

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -64,7 +64,8 @@ jobs:
 
           git checkout -b "${BRANCH}"
 
-          # Copy prepared bundle
+          # Copy prepared bundle (mkdir for first-time submissions)
+          mkdir -p operators/openclaw-operator
           cp -r ../submission/operators/openclaw-operator/${VERSION} operators/openclaw-operator/${VERSION}
 
           git add "operators/openclaw-operator/${VERSION}"


### PR DESCRIPTION
## Summary
- `cp -r` fails when `operators/openclaw-operator/` doesn't exist yet in the community-operators fork (first submission)
- Adds `mkdir -p` before the copy

## Test plan
- [ ] Merge, then re-trigger: `gh workflow run "OperatorHub Submission" -f tag=v0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)