### PR TITLE
fix: use copyFileSync instead of renameSync in merge mode init container

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -3315,6 +3315,13 @@ func TestBuildInitScript_MergeMode(t *testing.T) {
 	if !strings.Contains(script, "/tmp/merged.json") {
 		t.Errorf("merge mode should write to /tmp/merged.json atomically, got: %q", script)
 	}
+	// Regression: renameSync fails across mount boundaries (EXDEV) - #120
+	if strings.Contains(script, "renameSync") {
+		t.Errorf("merge mode must not use renameSync (fails cross-device between /tmp and /data), got: %q", script)
+	}
+	if !strings.Contains(script, "copyFileSync") {
+		t.Errorf("merge mode should use copyFileSync to move merged config to /data, got: %q", script)
+	}
 }
 
 func TestBuildStatefulSet_MergeMode_OpenClawImage(t *testing.T) {

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -469,7 +469,7 @@ func BuildInitScript(instance *openclawv1alpha1.OpenClawInstance) string {
 					`const base=fs.existsSync(e)?JSON.parse(fs.readFileSync(e,'utf8')):{};`+
 					`const inc=JSON.parse(fs.readFileSync(c,'utf8'));`+
 					`fs.writeFileSync(t,JSON.stringify(dm(base,inc),null,2));`+
-					`fs.renameSync(t,e);`+
+					`fs.copyFileSync(t,e);`+
 					`"`,
 				shellQuote(key)))
 		case instance.Spec.Config.Format == ConfigFormatJSON5:


### PR DESCRIPTION
## Summary
- Replaces `fs.renameSync` with `fs.copyFileSync` in the merge mode init container script
- `renameSync` fails with `EXDEV: cross-device link not permitted` when `/tmp` and `/data` are on different volume mounts (which they always are in the init container)
- Adds regression test asserting `renameSync` is never used in merge mode scripts

Fixes #120

## Test plan
- [x] Existing merge mode unit tests pass
- [x] New regression test prevents reintroduction of `renameSync`
- [ ] CI: unit tests, lint, reconcile guard
- [ ] E2E: merge mode config on kind cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)