### PR TITLE
fix: force push OperatorHub branch for retry resilience

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -75,7 +75,7 @@ jobs:
 
           git add "operators/openclaw-operator/${VERSION}"
           git commit -m "operator openclaw-operator (${VERSION})"
-          git push origin "${BRANCH}"
+          git push --force origin "${BRANCH}"
 
           # --head requires owner:branch for cross-fork PRs
           FORK_OWNER=$(gh api user --jq '.login')


### PR DESCRIPTION
## Summary
- If a previous run pushed the branch but failed at PR creation, a retry fails with non-fast-forward rejection
- Force push is safe since it's our own submission branch on our fork

## Test plan
- [ ] Merge, then: `gh workflow run "OperatorHub Submission" -f tag=v0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)