### PR TITLE
fix: prevent StatefulSet spec drift on every reconcile

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -258,6 +258,15 @@ func TestBuildStatefulSet_Defaults(t *testing.T) {
 	if sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
 		t.Errorf("updateStrategy = %v, want RollingUpdate", sts.Spec.UpdateStrategy.Type)
 	}
+	if sts.Spec.PersistentVolumeClaimRetentionPolicy == nil {
+		t.Fatal("persistentVolumeClaimRetentionPolicy should be set (prevents spec drift)")
+	}
+	if sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted != appsv1.RetainPersistentVolumeClaimRetentionPolicyType {
+		t.Errorf("pvcRetentionPolicy.whenDeleted = %v, want Retain", sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
+	}
+	if sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled != appsv1.RetainPersistentVolumeClaimRetentionPolicyType {
+		t.Errorf("pvcRetentionPolicy.whenScaled = %v, want Retain", sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
+	}
 
 	// Selector labels
 	sel := sts.Spec.Selector.MatchLabels
@@ -696,6 +705,14 @@ func TestBuildStatefulSet_ConfigVolume_RawConfig(t *testing.T) {
 	}
 	assertVolumeMount(t, initC.VolumeMounts, "data", "/data")
 	assertVolumeMount(t, initC.VolumeMounts, "config", "/config")
+
+	// Init container must set SeccompProfile to prevent spec drift
+	if initC.SecurityContext == nil {
+		t.Fatal("init-config security context is nil")
+	}
+	if initC.SecurityContext.SeccompProfile == nil || initC.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Error("init-config container: seccomp profile should be RuntimeDefault (prevents spec drift)")
+	}
 
 	// Should have config volume pointing to managed configmap
 	volumes := sts.Spec.Template.Spec.Volumes

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -60,6 +60,10 @@ func BuildStatefulSet(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenS
 			RevisionHistoryLimit: Ptr(int32(10)),
 			ServiceName:          ServiceName(instance),
 			PodManagementPolicy:  appsv1.ParallelPodManagement,
+			PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			},
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 			},
@@ -410,6 +414,9 @@ func buildInitContainers(instance *openclawv1alpha1.OpenClawInstance) []corev1.C
 				RunAsNonRoot:             Ptr(true),
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
 			},
 			VolumeMounts: mounts,


### PR DESCRIPTION
## Summary

- Fix StatefulSet spec drift that caused the operator to update every StatefulSet on every reconciliation loop
- The builder was missing `PersistentVolumeClaimRetentionPolicy` (Kubernetes defaults to `{Retain, Retain}`) and `SeccompProfile` on the `init-config` container
- This caused StatefulSet generations to reach 4700+ in production, triggering continuous rolling updates that prevented pods from stabilizing due to Longhorn volume reattachment delays

## Root Cause

The reconciler uses `sts.Spec = desired.Spec` which replaces the entire spec. Two fields that Kubernetes defaults server-side were not set by the builder:

1. **`PersistentVolumeClaimRetentionPolicy`** - K8s defaults to `{whenDeleted: Retain, whenScaled: Retain}`, but the builder produced `nil`
2. **`SeccompProfile` on init-config** - Pod-level seccomp (`RuntimeDefault`) is inherited by containers, but the builder didn't set it explicitly

On every reconcile: GET (has defaults) -> mutate (builder wipes defaults) -> diff detected -> UPDATE -> repeat.

## Test plan

- [x] `go test ./internal/resources/` passes
- [x] New test for `PersistentVolumeClaimRetentionPolicy` being explicitly set
- [x] New test for init-config container `SeccompProfile` being set
- [ ] Deploy to production and verify StatefulSet generation stops incrementing

🤖 Generated with [Claude Code](https://claude.com/claude-code)