### PR TITLE
docs: update README and API reference for gateway token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ spec:
 
 Config changes are detected via SHA-256 hashing and automatically trigger a rolling update. No manual restart needed.
 
+### Gateway authentication
+
+The operator automatically generates a gateway token Secret for each instance and injects it into both the config JSON (`gateway.auth.mode: token`) and the `OPENCLAW_GATEWAY_TOKEN` env var. This bypasses Bonjour/mDNS pairing, which is unusable in Kubernetes.
+
+- The token is generated once and never overwritten — rotate it by editing the Secret directly
+- If you set `gateway.auth.token` in your config or `OPENCLAW_GATEWAY_TOKEN` in `spec.env`, your value takes precedence
+- `OPENCLAW_DISABLE_BONJOUR=1` is always set (mDNS does not work in k8s)
+
 ### Chromium sidecar
 
 Enable headless browser automation for web scraping, screenshots, and browser-based integrations:
@@ -304,7 +312,7 @@ The operator follows a **secure-by-default** philosophy. Every instance ships wi
 - **All capabilities dropped**: no ambient Linux capabilities
 - **Seccomp RuntimeDefault**: syscall filtering enabled
 - **Default-deny NetworkPolicy**: only DNS (53) and HTTPS (443) egress allowed; ingress limited to same namespace
-- **Minimal RBAC**: each instance gets its own ServiceAccount with read-only access to its own ConfigMap; operator itself has secrets get-only (no list/watch)
+- **Minimal RBAC**: each instance gets its own ServiceAccount with read-only access to its own ConfigMap; operator can create/update Secrets only for operator-managed gateway tokens
 - **No automatic token mounting**: `automountServiceAccountToken: false` on both ServiceAccounts and pod specs
 - **Read-only root filesystem**: supported for the Chromium sidecar; scratch dirs via emptyDir
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -352,7 +352,8 @@ Standard `metav1.Condition` array. Condition types:
 
 | Field                | Type     | Description                           |
 |----------------------|----------|---------------------------------------|
-| `deployment`         | `string` | Name of the managed Deployment.       |
+| `statefulSet`        | `string` | Name of the managed StatefulSet.      |
+| `deployment`         | `string` | Name of the legacy Deployment (deprecated, used during migration). |
 | `service`            | `string` | Name of the managed Service.          |
 | `configMap`          | `string` | Name of the managed ConfigMap.        |
 | `pvc`                | `string` | Name of the managed PVC.             |
@@ -361,6 +362,7 @@ Standard `metav1.Condition` array. Condition types:
 | `serviceAccount`     | `string` | Name of the managed ServiceAccount.   |
 | `role`               | `string` | Name of the managed Role.            |
 | `roleBinding`        | `string` | Name of the managed RoleBinding.      |
+| `gatewayTokenSecret` | `string` | Name of the auto-generated gateway token Secret. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add gateway authentication section to README explaining auto-generated token, user override behavior, and Bonjour disable
- Fix stale RBAC claim in security section (secrets are no longer get-only after #85)
- Add `statefulSet` and `gatewayTokenSecret` to `managedResources` table in API reference
- Mark `deployment` field as deprecated in API reference

Follow-up to #85.

## Test plan

- [ ] Docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)