### PR TITLE
fix: FailedPostStartHook with mergeMode: merge

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -876,6 +876,11 @@ func TestBuildStatefulSet_PostStart_MergeMode(t *testing.T) {
 	if !strings.Contains(cmd[2], "/operator-config/openclaw.json") {
 		t.Errorf("merge mode postStart should reference operator-config path, got %q", cmd[2])
 	}
+	// Regression #162: node -e argument must be single-quoted so that
+	// !Array.isArray is not interpreted as bash history expansion.
+	if !strings.Contains(cmd[2], "node -e '") {
+		t.Errorf("merge mode postStart must single-quote the node -e argument to avoid bash history expansion (#162), got %q", cmd[2])
+	}
 }
 
 func TestBuildStatefulSet_PostStart_JSON5Mode_NoHook(t *testing.T) {
@@ -3631,6 +3636,11 @@ func TestBuildInitScript_MergeMode(t *testing.T) {
 	}
 	if !strings.Contains(script, "copyFileSync") {
 		t.Errorf("merge mode should use copyFileSync to move merged config to /data, got: %q", script)
+	}
+	// Regression #162: node -e argument must be single-quoted so that
+	// !Array.isArray is not interpreted as bash history expansion.
+	if !strings.Contains(script, "node -e '") {
+		t.Errorf("merge mode init script must single-quote the node -e argument to avoid bash history expansion (#162), got %q", script)
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -500,15 +500,15 @@ func BuildInitScript(instance *openclawv1alpha1.OpenClawInstance) string {
 			// cannot be used because it has no shell (#105).
 			// The config path is passed via env var to avoid shell/JS quoting issues.
 			lines = append(lines, fmt.Sprintf(
-				`__cfgpath=/config/%s node -e "`+
-					`const fs=require('fs');`+
-					`function dm(a,b){const r={...a};for(const k in b){r[k]=b[k]&&typeof b[k]==='object'&&!Array.isArray(b[k])&&r[k]&&typeof r[k]==='object'&&!Array.isArray(r[k])?dm(r[k],b[k]):b[k]}return r}`+
-					`const e='/data/openclaw.json',c=process.env.__cfgpath,t='/tmp/merged.json';`+
-					`const base=fs.existsSync(e)?JSON.parse(fs.readFileSync(e,'utf8')):{};`+
-					`const inc=JSON.parse(fs.readFileSync(c,'utf8'));`+
+				`__cfgpath=/config/%s node -e '`+
+					`const fs=require("fs");`+
+					`function dm(a,b){const r={...a};for(const k in b){r[k]=b[k]&&typeof b[k]==="object"&&!Array.isArray(b[k])&&r[k]&&typeof r[k]==="object"&&!Array.isArray(r[k])?dm(r[k],b[k]):b[k]}return r}`+
+					`const e="/data/openclaw.json",c=process.env.__cfgpath,t="/tmp/merged.json";`+
+					`const base=fs.existsSync(e)?JSON.parse(fs.readFileSync(e,"utf8")):{};`+
+					`const inc=JSON.parse(fs.readFileSync(c,"utf8"));`+
 					`fs.writeFileSync(t,JSON.stringify(dm(base,inc),null,2));`+
 					`fs.copyFileSync(t,e);`+
-					`"`,
+					`'`,
 				shellQuote(key)))
 		case instance.Spec.Config.Format == ConfigFormatJSON5:
 			// JSON5 overwrite — convert to standard JSON via npx json5
@@ -1427,15 +1427,15 @@ func buildConfigRestoreCommand(instance *openclawv1alpha1.OpenClawInstance) stri
 		// Deep-merge operator config into existing PVC config via Node.js.
 		// Same logic as the init container merge, but with main container paths.
 		return fmt.Sprintf(
-			`node -e "`+
-				`const fs=require('fs');`+
-				`function dm(a,b){const r={...a};for(const k in b){r[k]=b[k]&&typeof b[k]==='object'&&!Array.isArray(b[k])&&r[k]&&typeof r[k]==='object'&&!Array.isArray(r[k])?dm(r[k],b[k]):b[k]}return r}`+
-				`const e=%q,c=%q,t='/tmp/merged.json';`+
-				`const base=fs.existsSync(e)?JSON.parse(fs.readFileSync(e,'utf8')):{};`+
-				`const inc=JSON.parse(fs.readFileSync(c,'utf8'));`+
+			`node -e '`+
+				`const fs=require("fs");`+
+				`function dm(a,b){const r={...a};for(const k in b){r[k]=b[k]&&typeof b[k]==="object"&&!Array.isArray(b[k])&&r[k]&&typeof r[k]==="object"&&!Array.isArray(r[k])?dm(r[k],b[k]):b[k]}return r}`+
+				`const e="%s",c="%s",t="/tmp/merged.json";`+
+				`const base=fs.existsSync(e)?JSON.parse(fs.readFileSync(e,"utf8")):{};`+
+				`const inc=JSON.parse(fs.readFileSync(c,"utf8"));`+
 				`fs.writeFileSync(t,JSON.stringify(dm(base,inc),null,2));`+
 				`fs.copyFileSync(t,e);`+
-				`"`,
+				`'`,
 			dst, src)
 	case instance.Spec.Config.Format == ConfigFormatJSON5:
 		// JSON5 conversion requires npx which is too slow for a postStart hook.


### PR DESCRIPTION
## Summary
- Swaps the quoting in the `mergeMode: merge` Node.js deep-merge scripts from double-quoted to single-quoted outer wrapper
- Inside double-quoted shell strings, `!Array.isArray(...)` triggers bash history expansion in containers where `/bin/sh` is bash, causing `FailedPostStartHook` on every pod start
- Fixes both the **postStart lifecycle hook** (`buildConfigRestoreCommand`) and the **init container** (`BuildInitScript`) merge scripts
- Adds regression tests verifying single-quote wrapping for both locations

Fixes #162

## Test plan
- [x] Unit tests pass (`go test ./internal/resources/ -v`)
- [x] `go vet ./...` clean
- [ ] CI: lint, test, e2e
- [ ] Deploy with `mergeMode: merge` and verify no `FailedPostStartHook`

🤖 Generated with [Claude Code](https://claude.com/claude-code)