### PR TITLE
feat: migrate workload from Deployment to StatefulSet

### DIFF
--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -633,7 +633,11 @@ type OpenClawInstanceStatus struct {
 
 // ManagedResourcesStatus tracks resources created by the operator
 type ManagedResourcesStatus struct {
-	// Deployment is the name of the managed Deployment
+	// StatefulSet is the name of the managed StatefulSet
+	// +optional
+	StatefulSet string `json:"statefulSet,omitempty"`
+
+	// Deployment is the name of the legacy Deployment (deprecated, used during migration)
 	// +optional
 	Deployment string `json:"deployment,omitempty"`
 
@@ -707,7 +711,10 @@ const (
 	// ConditionTypeConfigValid indicates the configuration is valid
 	ConditionTypeConfigValid = "ConfigValid"
 
-	// ConditionTypeDeploymentReady indicates the Deployment is ready
+	// ConditionTypeStatefulSetReady indicates the StatefulSet is ready
+	ConditionTypeStatefulSetReady = "StatefulSetReady"
+
+	// ConditionTypeDeploymentReady indicates the Deployment is ready (deprecated)
 	ConditionTypeDeploymentReady = "DeploymentReady"
 
 	// ConditionTypeServiceReady indicates the Service is ready

--- a/charts/openclaw-operator/templates/rbac.yaml
+++ b/charts/openclaw-operator/templates/rbac.yaml
@@ -26,8 +26,11 @@ rules:
     verbs: ["create", "patch"]
   # Apps API
   - apiGroups: ["apps"]
-    resources: ["deployments"]
+    resources: ["statefulsets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "delete"]
   # RBAC
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["roles", "rolebindings"]

--- a/config/crd/bases/openclaw.rocks_openclawinstances.yaml
+++ b/config/crd/bases/openclaw.rocks_openclawinstances.yaml
@@ -5265,7 +5265,8 @@ spec:
                     description: ConfigMap is the name of the managed ConfigMap
                     type: string
                   deployment:
-                    description: Deployment is the name of the managed Deployment
+                    description: Deployment is the name of the legacy Deployment (deprecated,
+                      used during migration)
                     type: string
                   networkPolicy:
                     description: NetworkPolicy is the name of the managed NetworkPolicy
@@ -5287,6 +5288,9 @@ spec:
                     type: string
                   serviceAccount:
                     description: ServiceAccount is the name of the managed ServiceAccount
+                    type: string
+                  statefulSet:
+                    description: StatefulSet is the name of the managed StatefulSet
                     type: string
                 type: object
               observedGeneration:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -39,6 +39,15 @@ rules:
   resources:
   - deployments
   verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
   - create
   - delete
   - get

--- a/internal/controller/openclawinstance_controller_test.go
+++ b/internal/controller/openclawinstance_controller_test.go
@@ -120,13 +120,13 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			By("Verifying Deployment is created")
+			By("Verifying StatefulSet is created")
 			Eventually(func() bool {
-				dep := &appsv1.Deployment{}
+				sts := &appsv1.StatefulSet{}
 				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      resources.DeploymentName(instance),
+					Name:      resources.StatefulSetName(instance),
 					Namespace: "default",
-				}, dep)
+				}, sts)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
@@ -165,7 +165,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 		})
 	})
 
-	Context("When Deployment security contexts", func() {
+	Context("When StatefulSet security contexts", func() {
 		It("Should enforce non-root execution", func() {
 			instance := &openclawv1alpha1.OpenClawInstance{
 				ObjectMeta: metav1.ObjectMeta{
@@ -175,15 +175,15 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				Spec: openclawv1alpha1.OpenClawInstanceSpec{},
 			}
 
-			deployment := resources.BuildDeployment(instance)
+			sts := resources.BuildStatefulSet(instance)
 
 			// Verify pod security context
-			Expect(deployment.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
-			Expect(*deployment.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
-			Expect(*deployment.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(1000)))
+			Expect(sts.Spec.Template.Spec.SecurityContext).NotTo(BeNil())
+			Expect(*sts.Spec.Template.Spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(*sts.Spec.Template.Spec.SecurityContext.RunAsUser).To(Equal(int64(1000)))
 
 			// Verify container security context
-			container := deployment.Spec.Template.Spec.Containers[0]
+			container := sts.Spec.Template.Spec.Containers[0]
 			Expect(container.SecurityContext).NotTo(BeNil())
 			Expect(*container.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
 			Expect(container.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -54,7 +54,12 @@ func SelectorLabels(instance *openclawv1alpha1.OpenClawInstance) map[string]stri
 	}
 }
 
-// DeploymentName returns the name of the Deployment
+// StatefulSetName returns the name of the StatefulSet
+func StatefulSetName(instance *openclawv1alpha1.OpenClawInstance) string {
+	return instance.Name
+}
+
+// DeploymentName returns the name of the legacy Deployment (used during migration)
 func DeploymentName(instance *openclawv1alpha1.OpenClawInstance) string {
 	return instance.Name
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -132,13 +132,13 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				}, createdInstance)
 			}, timeout, interval).Should(Succeed())
 
-			// Verify Deployment is created
-			deployment := &appsv1.Deployment{}
+			// Verify StatefulSet is created
+			statefulSet := &appsv1.StatefulSet{}
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{
 					Name:      instanceName,
 					Namespace: namespace,
-				}, deployment)
+				}, statefulSet)
 			}, timeout, interval).Should(Succeed())
 
 			// Verify Service is created
@@ -150,19 +150,19 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				}, service)
 			}, timeout, interval).Should(Succeed())
 
-			// Verify the deployment has the correct image
-			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/openclaw/openclaw:latest"))
+			// Verify the StatefulSet has the correct image
+			Expect(statefulSet.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(statefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/openclaw/openclaw:latest"))
 
 			// Clean up
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 
-			// Verify the deployment is deleted (due to owner reference)
+			// Verify the StatefulSet is deleted (due to owner reference)
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      instanceName,
 					Namespace: namespace,
-				}, deployment)
+				}, statefulSet)
 				return err != nil
 			}, timeout, interval).Should(BeTrue())
 		})


### PR DESCRIPTION
## Summary
- Convert operator-managed workload from Deployment to StatefulSet for semantic correctness (stateful, PVC-backed instances)
- Add migration logic that detects and deletes legacy Deployments before creating StatefulSets (ownerRef safety check)
- PVCs are untouched — same claim name mounted by the new StatefulSet pod, zero data loss

## Test plan
- [x] `make test` passes (unit + integration)
- [x] Generated manifests (CRD, RBAC) updated via `make generate && make manifests`
- [ ] Deploy v0.8.0 to staging, verify 3 live instances migrate cleanly
- [ ] `kubectl get sts -A` shows all instances as StatefulSets
- [ ] `kubectl get deploy -A` shows no instance Deployments remaining
- [ ] PVCs remain bound, pod names now deterministic (`{name}-0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)