### PR TITLE
fix: configure git identity for OperatorHub submission commits

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -62,6 +62,8 @@ jobs:
           gh repo fork k8s-operatorhub/community-operators --clone=true --remote=true -- community-operators
           cd community-operators
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "${BRANCH}"
 
           # Copy prepared bundle (mkdir for first-time submissions)


### PR DESCRIPTION
## Summary
- The forked community-operators clone has no git user configured, causing `fatal: empty ident name` on commit
- Configures `github-actions[bot]` as the committer identity

## Test plan
- [ ] Merge, then re-trigger: `gh workflow run "OperatorHub Submission" -f tag=v0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)