### PR TITLE
fix: add skip-backup annotation to E2E test instance

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -112,6 +112,9 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      instanceName,
 					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
 				},
 				Spec: openclawv1alpha1.OpenClawInstanceSpec{
 					Image: openclawv1alpha1.ImageSpec{


### PR DESCRIPTION
## Summary
- Add `openclaw.rocks/skip-backup: "true"` annotation to the E2E test instance
- The backup-on-delete finalizer blocks deletion in CI (no B2 credentials), causing a 60s timeout failure
- This has been breaking CI on main since the backup feature was introduced

## Test plan
- [x] E2E test should no longer time out waiting for StatefulSet deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)