### PR TITLE
fix: break reconciliation tight loop caused by unconditional status writes

### DIFF
--- a/internal/controller/autoupdate.go
+++ b/internal/controller/autoupdate.go
@@ -202,11 +202,10 @@ func (r *OpenClawInstanceReconciler) reconcileAutoUpdate(ctx context.Context, in
 		fmt.Sprintf("New version %s available (current: %s)", version, currentTag))
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:               openclawv1alpha1.ConditionTypeAutoUpdateAvailable,
-		Status:             metav1.ConditionTrue,
-		Reason:             "NewVersionAvailable",
-		Message:            fmt.Sprintf("Version %s is available (current: %s)", version, currentTag),
-		LastTransitionTime: metav1.Now(),
+		Type:    openclawv1alpha1.ConditionTypeAutoUpdateAvailable,
+		Status:  metav1.ConditionTrue,
+		Reason:  "NewVersionAvailable",
+		Message: fmt.Sprintf("Version %s is available (current: %s)", version, currentTag),
 	})
 
 	instance.Status.AutoUpdate.PendingVersion = version

--- a/internal/controller/backup.go
+++ b/internal/controller/backup.go
@@ -190,11 +190,10 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 			fmt.Sprintf("Backup Job %s failed. Fix and delete the Job to retry, or annotate %s=true to skip.", jobName, AnnotationSkipBackup))
 
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:               openclawv1alpha1.ConditionTypeBackupComplete,
-			Status:             metav1.ConditionFalse,
-			Reason:             "BackupFailed",
-			Message:            "Backup Job failed",
-			LastTransitionTime: metav1.Now(),
+			Type:    openclawv1alpha1.ConditionTypeBackupComplete,
+			Status:  metav1.ConditionFalse,
+			Reason:  "BackupFailed",
+			Message: "Backup Job failed",
 		})
 		if err := r.Status().Update(ctx, instance); err != nil {
 			return ctrl.Result{}, err
@@ -212,11 +211,10 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 	instance.Status.Phase = openclawv1alpha1.PhaseTerminating
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:               openclawv1alpha1.ConditionTypeBackupComplete,
-		Status:             metav1.ConditionTrue,
-		Reason:             "BackupSucceeded",
-		Message:            fmt.Sprintf("Backup completed to %s", instance.Status.LastBackupPath),
-		LastTransitionTime: metav1.Now(),
+		Type:    openclawv1alpha1.ConditionTypeBackupComplete,
+		Status:  metav1.ConditionTrue,
+		Reason:  "BackupSucceeded",
+		Message: fmt.Sprintf("Backup completed to %s", instance.Status.LastBackupPath),
 	})
 	if err := r.Status().Update(ctx, instance); err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/restore.go
+++ b/internal/controller/restore.go
@@ -118,11 +118,10 @@ func (r *OpenClawInstanceReconciler) reconcileRestore(ctx context.Context, insta
 			fmt.Sprintf("Restore Job %s failed. Delete the Job to retry.", jobName))
 
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:               openclawv1alpha1.ConditionTypeRestoreComplete,
-			Status:             metav1.ConditionFalse,
-			Reason:             "RestoreFailed",
-			Message:            fmt.Sprintf("Restore Job %s failed", jobName),
-			LastTransitionTime: metav1.Now(),
+			Type:    openclawv1alpha1.ConditionTypeRestoreComplete,
+			Status:  metav1.ConditionFalse,
+			Reason:  "RestoreFailed",
+			Message: fmt.Sprintf("Restore Job %s failed", jobName),
 		})
 		if err := r.Status().Update(ctx, instance); err != nil {
 			return ctrl.Result{}, false, err
@@ -139,11 +138,10 @@ func (r *OpenClawInstanceReconciler) reconcileRestore(ctx context.Context, insta
 	instance.Status.RestoredFrom = instance.Spec.RestoreFrom
 	instance.Status.Phase = openclawv1alpha1.PhaseProvisioning
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:               openclawv1alpha1.ConditionTypeRestoreComplete,
-		Status:             metav1.ConditionTrue,
-		Reason:             "RestoreSucceeded",
-		Message:            fmt.Sprintf("Restored from %s", instance.Spec.RestoreFrom),
-		LastTransitionTime: metav1.Now(),
+		Type:    openclawv1alpha1.ConditionTypeRestoreComplete,
+		Status:  metav1.ConditionTrue,
+		Reason:  "RestoreSucceeded",
+		Message: fmt.Sprintf("Restored from %s", instance.Spec.RestoreFrom),
 	})
 	if err := r.Status().Update(ctx, instance); err != nil {
 		return ctrl.Result{}, false, err


### PR DESCRIPTION
## Summary

Fixes the operator reconciling in a tight loop even when nothing changes. The root cause was that every successful reconciliation unconditionally wrote a new `LastReconcileTime` timestamp to the status subresource, which triggered a watch event that bypassed the 5-minute `RequeueAfter`.

- **Status equality guard**: snapshot status before mutations, compare with `equality.Semantic.DeepEqual` after, skip `r.Status().Update()` when nothing changed
- **Conditional `LastReconcileTime`**: only update when `ObservedGeneration != Generation` (new spec processed), making it idempotent on steady-state reconciles
- **Conditional event emission**: only emit `ReconcileSucceeded` event when status actually changed, preventing event stream flooding
- **Remove explicit `LastTransitionTime`**: cleaned up all 13 `meta.SetStatusCondition` call sites -- the function already handles transition time correctly internally

## Test plan

- [x] `go vet ./...` passes
- [x] `make test` passes (unit + envtest integration)
- [x] `make lint` passes (golangci-lint)
- [ ] E2E tests pass in CI
- [ ] Deploy to staging and verify reconcile loop settles after initial convergence (check controller logs for reconcile frequency)

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)