### PR TITLE
feat: support npm packages in skills field and disable lifecycle scripts

### DIFF
--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -23,8 +23,10 @@ type OpenClawInstanceSpec struct {
 	// +optional
 	Workspace *WorkspaceSpec `json:"workspace,omitempty"`
 
-	// Skills is a list of ClawHub skills to install via init container.
-	// Each entry is a skill identifier (e.g., "@anthropic/mcp-server-fetch").
+	// Skills is a list of skills to install via init container.
+	// Each entry is either a ClawHub skill identifier (e.g., "@anthropic/mcp-server-fetch")
+	// or an npm package prefixed with "npm:" (e.g., "npm:@openclaw/matrix").
+	// npm lifecycle scripts are disabled for security (see #91).
 	// +kubebuilder:validation:MaxItems=20
 	// +optional
 	Skills []string `json:"skills,omitempty"`

--- a/internal/webhook/openclawinstance_webhook.go
+++ b/internal/webhook/openclawinstance_webhook.go
@@ -327,6 +327,8 @@ func validateWorkspaceDirectory(dir string) error {
 }
 
 // validateSkillName checks a single skill identifier.
+// Entries may use the "npm:" prefix to install npm packages instead of ClawHub
+// skills. The prefix is stripped before character-set validation.
 func validateSkillName(name string) error {
 	if name == "" {
 		return fmt.Errorf("skill name must not be empty")
@@ -334,7 +336,15 @@ func validateSkillName(name string) error {
 	if len(name) > 128 {
 		return fmt.Errorf("skill name must be at most 128 characters")
 	}
-	for _, c := range name {
+	// Strip known prefix before character validation
+	check := name
+	if after, ok := strings.CutPrefix(name, "npm:"); ok {
+		if after == "" {
+			return fmt.Errorf("npm: prefix requires a package name")
+		}
+		check = after
+	}
+	for _, c := range check {
 		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
 			c == '-' || c == '_' || c == '/' || c == '.' || c == '@') {
 			return fmt.Errorf("skill name contains invalid character %q", string(c))


### PR DESCRIPTION
## Summary

- Add `npm:` prefix support for `spec.skills` entries, allowing users to install npm packages from npmjs.com alongside ClawHub skills (#131)
- Set `NPM_CONFIG_IGNORE_SCRIPTS=true` on the skills init container to disable npm lifecycle scripts globally, mitigating supply chain attacks (#91)

### How it works

```yaml
spec:
  skills:
    - "@anthropic/mcp-server-fetch"      # ClawHub (default, backwards compatible)
    - "npm:@openclaw/matrix"             # npm install from npmjs.com
```

- Unprefixed entries: `npx -y clawhub install '<skill>'` (existing behavior)
- `npm:` prefixed entries: `cd /home/openclaw/.openclaw && npm install '<package>'`
- Webhook validates `npm:` prefix (strips before charset check, rejects bare `npm:`)
- No CRD schema changes needed (`Skills []string` stays the same)

Closes #131
Closes #91

## Test plan

- [x] `TestParseSkillEntry_ClawHub` - unprefixed entry generates clawhub command
- [x] `TestParseSkillEntry_Npm` - `npm:@openclaw/matrix` generates npm install command
- [x] `TestParseSkillEntry_NpmUnscoped` - `npm:some-package` works
- [x] `TestBuildSkillsScript_MixedPrefixes` - mixed clawhub + npm entries sorted correctly
- [x] `TestBuildStatefulSet_WithNpmSkill_InitSkillsScript` - npm skill produces correct init container
- [x] `TestBuildStatefulSet_WithSkills_InitSkillsContainer` - verifies `NPM_CONFIG_IGNORE_SCRIPTS=true`
- [x] `TestValidateSkillName_NpmPrefix` - valid npm-prefixed skill passes
- [x] `TestValidateSkillName_NpmPrefixEmpty` - bare `npm:` rejected
- [x] `TestValidateCreate_NpmPrefixedSkillAccepted` - full webhook path with npm skill
- [x] `TestValidateCreate_BareColonSkillRejected` - `foo:bar` rejected (colon not allowed without known prefix)
- [x] E2E test: instance with mixed skills produces correct init-skills container script and env

🤖 Generated with [Claude Code](https://claude.com/claude-code)