### PR TITLE
ci: fix release-please stalling on stale autorelease labels

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,8 +23,7 @@ jobs:
       # conflict with GoReleaser's draft-then-publish flow on immutable
       # releases). However, this also skips tag creation AND leaves the
       # merged PR labeled "autorelease: pending" forever. We create the
-      # tag manually and flip the label to "autorelease: tagged" so that
-      # release-please doesn't stall on the next push.
+      # tag manually below, and flip stale labels in a separate step.
       - name: Create release tag
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -45,21 +44,36 @@ jobs:
               gh api "repos/${{ github.repository }}/git/refs" \
                 -f ref="refs/tags/${TAG}" \
                 -f sha="${{ github.sha }}"
-              echo "Tag ${TAG} created — release workflow will trigger"
-            fi
-
-            # Flip the release PR label from "autorelease: pending" to
-            # "autorelease: tagged". Without this, skip-github-release
-            # leaves the label stuck and release-please aborts future
-            # runs with "untagged, merged release PRs outstanding".
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-              --jq '.[0].number // empty')
-            if [ -n "$PR_NUMBER" ]; then
-              gh pr edit "$PR_NUMBER" \
-                --remove-label "autorelease: pending" \
-                --add-label "autorelease: tagged" || true
-              echo "Labeled PR #${PR_NUMBER} as autorelease: tagged"
+              echo "Tag ${TAG} created - release workflow will trigger"
             fi
           else
             echo "Not a release commit, skipping tag creation"
+          fi
+
+      # Flip "autorelease: pending" to "autorelease: tagged" on any
+      # merged release PR that still has the stale label. This runs on
+      # every push to main (not just release commits) so that the label
+      # gets fixed even if the tag step above was skipped or failed.
+      # Without this, release-please aborts with "untagged, merged
+      # release PRs outstanding".
+      - name: Fix stale autorelease labels
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          STALE_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state merged \
+            --label "autorelease: pending" \
+            --json number,title \
+            --jq '.[].number')
+
+          for PR in $STALE_PRS; do
+            echo "Fixing stale label on PR #${PR}"
+            gh pr edit "$PR" \
+              --remove-label "autorelease: pending" \
+              --add-label "autorelease: tagged" || true
+          done
+
+          if [ -z "$STALE_PRS" ]; then
+            echo "No stale autorelease labels found"
           fi


### PR DESCRIPTION
## Summary
- The `autorelease: pending` -> `autorelease: tagged` label flip was nested inside the release-commit detection block, so it only ran when the triggering commit was the release PR merge itself
- If that step failed or a non-release commit was pushed to main first, the stale label permanently blocked release-please with "untagged, merged release PRs outstanding"
- Moved the label fix into a separate step that runs on every push to main, scanning for any merged PRs still carrying the stale label

## Test plan
- [x] Manually verified the fix works: flipped label on PR #104, re-ran release-please, and PR #113 was created successfully
- [ ] Merge this PR, then merge release PR #113 - the new "Fix stale autorelease labels" step should flip #113's label automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)