### PR TITLE
fix: server-side apply for CRDs + comprehensive README update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | kubectl apply --server-side -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
@@ -101,7 +101,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | kubectl apply --server-side -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.


### PR DESCRIPTION
## Summary

- **Fix CI E2E failure**: Switch `make install` and `make deploy` to `kubectl apply --server-side` to avoid the 256KB `last-applied-configuration` annotation limit with the 546KB CRD YAML
- **Comprehensive README update**: Add ~27 missing CRD fields, ~14 shipped features, fix security inaccuracies, expand webhook docs, update architecture diagram with init containers

## Changes

### Makefile
- `install` target: `kubectl apply -f -` → `kubectl apply --server-side -f -`
- `deploy` target: `kubectl apply -f -` → `kubectl apply --server-side -f -`

### README.md
- **Features table**: Added config merge mode, skill installation, runtime deps, gateway auth, custom sidecars/init containers, SA annotations + CA bundles, agent spawning
- **Architecture diagram**: Added init container pipeline (config → pnpm → python → skills → custom), custom sidecars, GatewayToken Secret
- **Configuration section**: 7 new subsections with YAML examples (merge mode, skills, runtime deps, init containers/sidecars, extra volumes, CA bundle, SA annotations)
- **Config options table**: Reorganized with category headers; added all missing fields (image.digest, pullPolicy, pullSecrets, config.mergeMode, config.format, env, skills, runtimeDeps, initContainers, sidecars, sidecarVolumes, extraVolumes, extraVolumeMounts, caBundle, serviceAccountAnnotations, fsGroupChangePolicy, readOnlyRootFilesystem, nodeSelector, tolerations, affinity, spawn)
- **Security section**: Fixed read-only rootfs (now correctly states "enabled by default for the main container"), added secret validation
- **Webhook table**: Added 8 new checks (reserved init container names, skill validation, CA bundle, JSON5 constraints, spawn validation, readOnlyRootFilesystem warning, provider key detection, config schema warnings)
- **Roadmap**: Consolidated to single v1.0.0 target

## Test plan

- [ ] CI lint/test/build passes
- [ ] `make install` works with server-side apply (no annotation size error)
- [ ] README renders correctly on GitHub
- [ ] All config table entries match actual CRD types in `api/v1alpha1/openclawinstance_types.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)