### PR TITLE
docs: update API reference with all missing spec/status fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,15 @@ Use prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `ci/`, `refactor/`
 
 Merged branches are auto-deleted. Always delete stale remote branches.
 
+### Git worktrees
+Always use `git worktree` when working on a separate branch to avoid switching branches and disrupting local state. Never use `git checkout` or `git switch` to change branches in the main working directory:
+
+```bash
+git worktree add ../k8s-operator-<suffix> -b <branch> main
+# work in the worktree directory, then clean up:
+git worktree remove ../k8s-operator-<suffix>
+```
+
 ### CRD API changes
 After modifying types in `api/v1alpha1/openclawinstance_types.go`:
 1. Run `make generate` (regenerates `zz_generated.deepcopy.go`)
@@ -134,13 +143,20 @@ After modifying types in `api/v1alpha1/openclawinstance_types.go`:
 - Resource builders: unit tests in `internal/resources/resources_test.go` (fast, no deps)
 - Controller integration: envtest suite in `internal/controller/` (needs kubebuilder binaries)
 - E2E: `test/e2e/` (needs kind cluster, runs in CI on PRs and main)
-- **Always add e2e tests when feasible** — any new feature or bug fix that changes the behavior of managed Kubernetes resources should include an e2e test verifying the resources are created correctly on a real cluster
-- The `RawConfig` type embeds `runtime.RawExtension` — in tests use:
+- **Always add e2e tests when feasible** -- any new feature or bug fix that changes the behavior of managed Kubernetes resources should include an e2e test verifying the resources are created correctly on a real cluster
+- The `RawConfig` type embeds `runtime.RawExtension` -- in tests use:
   ```go
   instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
       RawExtension: runtime.RawExtension{Raw: []byte(`{}`)},
   }
   ```
+
+### Documentation
+When adding or changing CRD fields, features, or behavior, **always** update both:
+- `README.md` -- user-facing overview, examples, and feature table
+- `docs/api-reference.md` -- exhaustive field-level reference for every spec and status field
+
+Both files must stay in sync with the types in `api/v1alpha1/openclawinstance_types.go`.
 
 ## CI Pipeline
 


### PR DESCRIPTION
## Summary

- Bring `docs/api-reference.md` fully up to date with the current CRD types in `api/v1alpha1/openclawinstance_types.go`
- Update `CLAUDE.md` with git worktree instructions and documentation requirements

### New spec sections added
- `spec.workspace` (initialFiles, initialDirectories)
- `spec.skills` (ClawHub + `npm:` prefix support)
- `spec.ollama` (image, models, resources, storage, gpu)
- `spec.sidecars`, `spec.sidecarVolumes`
- `spec.extraVolumes`, `spec.extraVolumeMounts`
- `spec.restoreFrom` (B2 backup restore)
- `spec.runtimeDeps` (pnpm, python)
- `spec.gateway` (existingSecret)
- `spec.autoUpdate` (enabled, checkInterval, backupBeforeUpdate, rollbackOnFailure, healthCheckTimeout)
- `spec.security.caBundle` (configMapName, secretName, key)
- `spec.security.rbac.serviceAccountAnnotations`
- `spec.security.podSecurityContext.fsGroupChangePolicy`
- `spec.security.networkPolicy.additionalEgress`

### Updated sections
- `spec.initContainers`: reserved names expanded to include `init-pnpm`, `init-python`, `init-ollama`
- `spec.chromium`: fixed port (3000 not 9222), UID (999 not 1001), /dev/shm (1Gi not 256Mi)
- `status.phase`: added BackingUp, Restoring, Updating
- `status.conditions`: added StatefulSetReady, BackupComplete, RestoreComplete, AutoUpdateAvailable, SecretsReady; marked DeploymentReady as deprecated
- Added `status.backup and restore` section
- Added `status.autoUpdate` section with all sub-fields
- Full example YAML expanded with all new fields

### CLAUDE.md updates
- Added git worktree instructions (always use worktrees, never git checkout/switch)
- Added documentation requirements (always update both README.md and docs/api-reference.md)

Closes #132

## Test plan

- [ ] Verify all spec fields in types.go have a corresponding entry in api-reference.md
- [ ] Verify all status fields in types.go have a corresponding entry in api-reference.md
- [ ] Verify full example YAML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)