### PR TITLE
fix: use --head flag for cross-fork OperatorHub PR creation

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -77,8 +77,11 @@ jobs:
           git commit -m "operator openclaw-operator (${VERSION})"
           git push origin "${BRANCH}"
 
+          # --head requires owner:branch for cross-fork PRs
+          FORK_OWNER=$(gh api user --jq '.login')
           gh pr create \
             --repo k8s-operatorhub/community-operators \
+            --head "${FORK_OWNER}:${BRANCH}" \
             --title "operator openclaw-operator (${VERSION})" \
             --body "$(cat <<EOF
           ### Update to openclaw-operator


### PR DESCRIPTION
## Summary
- `gh pr create` needs `--head owner:branch` for cross-fork PRs
- Dynamically resolves the fork owner via `gh api user`

## Test plan
- [ ] Merge, then: `gh workflow run "OperatorHub Submission" -f tag=v0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)