### PR TITLE
fix: update OLM bundle CSV to v0.9.0

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -41,6 +41,7 @@ jobs:
             -e "s/openclaw-operator\.v[0-9]\+\.[0-9]\+\.[0-9]\+/openclaw-operator.v${VERSION}/g" \
             -e "s|ghcr.io/openclaw-rocks/openclaw-operator:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/openclaw-rocks/openclaw-operator:${TAG}|g" \
             -e "s/createdAt: .*/createdAt: \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"/" \
+            -e "s/^  version: [0-9]\+\.[0-9]\+\.[0-9]\+/  version: ${VERSION}/" \
             bundle/manifests/openclaw-operator.v*.clusterserviceversion.yaml \
             > "${BUNDLE_DIR}/manifests/openclaw-operator.v${VERSION}.clusterserviceversion.yaml"
 

--- a/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
+++ b/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
@@ -1,12 +1,12 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: openclaw-operator.v0.2.4
+  name: openclaw-operator.v0.9.0
   namespace: placeholder
   annotations:
     capabilities: "Basic Install"
     categories: "AI/Machine Learning"
-    containerImage: ghcr.io/openclaw-rocks/openclaw-operator:v0.2.4
+    containerImage: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
     createdAt: "2026-02-11T00:00:00Z"
     support: OpenClaw.rocks
     repository: https://github.com/OpenClaw-rocks/k8s-operator
@@ -140,7 +140,7 @@ spec:
 
     For full documentation, visit [openclaw.rocks/blog/openclaw-kubernetes-operator](https://openclaw.rocks/blog/openclaw-kubernetes-operator).
   maturity: alpha
-  version: 0.2.4
+  version: 0.9.0
   minKubeVersion: 1.28.0
   keywords:
     - ai
@@ -234,7 +234,7 @@ spec:
             x-descriptors:
               - "urn:alm:descriptor:text"
         resources:
-          - kind: Deployment
+          - kind: StatefulSet
             version: v1
           - kind: Service
             version: v1
@@ -291,9 +291,24 @@ spec:
                 - list
                 - watch
             - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - list
+            - apiGroups:
                 - apps
               resources:
                 - deployments
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
               verbs:
                 - create
                 - delete
@@ -301,6 +316,16 @@ spec:
                 - list
                 - patch
                 - update
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
                 - watch
             - apiGroups:
                 - monitoring.coreos.com
@@ -425,7 +450,7 @@ spec:
                 terminationGracePeriodSeconds: 10
                 containers:
                   - name: manager
-                    image: ghcr.io/openclaw-rocks/openclaw-operator:v0.2.4
+                    image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
                     command:
                       - /manager
                     args:


### PR DESCRIPTION
## Summary
- Updates the OLM bundle CSV from v0.2.4 to v0.9.0 with correct version, image tag, and RBAC
- Fixes the `operatorhub.yaml` workflow to also replace `spec.version` in the CSV (the field OperatorHub CI validates)
- Adds missing RBAC: StatefulSets (full CRUD), batch/jobs (backup/restore), pods (list)
- Updates managed resources: StatefulSet replaces Deployment

This fixes the OperatorHub CI failure: `Operator 'openclaw-operator with version 0.9.0' has different version name defined in CSV as 'spec.version'`

## Test plan
- [ ] Merge and re-run `workflow_dispatch` with tag `v0.9.0`
- [ ] Verify OperatorHub PR passes all CI checks (operator-ci, kiwi, lemon, orange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)