### PR TITLE
security: harden instance pods and reduce operator RBAC surface

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,8 +38,6 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - apps
   resources:

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -77,7 +77,7 @@ type OpenClawInstanceReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
@@ -311,6 +311,7 @@ func (r *OpenClawInstanceReconciler) reconcileRBAC(ctx context.Context, instance
 			desired := resources.BuildServiceAccount(instance)
 			sa.Labels = desired.Labels
 			sa.Annotations = desired.Annotations
+			sa.AutomountServiceAccountToken = desired.AutomountServiceAccountToken
 			return controllerutil.SetControllerReference(instance, sa, r.Scheme)
 		}); err != nil {
 			return err

--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -34,6 +34,7 @@ func BuildServiceAccount(instance *openclawv1alpha1.OpenClawInstance) *corev1.Se
 			Namespace: instance.Namespace,
 			Labels:    labels,
 		},
+		AutomountServiceAccountToken: Ptr(false),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Disable `automountServiceAccountToken` on instance pods and ServiceAccounts — pods don't need K8s API tokens
- Add `shellQuote()` helper in `BuildInitScript` for defense-in-depth against shell injection via user-controlled paths (webhook already validates, but quoting is belt-and-suspenders)
- Reduce operator secret RBAC from `get/list/watch` to `get` only — operator only fetches B2 credentials by exact name, never enumerates

Companion commit in cloud repo adds a default-deny NetworkPolicy for the operator namespace (DNS, K8s API, webhook, metrics only).

## Test plan
- [x] `make generate manifests` — role.yaml regenerated with secrets verb `get` only
- [x] `make test` — all tests pass (new tests for automount, shell quoting, special chars)
- [ ] Deploy to staging and verify instance pods have no mounted service account token
- [ ] Verify operator can still read B2 backup secret by name


🤖 Generated with [Claude Code](https://claude.com/claude-code)