### PR TITLE
fix: sync fork with upstream in OperatorHub workflow

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -67,6 +67,11 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Sync fork with upstream to avoid stale-branch CI failures
+          git fetch upstream main
+          git reset --hard upstream/main
+
           git checkout -b "${BRANCH}"
 
           # Copy prepared bundle (mkdir for first-time submissions)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,5 +135,6 @@ jobs:
 
       - name: Package and push Helm chart to OCI registry
         run: |
-          helm package charts/openclaw-operator
-          helm push openclaw-operator-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ steps.owner.outputs.name }}/charts
+          VERSION="${{ steps.version.outputs.version }}"
+          helm package charts/openclaw-operator --version "${VERSION}" --app-version "${VERSION}"
+          helm push "openclaw-operator-${VERSION}.tgz" oci://ghcr.io/${{ steps.owner.outputs.name }}/charts

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   A Kubernetes operator for deploying and managing OpenClaw AI assistant
   instances
 type: application
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.9.0
+appVersion: 0.9.0
 keywords:
   - kubernetes
   - operator
@@ -62,7 +62,7 @@ annotations:
             size: 10Gi
   artifacthub.io/images: |
     - name: openclaw-operator
-      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.2.4
+      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
   artifacthub.io/changes: |
     - kind: added
-      description: Initial ArtifactHub listing with full operator metadata
+      description: PVC backup-on-delete and restore-from-backup via rclone/B2


### PR DESCRIPTION
## Summary
- **OperatorHub workflow**: Syncs fork with upstream `main` (`git fetch upstream main && git reset --hard upstream/main`) before creating the PR branch. This fixes the stale-branch CI failures that caused PR #7517 to fail.
- **Helm chart release**: Uses `helm package --version --app-version` flags to set the version from the git tag, preventing mismatches between Chart.yaml and the release tag.
- **Chart.yaml**: Updated to v0.9.0 to match the current release.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the OperatorHub submission via `workflow_dispatch` with tag `v0.9.0`
- [ ] Verify the new community-operators PR passes CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)