### PR TITLE
feat: add phase 1 high-priority features

### DIFF
--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -23,6 +23,12 @@ type OpenClawInstanceSpec struct {
 	// +optional
 	Workspace *WorkspaceSpec `json:"workspace,omitempty"`
 
+	// Skills is a list of ClawHub skills to install via init container.
+	// Each entry is a skill identifier (e.g., "@anthropic/mcp-server-fetch").
+	// +kubebuilder:validation:MaxItems=20
+	// +optional
+	Skills []string `json:"skills,omitempty"`
+
 	// EnvFrom is a list of sources to populate environment variables from
 	// Use this for API keys and other secrets (e.g., ANTHROPIC_API_KEY, OPENAI_API_KEY)
 	// +optional
@@ -121,6 +127,14 @@ type ConfigSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	Raw *RawConfig `json:"raw,omitempty"`
+
+	// MergeMode controls how operator-managed config is applied to the PVC.
+	// "overwrite" replaces the config file on every pod restart.
+	// "merge" deep-merges operator config with existing PVC config, preserving runtime changes.
+	// +kubebuilder:validation:Enum=overwrite;merge
+	// +kubebuilder:default="overwrite"
+	// +optional
+	MergeMode string `json:"mergeMode,omitempty"`
 }
 
 // ConfigMapKeySelector selects a key from a ConfigMap
@@ -229,8 +243,8 @@ type ContainerSecurityContextSpec struct {
 	AllowPrivilegeEscalation *bool `json:"allowPrivilegeEscalation,omitempty"`
 
 	// ReadOnlyRootFilesystem mounts the container's root filesystem as read-only
-	// Note: OpenClaw requires write access to ~/.openclaw/, so this is false by default
-	// +kubebuilder:default=false
+	// The PVC at ~/.openclaw/ provides writable home, and a /tmp emptyDir handles temp files
+	// +kubebuilder:default=true
 	// +optional
 	ReadOnlyRootFilesystem *bool `json:"readOnlyRootFilesystem,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -578,6 +578,11 @@ func (in *OpenClawInstanceSpec) DeepCopyInto(out *OpenClawInstanceSpec) {
 		*out = new(WorkspaceSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Skills != nil {
+		in, out := &in.Skills, &out.Skills
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EnvFrom != nil {
 		in, out := &in.EnvFrom, &out.EnvFrom
 		*out = make([]v1.EnvFromSource, len(*in))

--- a/charts/openclaw-operator/crds/openclaw.rocks_openclawinstances.yaml
+++ b/charts/openclaw-operator/crds/openclaw.rocks_openclawinstances.yaml
@@ -1144,6 +1144,16 @@ spec:
                     required:
                     - name
                     type: object
+                  mergeMode:
+                    default: overwrite
+                    description: |-
+                      MergeMode controls how operator-managed config is applied to the PVC.
+                      "overwrite" replaces the config file on every pod restart.
+                      "merge" deep-merges operator config with existing PVC config, preserving runtime changes.
+                    enum:
+                    - overwrite
+                    - merge
+                    type: string
                   raw:
                     description: Raw is inline openclaw.json configuration (used if
                       ConfigMapRef is not set)
@@ -1684,10 +1694,10 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       readOnlyRootFilesystem:
-                        default: false
+                        default: true
                         description: |-
                           ReadOnlyRootFilesystem mounts the container's root filesystem as read-only
-                          Note: OpenClaw requires write access to ~/.openclaw/, so this is false by default
+                          The PVC at ~/.openclaw/ provides writable home, and a /tmp emptyDir handles temp files
                         type: boolean
                     type: object
                   networkPolicy:
@@ -5168,6 +5178,14 @@ spec:
                   required:
                   - name
                   type: object
+                type: array
+              skills:
+                description: |-
+                  Skills is a list of ClawHub skills to install via init container.
+                  Each entry is a skill identifier (e.g., "@anthropic/mcp-server-fetch").
+                items:
+                  type: string
+                maxItems: 20
                 type: array
               storage:
                 description: Storage specifies persistent storage configuration

--- a/config/crd/bases/openclaw.rocks_openclawinstances.yaml
+++ b/config/crd/bases/openclaw.rocks_openclawinstances.yaml
@@ -1144,6 +1144,16 @@ spec:
                     required:
                     - name
                     type: object
+                  mergeMode:
+                    default: overwrite
+                    description: |-
+                      MergeMode controls how operator-managed config is applied to the PVC.
+                      "overwrite" replaces the config file on every pod restart.
+                      "merge" deep-merges operator config with existing PVC config, preserving runtime changes.
+                    enum:
+                    - overwrite
+                    - merge
+                    type: string
                   raw:
                     description: Raw is inline openclaw.json configuration (used if
                       ConfigMapRef is not set)
@@ -1684,10 +1694,10 @@ spec:
                             x-kubernetes-list-type: atomic
                         type: object
                       readOnlyRootFilesystem:
-                        default: false
+                        default: true
                         description: |-
                           ReadOnlyRootFilesystem mounts the container's root filesystem as read-only
-                          Note: OpenClaw requires write access to ~/.openclaw/, so this is false by default
+                          The PVC at ~/.openclaw/ provides writable home, and a /tmp emptyDir handles temp files
                         type: boolean
                     type: object
                   networkPolicy:
@@ -5168,6 +5178,14 @@ spec:
                   required:
                   - name
                   type: object
+                type: array
+              skills:
+                description: |-
+                  Skills is a list of ClawHub skills to install via init container.
+                  Each entry is a skill identifier (e.g., "@anthropic/mcp-server-fetch").
+                items:
+                  type: string
+                maxItems: 20
                 type: array
               storage:
                 description: Storage specifies persistent storage configuration

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,6 +38,8 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -30,6 +30,12 @@ const (
 	// ChromiumPort is the port for Chrome DevTools Protocol
 	ChromiumPort = 9222
 
+	// JqImage is the image used for jq-based config merge operations
+	JqImage = "ghcr.io/jqlang/jq:1.7.1"
+
+	// ConfigMergeModeMerge is the merge mode that deep-merges config with existing PVC config
+	ConfigMergeModeMerge = "merge"
+
 	// AppName is the application name used in labels
 	AppName = "openclaw"
 


### PR DESCRIPTION
## Summary

Implements the top 4 features from the community Helm chart gap analysis (Phase 1 — high priority):

- **Read-only root filesystem**: Default `readOnlyRootFilesystem` to `true` with `/tmp` emptyDir for writable temp paths. Significant security hardening validated by community charts.
- **Config merge mode**: New `spec.config.mergeMode: merge` option that deep-merges operator config with existing PVC config using jq, preserving runtime changes across pod restarts. Default remains `overwrite` (backward compatible).
- **Declarative skill installation**: New `spec.skills` field installs ClawHub skills via init container. Supports up to 20 skills with name validation.
- **Secret change detection**: Controller watches Secrets referenced in `envFrom` and injects a hash annotation into the pod template, triggering automatic rollout on Secret rotation.

### Files changed (10)

| Area | File | Changes |
|------|------|---------|
| API | `api/v1alpha1/openclawinstance_types.go` | Added `MergeMode`, `Skills` fields |
| API | `api/v1alpha1/zz_generated.deepcopy.go` | Regenerated |
| CRD | `config/crd/bases/`, `charts/.../crds/` | Regenerated CRD YAML |
| RBAC | `config/rbac/role.yaml` | Added `list;watch` on secrets |
| Builder | `internal/resources/statefulset.go` | Init containers, volumes, security context |
| Builder | `internal/resources/common.go` | `JqImage`, `ConfigMergeModeMerge` constants |
| Controller | `internal/controller/openclawinstance_controller.go` | Secret hash, Secret watcher |
| Webhook | `internal/webhook/openclawinstance_webhook.go` | Defaults + validation for new fields |
| Tests | `internal/resources/resources_test.go` | 18 new unit tests |

### Breaking changes

- `readOnlyRootFilesystem` now defaults to `true` (was `false`). Existing instances without an explicit override will get read-only rootfs on next reconcile. This is safe — the PVC at `~/.openclaw/` and `/tmp` emptyDir provide writable paths.

### Migration notes

- Config merge mode, skills, and secret detection are fully backward compatible (new fields default to no-op values).
- No manual migration required — new defaults apply on next reconcile.

## Test plan

- [x] 18 new unit tests covering all 4 features
- [x] `make test` passes locally
- [x] `make lint` passes (no new warnings)
- [x] `make generate && make manifests` — generated files committed
- [ ] CI: lint, test, security scan, reconcile guard
- [ ] CI: envtest integration tests (controller-level secret hash tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)