### PR TITLE
docs: rewrite README and add Tailscale to API reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -199,6 +199,27 @@ When enabled, the sidecar:
 - Mounts a memory-backed emptyDir at `/dev/shm` (256Mi) for shared memory.
 - Mounts an emptyDir at `/tmp` for scratch space.
 
+When Chromium is enabled, the operator also auto-configures browser profiles in the OpenClaw config. Both `"default"` and `"chrome"` profiles are set to point at the sidecar's CDP endpoint (`http://localhost:3000`). This ensures browser tool calls work regardless of which profile name the LLM passes.
+
+### spec.tailscale
+
+Optional Tailscale integration for secure tailnet access without Ingress or LoadBalancer.
+
+| Field                | Type                     | Default          | Description                                                                |
+|----------------------|--------------------------|------------------|----------------------------------------------------------------------------|
+| `enabled`            | `bool`                   | `false`          | Enable Tailscale integration.                                              |
+| `mode`               | `string`                 | `serve`          | Tailscale mode. `serve` exposes to tailnet members only. `funnel` exposes to the public internet via Tailscale Funnel. |
+| `authKeySecretRef`   | `*LocalObjectReference`  | --               | Reference to a Secret containing the Tailscale auth key. Use ephemeral+reusable keys from the Tailscale admin console. |
+| `authKeySecretKey`   | `string`                 | `authkey`        | Key in the referenced Secret containing the auth key.                      |
+| `hostname`           | `string`                 | (instance name)  | Tailscale device name. Defaults to the OpenClawInstance name.              |
+| `authSSO`            | `bool`                   | `false`          | Enable passwordless login for tailnet members. Sets `gateway.auth.allowTailscale=true` in the OpenClaw config. |
+
+When enabled, the operator:
+
+- Merges `gateway.tailscale` settings (mode, hostname) into the OpenClaw config.
+- Injects the auth key from the referenced Secret.
+- When `authSSO` is true, sets `gateway.auth.allowTailscale=true` so tailnet members can authenticate without a gateway token.
+
 ### spec.networking
 
 Network-related configuration for the instance.


### PR DESCRIPTION
## Summary

- Rewrites README from 663 to 558 lines while adding previously undocumented features
- Adds Tailscale integration section with YAML example and serve/funnel explanation
- Adds "What the operator manages automatically" table documenting 7 implicit behaviors (gateway.bind injection, auth token generation, bonjour disable, browser profile auto-config, Tailscale config merge, config hash rollouts, config restoration)
- Documents Chromium browser profile auto-injection (both `"default"` and `"chrome"` profiles)
- Updates features table and architecture diagram to include Tailscale
- Condenses auto-update section from ~45 lines to ~12 lines (YAML + two paragraphs)
- Collapses webhook warning checks into a `<details>` block
- Removes duplicative "All configuration options" table (80 lines) in favor of a link to `docs/api-reference.md`
- Removes "Instance status" YAML and "Custom network rules" examples
- Replaces em dashes with hyphens and Unicode box-drawing with ASCII
- Adds `spec.tailscale` section to `docs/api-reference.md` with full field table

## Test plan

- [ ] Verify README renders correctly on GitHub (check markdown tables, code blocks, `<details>` block)
- [ ] Verify all internal links resolve (`docs/api-reference.md`, `docs/custom-providers.md`, `docs/deployment.md`, `config/samples/...`, `CONTRIBUTING.md`, `ROADMAP.md`)
- [ ] Spot-check no features were lost compared to the previous README
- [ ] Verify `docs/api-reference.md` Tailscale section matches `TailscaleSpec` in types

🤖 Generated with [Claude Code](https://claude.com/claude-code)