### PR TITLE
fix: configure git credential helper for OperatorHub push

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -58,6 +58,9 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="openclaw-operator-v${VERSION}"
 
+          # Configure gh as git credential helper so git push works with the PAT
+          gh auth setup-git
+
           # Clone the community-operators repo (fork is auto-created by gh)
           gh repo fork k8s-operatorhub/community-operators --clone=true --remote=true -- community-operators
           cd community-operators


### PR DESCRIPTION
## Summary
- `gh repo fork --clone` sets up HTTPS remotes, but `git push` doesn't inherit `GH_TOKEN`
- Adds `gh auth setup-git` to register the gh credential helper before forking

## Test plan
- [ ] Merge, then: `gh workflow run "OperatorHub Submission" -f tag=v0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)