### PR TITLE
ci: use gh api for autorelease label flip

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -69,9 +69,10 @@ jobs:
 
           for PR in $STALE_PRS; do
             echo "Fixing stale label on PR #${PR}"
-            gh pr edit "$PR" \
-              --remove-label "autorelease: pending" \
-              --add-label "autorelease: tagged" || true
+            gh api "repos/${{ github.repository }}/issues/${PR}/labels/autorelease:%20pending" \
+              -X DELETE || true
+            gh api "repos/${{ github.repository }}/issues/${PR}/labels" \
+              -f "labels[]=autorelease: tagged" || true
           done
 
           if [ -z "$STALE_PRS" ]; then


### PR DESCRIPTION
## Summary
- The "Fix stale autorelease labels" step used `gh pr edit` which requires a git checkout that doesn't exist in the workflow
- Replace with `gh api` REST calls to remove/add labels directly, which works without a repo checkout

## Test plan
- [ ] Next release PR merge should show clean label flip in the "Fix stale autorelease labels" step (no git error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)