### PR TITLE
fix: set CSV capabilities to Deep Insights (Level 4)

### DIFF
--- a/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
+++ b/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   name: openclaw-operator.v0.9.0
   namespace: placeholder
   annotations:
-    capabilities: "Full Lifecycle"
+    capabilities: "Deep Insights"
     categories: "AI/Machine Learning, Developer Tools, Application Runtime"
     containerImage: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
     createdAt: "2026-02-11T00:00:00Z"


### PR DESCRIPTION
## Summary

- Fix CSV `capabilities` annotation from "Full Lifecycle" (Level 3) to "Deep Insights" (Level 4)
- The rebase conflict in PR #149 was incorrectly resolved to keep the lower capability level

With auto-provisioned PrometheusRule alerts, Grafana dashboards, and custom metrics (`openclaw_instance_info`, `openclaw_instance_ready`), the operator qualifies for Level 4.

## Test plan

- [ ] Verify next OperatorHub submission shows "Deep Insights" on the listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)