### PR TITLE
docs: update managed hosting price to EUR 15/mo

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ See the full [roadmap](ROADMAP.md) for details.
 
 ## Don't Want to Self-Host?
 
-[OpenClaw.rocks](https://openclaw.rocks) offers fully managed hosting starting at **EUR 10/mo**. No Kubernetes cluster required. Setup, updates, and 24/7 uptime handled for you.
+[OpenClaw.rocks](https://openclaw.rocks) offers fully managed hosting starting at **EUR 15/mo**. No Kubernetes cluster required. Setup, updates, and 24/7 uptime handled for you.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Updated README pricing from EUR 10/mo to EUR 15/mo to match current pricing on [openclaw.rocks](https://openclaw.rocks)

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)