### PR TITLE
fix: suppress gosec false positive and handle existing releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,6 +68,7 @@ changelog:
 
 release:
   draft: true
+  replace_existing_artifacts: true
   github:
     owner: openclaw-rocks
     name: k8s-operator

--- a/internal/controller/b2.go
+++ b/internal/controller/b2.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// BackupSecretName is the name of the Secret containing B2 credentials
-	BackupSecretName = "b2-backup-credentials"
+	BackupSecretName = "b2-backup-credentials" // #nosec G101 -- not a credential, just a Secret resource name
 
 	// RcloneImage is the pinned rclone container image
 	RcloneImage = "rclone/rclone:1.68"

--- a/internal/controller/restore.go
+++ b/internal/controller/restore.go
@@ -38,7 +38,7 @@ import (
 // Returns (result, done, error):
 //   - done=true: restore is complete (or not needed), continue to create StatefulSet
 //   - done=false: restore is in progress, requeue with result
-func (r *OpenClawInstanceReconciler) reconcileRestore(ctx context.Context, instance *openclawv1alpha1.OpenClawInstance) (ctrl.Result, bool, error) {
+func (r *OpenClawInstanceReconciler) reconcileRestore(ctx context.Context, instance *openclawv1alpha1.OpenClawInstance) (result ctrl.Result, done bool, _ error) {
 	logger := log.FromContext(ctx)
 
 	// Skip if no restore requested


### PR DESCRIPTION
## Summary
- Suppress gosec G101 false positive on `BackupSecretName` constant — it's a K8s Secret resource name, not a hardcoded credential
- Add `replace_existing_artifacts: true` to goreleaser config so release uploads succeed even when a release already exists for the tag (e.g. manually created)

## Test plan
- [x] CI should pass with gosec no longer flagging b2.go
- [ ] Next release tag should succeed even if release is pre-created


🤖 Generated with [Claude Code](https://claude.com/claude-code)