### PR TITLE
fix: auto-label release PRs to prevent release-please stalling

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -21,8 +21,10 @@ jobs:
       # skip-github-release is set in release-please-config.json so that
       # release-please does NOT create a GitHub release (which would
       # conflict with GoReleaser's draft-then-publish flow on immutable
-      # releases). However, this also skips tag creation. We create the
-      # tag manually here so the release workflow triggers.
+      # releases). However, this also skips tag creation AND leaves the
+      # merged PR labeled "autorelease: pending" forever. We create the
+      # tag manually and flip the label to "autorelease: tagged" so that
+      # release-please doesn't stall on the next push.
       - name: Create release tag
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -44,6 +46,19 @@ jobs:
                 -f ref="refs/tags/${TAG}" \
                 -f sha="${{ github.sha }}"
               echo "Tag ${TAG} created — release workflow will trigger"
+            fi
+
+            # Flip the release PR label from "autorelease: pending" to
+            # "autorelease: tagged". Without this, skip-github-release
+            # leaves the label stuck and release-please aborts future
+            # runs with "untagged, merged release PRs outstanding".
+            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+              --jq '.[0].number // empty')
+            if [ -n "$PR_NUMBER" ]; then
+              gh pr edit "$PR_NUMBER" \
+                --remove-label "autorelease: pending" \
+                --add-label "autorelease: tagged" || true
+              echo "Labeled PR #${PR_NUMBER} as autorelease: tagged"
             fi
           else
             echo "Not a release commit, skipping tag creation"


### PR DESCRIPTION
## Summary
- After creating a release tag, automatically flips the merged PR label from `autorelease: pending` to `autorelease: tagged`
- Prevents release-please from aborting with "untagged, merged release PRs outstanding" on subsequent pushes
- Root cause: `skip-github-release: true` means release-please never marks its own PRs as released

## Test plan
- [x] Workflow YAML is valid
- [ ] CI passes
- [ ] Next release cycle creates and merges a release PR without stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)