### PR TITLE
feat!: rename B2/Backblaze to generic S3-compatible storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Every request is validated against the instance's allowlist policy. Protected co
 | **Auto-Update** | OCI registry polling | Opt-in version tracking: checks the registry for new semver releases, backs up first, rolls out, and auto-rolls back if the new version fails health checks |
 | **Scalable** | Auto-scaling | HPA integration with CPU and memory metrics, min/max replica bounds, automatic StatefulSet replica management |
 | **Resilient** | Self-healing lifecycle | PodDisruptionBudgets, health probes, automatic config rollouts via content hashing, 5-minute drift detection |
-| **Backup/Restore** | B2-backed snapshots | Automatic backup to Backblaze B2 on instance deletion; restore into a new instance from any snapshot |
+| **Backup/Restore** | S3-backed snapshots | Automatic backup to S3-compatible storage on instance deletion; restore into a new instance from any snapshot |
 | **Workspace Seeding** | Initial files & dirs | Pre-populate the workspace with files and directories before the agent starts |
 | **Gateway Auth** | Auto-generated tokens | Automatic gateway token Secret per instance, bypassing mDNS pairing (unusable in k8s) |
 | **Tailscale** | Tailnet access | Expose via Tailscale Serve or Funnel with SSO auth - no Ingress needed |
@@ -488,7 +488,7 @@ spec:
     healthCheckTimeout: "10m"    # how long to wait for the pod to become ready (2m-30m)
 ```
 
-When enabled, the operator resolves `latest` to the highest stable semver tag on creation, then polls for newer versions on each `checkInterval`. Before updating, it optionally runs a B2 backup, then patches the image tag and monitors the rollout. If the pod fails to become ready within `healthCheckTimeout`, it reverts the image tag and (optionally) restores the PVC from the pre-update snapshot.
+When enabled, the operator resolves `latest` to the highest stable semver tag on creation, then polls for newer versions on each `checkInterval`. Before updating, it optionally runs an S3 backup, then patches the image tag and monitors the rollout. If the pod fails to become ready within `healthCheckTimeout`, it reverts the image tag and (optionally) restores the PVC from the pre-update snapshot.
 
 Safety mechanisms include failed-version tracking (skips versions that failed health checks), a circuit breaker (pauses after 3 consecutive rollbacks), and full data restore when `backupBeforeUpdate` is enabled. Auto-update is a no-op for digest-pinned images (`spec.image.digest`).
 

--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -107,7 +107,7 @@ type OpenClawInstanceSpec struct {
 	// +optional
 	Availability AvailabilitySpec `json:"availability,omitempty"`
 
-	// RestoreFrom is the B2 backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
+	// RestoreFrom is the remote backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
 	// When set, the operator restores PVC data from this path before creating the StatefulSet.
 	// Cleared automatically after successful restore.
 	// +optional
@@ -1014,7 +1014,7 @@ type AutoUpdateStatus struct {
 	// +optional
 	PreviousVersion string `json:"previousVersion,omitempty"`
 
-	// PreUpdateBackupPath is the B2 path of the pre-update backup (used for rollback restore)
+	// PreUpdateBackupPath is the S3 path of the pre-update backup (used for rollback restore)
 	// +optional
 	PreUpdateBackupPath string `json:"preUpdateBackupPath,omitempty"`
 
@@ -1068,7 +1068,7 @@ type OpenClawInstanceStatus struct {
 	// +optional
 	RestoreJobName string `json:"restoreJobName,omitempty"`
 
-	// LastBackupPath is the B2 path of the last successful backup
+	// LastBackupPath is the S3 path of the last successful backup
 	// +optional
 	LastBackupPath string `json:"lastBackupPath,omitempty"`
 
@@ -1076,7 +1076,7 @@ type OpenClawInstanceStatus struct {
 	// +optional
 	LastBackupTime *metav1.Time `json:"lastBackupTime,omitempty"`
 
-	// RestoredFrom is the B2 path this instance was restored from
+	// RestoredFrom is the S3 path this instance was restored from
 	// +optional
 	RestoredFrom string `json:"restoredFrom,omitempty"`
 

--- a/bundle/manifests/openclaw.rocks_openclawinstances.yaml
+++ b/bundle/manifests/openclaw.rocks_openclawinstances.yaml
@@ -3169,6 +3169,16 @@ spec:
                   type: object
                 maxItems: 10
                 type: array
+              gateway:
+                description: Gateway configures the gateway authentication token
+                properties:
+                  existingSecret:
+                    description: |-
+                      ExistingSecret is the name of a user-managed Secret containing the gateway token.
+                      The Secret must have a key named "token". When set, the operator skips
+                      auto-generating a gateway token Secret and uses this Secret instead.
+                    type: string
+                type: object
               image:
                 description: Image configuration for the OpenClaw container
                 properties:
@@ -4680,6 +4690,14 @@ spec:
                                     - Exact
                                     - ImplementationSpecific
                                     type: string
+                                  port:
+                                    description: |-
+                                      Port is the backend service port number to route traffic to.
+                                      Defaults to the gateway port (18789) when not set.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
                                 type: object
                               type: array
                           required:
@@ -4741,6 +4759,47 @@ spec:
                           type: string
                         description: Annotations to add to the Service
                         type: object
+                      ports:
+                        description: |-
+                          Ports defines custom ports exposed on the Service.
+                          When set, these replace the default gateway and canvas ports.
+                          When empty, the operator creates default gateway (18789) and canvas (18793) ports.
+                        items:
+                          description: ServicePortSpec defines a port exposed by the
+                            Service
+                          properties:
+                            name:
+                              description: Name is the name of the port
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Port is the port number exposed on the
+                                Service
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: Protocol is the protocol for the port
+                              enum:
+                              - TCP
+                              - UDP
+                              - SCTP
+                              type: string
+                            targetPort:
+                              description: TargetPort is the port on the container
+                                to route to (defaults to Port)
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                          - name
+                          - port
+                          type: object
+                        maxItems: 20
+                        type: array
                       type:
                         default: ClusterIP
                         description: Type is the Kubernetes Service type
@@ -4803,6 +4862,83 @@ spec:
                             description: Labels to add to the ServiceMonitor
                             type: object
                         type: object
+                    type: object
+                type: object
+              ollama:
+                description: Ollama enables the Ollama sidecar for local LLM inference
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled enables the Ollama sidecar
+                    type: boolean
+                  gpu:
+                    description: GPU is the number of NVIDIA GPUs to allocate (sets
+                      nvidia.com/gpu resource limit)
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  image:
+                    description: Image configures the Ollama container image
+                    properties:
+                      digest:
+                        description: Digest is the container image digest for supply
+                          chain security
+                        type: string
+                      repository:
+                        default: ollama/ollama
+                        description: Repository is the container image repository
+                        type: string
+                      tag:
+                        default: latest
+                        description: Tag is the container image tag
+                        type: string
+                    type: object
+                  models:
+                    description: Models is a list of models to pre-pull during pod
+                      init (e.g. ["llama3.2", "nomic-embed-text"])
+                    items:
+                      type: string
+                    maxItems: 10
+                    type: array
+                  resources:
+                    description: Resources specifies compute resources for the Ollama
+                      container
+                    properties:
+                      limits:
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                    type: object
+                  storage:
+                    description: Storage configures the model cache volume
+                    properties:
+                      existingClaim:
+                        description: ExistingClaim is the name of an existing PVC
+                          for persistent model storage
+                        type: string
+                      sizeLimit:
+                        default: 20Gi
+                        description: SizeLimit is the size limit for the emptyDir
+                          model cache (default "20Gi")
+                        type: string
                     type: object
                 type: object
               probes:
@@ -4922,7 +5058,7 @@ spec:
                 type: object
               restoreFrom:
                 description: |-
-                  RestoreFrom is the B2 backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
+                  RestoreFrom is the remote backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
                   When set, the operator restores PVC data from this path before creating the StatefulSet.
                   Cleared automatically after successful restore.
                 type: string
@@ -8498,8 +8634,10 @@ spec:
                 type: array
               skills:
                 description: |-
-                  Skills is a list of ClawHub skills to install via init container.
-                  Each entry is a skill identifier (e.g., "@anthropic/mcp-server-fetch").
+                  Skills is a list of skills to install via init container.
+                  Each entry is either a ClawHub skill identifier (e.g., "@anthropic/mcp-server-fetch")
+                  or an npm package prefixed with "npm:" (e.g., "npm:@openclaw/matrix").
+                  npm lifecycle scripts are disabled for security (see #91).
                 items:
                   type: string
                 maxItems: 20
@@ -8535,6 +8673,56 @@ spec:
                           to use
                         type: string
                     type: object
+                type: object
+              tailscale:
+                description: Tailscale configures Tailscale integration for tailnet
+                  access and HTTPS
+                properties:
+                  authKeySecretKey:
+                    default: authkey
+                    description: AuthKeySecretKey is the key in the referenced Secret.
+                    type: string
+                  authKeySecretRef:
+                    description: |-
+                      AuthKeySecretRef references a Secret containing the Tailscale auth key.
+                      The Secret must have a key matching AuthKeySecretKey (default: "authkey").
+                      Use ephemeral+reusable keys from the Tailscale admin console.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  authSSO:
+                    default: false
+                    description: |-
+                      AuthSSO enables passwordless login for tailnet members.
+                      Sets gateway.auth.allowTailscale=true in the OpenClaw config.
+                    type: boolean
+                  enabled:
+                    default: false
+                    description: Enabled enables Tailscale integration
+                    type: boolean
+                  hostname:
+                    description: Hostname sets the Tailscale device name (defaults
+                      to instance name).
+                    type: string
+                  mode:
+                    default: serve
+                    description: |-
+                      Mode selects the Tailscale mode.
+                      "serve" exposes the instance to tailnet members only (default).
+                      "funnel" exposes the instance to the public internet via Tailscale Funnel.
+                    enum:
+                    - serve
+                    - funnel
+                    type: string
                 type: object
               workspace:
                 description: |-
@@ -8596,7 +8784,7 @@ spec:
                     description: PendingVersion is set during an in-flight update
                     type: string
                   preUpdateBackupPath:
-                    description: PreUpdateBackupPath is the B2 path of the pre-update
+                    description: PreUpdateBackupPath is the S3 path of the pre-update
                       backup (used for rollback restore)
                     type: string
                   previousVersion:
@@ -8687,7 +8875,7 @@ spec:
                 description: GatewayEndpoint is the endpoint for the OpenClaw gateway
                 type: string
               lastBackupPath:
-                description: LastBackupPath is the B2 path of the last successful
+                description: LastBackupPath is the S3 path of the last successful
                   backup
                 type: string
               lastBackupTime:
@@ -8761,7 +8949,7 @@ spec:
                 description: RestoreJobName is the name of the active restore Job
                 type: string
               restoredFrom:
-                description: RestoredFrom is the B2 path this instance was restored
+                description: RestoredFrom is the S3 path this instance was restored
                   from
                 type: string
             type: object

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -70,4 +70,4 @@ annotations:
       image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
   artifacthub.io/changes: |
     - kind: added
-      description: PVC backup-on-delete and restore-from-backup via rclone/B2
+      description: PVC backup-on-delete and restore-from-backup via rclone/S3

--- a/charts/openclaw-operator/crds/openclaw.rocks_openclawinstances.yaml
+++ b/charts/openclaw-operator/crds/openclaw.rocks_openclawinstances.yaml
@@ -5138,7 +5138,7 @@ spec:
                 type: object
               restoreFrom:
                 description: |-
-                  RestoreFrom is the B2 backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
+                  RestoreFrom is the remote backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
                   When set, the operator restores PVC data from this path before creating the StatefulSet.
                   Cleared automatically after successful restore.
                 type: string
@@ -8891,7 +8891,7 @@ spec:
                     description: PendingVersion is set during an in-flight update
                     type: string
                   preUpdateBackupPath:
-                    description: PreUpdateBackupPath is the B2 path of the pre-update
+                    description: PreUpdateBackupPath is the S3 path of the pre-update
                       backup (used for rollback restore)
                     type: string
                   previousVersion:
@@ -8982,7 +8982,7 @@ spec:
                 description: GatewayEndpoint is the endpoint for the OpenClaw gateway
                 type: string
               lastBackupPath:
-                description: LastBackupPath is the B2 path of the last successful
+                description: LastBackupPath is the S3 path of the last successful
                   backup
                 type: string
               lastBackupTime:
@@ -9071,7 +9071,7 @@ spec:
                 description: RestoreJobName is the name of the active restore Job
                 type: string
               restoredFrom:
-                description: RestoredFrom is the B2 path this instance was restored
+                description: RestoredFrom is the S3 path this instance was restored
                   from
                 type: string
             type: object

--- a/config/crd/bases/openclaw.rocks_openclawinstances.yaml
+++ b/config/crd/bases/openclaw.rocks_openclawinstances.yaml
@@ -5138,7 +5138,7 @@ spec:
                 type: object
               restoreFrom:
                 description: |-
-                  RestoreFrom is the B2 backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
+                  RestoreFrom is the remote backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
                   When set, the operator restores PVC data from this path before creating the StatefulSet.
                   Cleared automatically after successful restore.
                 type: string
@@ -8891,7 +8891,7 @@ spec:
                     description: PendingVersion is set during an in-flight update
                     type: string
                   preUpdateBackupPath:
-                    description: PreUpdateBackupPath is the B2 path of the pre-update
+                    description: PreUpdateBackupPath is the S3 path of the pre-update
                       backup (used for rollback restore)
                     type: string
                   previousVersion:
@@ -8982,7 +8982,7 @@ spec:
                 description: GatewayEndpoint is the endpoint for the OpenClaw gateway
                 type: string
               lastBackupPath:
-                description: LastBackupPath is the B2 path of the last successful
+                description: LastBackupPath is the S3 path of the last successful
                   backup
                 type: string
               lastBackupTime:
@@ -9071,7 +9071,7 @@ spec:
                 description: RestoreJobName is the name of the active restore Job
                 type: string
               restoredFrom:
-                description: RestoredFrom is the B2 path this instance was restored
+                description: RestoredFrom is the S3 path this instance was restored
                   from
                 type: string
             type: object

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -608,7 +608,7 @@ High availability and scheduling configuration.
 
 | Field         | Type     | Default | Description                                                                                       |
 |---------------|----------|---------|---------------------------------------------------------------------------------------------------|
-| `restoreFrom` | `string` | --      | B2 backup path to restore data from (e.g., `backups/{tenantId}/{instanceId}/{timestamp}`). When set, the operator restores PVC data from this path before creating the StatefulSet. Cleared automatically after successful restore. |
+| `restoreFrom` | `string` | --      | Remote backup path to restore data from (e.g., `backups/{tenantId}/{instanceId}/{timestamp}`). When set, the operator restores PVC data from this S3 path before creating the StatefulSet. Cleared automatically after successful restore. |
 
 ### spec.runtimeDeps
 
@@ -742,9 +742,9 @@ Standard `metav1.Condition` array. Condition types:
 |------------------|----------------|----------------------------------------------------------|
 | `backupJobName`  | `string`       | Name of the active backup Job.                           |
 | `restoreJobName` | `string`       | Name of the active restore Job.                          |
-| `lastBackupPath` | `string`       | B2 path of the last successful backup.                   |
+| `lastBackupPath` | `string`       | S3 path of the last successful backup.                   |
 | `lastBackupTime` | `*metav1.Time` | Timestamp of the last successful backup.                 |
-| `restoredFrom`   | `string`       | B2 path this instance was restored from.                 |
+| `restoredFrom`   | `string`       | S3 path this instance was restored from.                 |
 
 ### status.autoUpdate
 
@@ -760,7 +760,7 @@ Tracks the state of automatic version updates.
 | `lastUpdateTime`     | `*metav1.Time` | When the last successful update was applied.                                             |
 | `lastUpdateError`    | `string`       | Error message from the last failed update attempt.                                       |
 | `previousVersion`    | `string`       | Version before the last update (used for rollback).                                      |
-| `preUpdateBackupPath`| `string`       | B2 path of the pre-update backup (used for rollback restore).                            |
+| `preUpdateBackupPath`| `string`       | S3 path of the pre-update backup (used for rollback restore).                            |
 | `failedVersion`      | `string`       | Version that failed health checks and will be skipped in future checks. Cleared when a newer version becomes available. |
 | `rollbackCount`      | `int32`        | Consecutive rollback count. Auto-update pauses after 3. Reset to 0 on any successful update. |
 

--- a/internal/controller/backup_test.go
+++ b/internal/controller/backup_test.go
@@ -37,9 +37,9 @@ var _ = Describe("Backup on Delete", func() {
 		interval = time.Millisecond * 250
 	)
 
-	Context("When deleting an instance without B2 credentials Secret", func() {
+	Context("When deleting an instance without S3 credentials Secret", func() {
 		It("Should remove the finalizer and delete cleanly", func() {
-			// Ensure B2 secret doesn't exist (may have been created by another test)
+			// Ensure S3 secret doesn't exist (may have been created by another test)
 			_ = k8sClient.Delete(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      BackupSecretName,
@@ -49,14 +49,14 @@ var _ = Describe("Backup on Delete", func() {
 
 			instance := &openclawv1alpha1.OpenClawInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "backup-no-b2-test",
+					Name:      "backup-no-s3-test",
 					Namespace: "default",
 				},
 				Spec: openclawv1alpha1.OpenClawInstanceSpec{},
 			}
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
-			instanceKey := types.NamespacedName{Name: "backup-no-b2-test", Namespace: "default"}
+			instanceKey := types.NamespacedName{Name: "backup-no-s3-test", Namespace: "default"}
 
 			// Wait for instance to be provisioned (finalizer added)
 			Eventually(func() bool {
@@ -81,20 +81,20 @@ var _ = Describe("Backup on Delete", func() {
 
 	Context("When deleting an instance with skip-backup annotation", func() {
 		It("Should remove the finalizer immediately", func() {
-			// Create a B2 credentials secret (needed by controller)
-			b2Secret := &corev1.Secret{
+			// Create an S3 credentials secret (needed by controller)
+			s3Secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      BackupSecretName,
 					Namespace: "default",
 				},
 				Data: map[string][]byte{
-					"B2_BUCKET":   []byte("test-bucket"),
-					"B2_KEY_ID":   []byte("key123"),
-					"B2_APP_KEY":  []byte("secret456"),
-					"B2_ENDPOINT": []byte("https://s3.example.com"),
+					"S3_BUCKET":            []byte("test-bucket"),
+					"S3_ACCESS_KEY_ID":     []byte("key123"),
+					"S3_SECRET_ACCESS_KEY": []byte("secret456"),
+					"S3_ENDPOINT":          []byte("https://s3.example.com"),
 				},
 			}
-			_ = k8sClient.Create(ctx, b2Secret)
+			_ = k8sClient.Create(ctx, s3Secret)
 
 			instance := &openclawv1alpha1.OpenClawInstance{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/restore.go
+++ b/internal/controller/restore.go
@@ -34,7 +34,7 @@ import (
 	openclawv1alpha1 "github.com/openclawrocks/k8s-operator/api/v1alpha1"
 )
 
-// reconcileRestore handles restoring PVC data from a B2 backup before StatefulSet creation.
+// reconcileRestore handles restoring PVC data from an S3 backup before StatefulSet creation.
 // Returns (result, done, error):
 //   - done=true: restore is complete (or not needed), continue to create StatefulSet
 //   - done=false: restore is in progress, requeue with result
@@ -61,10 +61,10 @@ func (r *OpenClawInstanceReconciler) reconcileRestore(ctx context.Context, insta
 		}
 	}
 
-	// Get B2 credentials
-	creds, err := r.getB2Credentials(ctx)
+	// Get S3 credentials
+	creds, err := r.getS3Credentials(ctx)
 	if err != nil {
-		logger.Error(err, "Failed to get B2 credentials for restore")
+		logger.Error(err, "Failed to get S3 credentials for restore")
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "RestoreCredentialsFailed", err.Error())
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, false, nil
 	}

--- a/internal/controller/restore_test.go
+++ b/internal/controller/restore_test.go
@@ -91,20 +91,20 @@ var _ = Describe("Restore from Backup", func() {
 
 	Context("When creating an instance with restoreFrom", func() {
 		It("Should enter Restoring phase and create a restore Job", func() {
-			// Ensure B2 credentials exist
-			b2Secret := &corev1.Secret{
+			// Ensure S3 credentials exist
+			s3Secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      BackupSecretName,
 					Namespace: "default",
 				},
 				Data: map[string][]byte{
-					"B2_BUCKET":   []byte("test-bucket"),
-					"B2_KEY_ID":   []byte("key123"),
-					"B2_APP_KEY":  []byte("secret456"),
-					"B2_ENDPOINT": []byte("https://s3.example.com"),
+					"S3_BUCKET":            []byte("test-bucket"),
+					"S3_ACCESS_KEY_ID":     []byte("key123"),
+					"S3_SECRET_ACCESS_KEY": []byte("secret456"),
+					"S3_ENDPOINT":          []byte("https://s3.example.com"),
 				},
 			}
-			_ = k8sClient.Create(ctx, b2Secret)
+			_ = k8sClient.Create(ctx, s3Secret)
 
 			instance := &openclawv1alpha1.OpenClawInstance{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -27,7 +27,7 @@ import (
 	openclawv1alpha1 "github.com/openclawrocks/k8s-operator/api/v1alpha1"
 )
 
-var _ = Describe("B2 Helpers", func() {
+var _ = Describe("S3 Helpers", func() {
 	Context("getTenantID", func() {
 		It("Should return the tenant label value when present", func() {
 			instance := &openclawv1alpha1.OpenClawInstance{
@@ -64,10 +64,10 @@ var _ = Describe("B2 Helpers", func() {
 	})
 
 	Context("buildRcloneJob", func() {
-		var creds *b2Credentials
+		var creds *s3Credentials
 
 		BeforeEach(func() {
-			creds = &b2Credentials{
+			creds = &s3Credentials{
 				Bucket:   "test-bucket",
 				KeyID:    "key123",
 				AppKey:   "secret456",
@@ -111,10 +111,10 @@ var _ = Describe("B2 Helpers", func() {
 			for _, e := range container.Env {
 				envNames = append(envNames, e.Name)
 			}
-			Expect(envNames).To(ContainElements("B2_ENDPOINT", "B2_KEY_ID", "B2_APP_KEY"))
+			Expect(envNames).To(ContainElements("S3_ENDPOINT", "S3_ACCESS_KEY_ID", "S3_SECRET_ACCESS_KEY"))
 		})
 
-		It("Should build a restore Job with B2 as source", func() {
+		It("Should build a restore Job with S3 as source", func() {
 			instance := &openclawv1alpha1.OpenClawInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "myinst",

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -378,11 +378,11 @@ var _ = Describe("OpenClawInstance Controller", func() {
 		})
 	})
 
-	Context("When deleting an OpenClawInstance without B2 backup credentials", func() {
+	Context("When deleting an OpenClawInstance without S3 backup credentials", func() {
 		var namespace string
 
 		BeforeEach(func() {
-			namespace = "test-no-b2-" + time.Now().Format("20060102150405")
+			namespace = "test-no-s3-" + time.Now().Format("20060102150405")
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
@@ -400,14 +400,14 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			_ = k8sClient.Delete(ctx, ns)
 		})
 
-		It("Should delete cleanly when B2 backup credentials are not configured", func() {
+		It("Should delete cleanly when S3 backup credentials are not configured", func() {
 			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
 				Skip("Skipping resource validation in minimal mode")
 			}
 
-			instanceName := "no-b2-delete"
+			instanceName := "no-s3-delete"
 
-			// No B2 secret exists in the namespace or operator namespace
+			// No S3 secret exists in the namespace or operator namespace
 			instance := &openclawv1alpha1.OpenClawInstance{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      instanceName,
@@ -434,7 +434,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				}, statefulSet)
 			}, timeout, interval).Should(Succeed())
 
-			// Delete the instance - should succeed without B2 credentials
+			// Delete the instance - should succeed without S3 credentials
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 
 			// Instance should be fully garbage collected (finalizer removed)


### PR DESCRIPTION
## Summary
- Renames all B2/Backblaze references to generic S3-compatible storage
- Secret name: `b2-backup-credentials` -> `s3-backup-credentials`
- Secret keys: `B2_BUCKET`/`B2_KEY_ID`/`B2_APP_KEY`/`B2_ENDPOINT` -> `S3_BUCKET`/`S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY`/`S3_ENDPOINT`
- Renames `b2.go` -> `s3.go`, struct/function names, comments, docs, and tests

**BREAKING CHANGE:** Users must update their backup credentials Secret name and keys.

## Test plan
- [x] `make generate && make manifests` - CRDs regenerated
- [x] `make fmt && make lint` - passes
- [x] `make test` - all unit + integration tests pass
- [ ] E2E tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)