### PR TITLE
fix: auto-set gateway.bind=loopback and exec probes for Tailscale serve/funnel

### DIFF
--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -74,6 +74,15 @@ const (
 
 	// TailscaleModeServe is the default Tailscale mode (tailnet-only access)
 	TailscaleModeServe = "serve"
+
+	// TailscaleModeFunnel exposes the instance to the public internet via Tailscale Funnel
+	TailscaleModeFunnel = "funnel"
+
+	// GatewayBindLoopback is the bind value for loopback mode (required for Tailscale serve/funnel)
+	GatewayBindLoopback = "loopback"
+
+	// GatewayBindLAN is the default bind value for LAN mode (pod IP, required for TCPSocket probes)
+	GatewayBindLAN = "lan"
 )
 
 // Labels returns the standard labels for an OpenClawInstance
@@ -184,6 +193,16 @@ func GetImage(instance *openclawv1alpha1.OpenClawInstance) string {
 		return repo + "@" + instance.Spec.Image.Digest
 	}
 	return repo + ":" + GetImageTag(instance)
+}
+
+// IsTailscaleServeOrFunnel returns true when Tailscale is enabled with serve
+// or funnel mode. Both modes require gateway.bind=loopback.
+func IsTailscaleServeOrFunnel(instance *openclawv1alpha1.OpenClawInstance) bool {
+	if !instance.Spec.Tailscale.Enabled {
+		return false
+	}
+	mode := instance.Spec.Tailscale.Mode
+	return mode == "" || mode == TailscaleModeServe || mode == TailscaleModeFunnel
 }
 
 // Ptr returns a pointer to the given value


### PR DESCRIPTION
## Summary

- When Tailscale serve/funnel is enabled, automatically set `gateway.bind=loopback` instead of `lan` (required by the OpenClaw gateway for Tailscale modes)
- Switch health probes from TCPSocket to exec-based (`wget --spider`) when Tailscale serve/funnel is active, since kubelet TCPSocket probes can't reach a loopback-bound service
- User overrides of `gateway.bind` are still preserved

Fixes #167

## Test plan

- [x] Unit tests: ConfigMap sets `gateway.bind=loopback` for serve, funnel, and default mode
- [x] Unit tests: ConfigMap sets `gateway.bind=lan` when Tailscale is disabled
- [x] Unit tests: User override of `gateway.bind` is preserved
- [x] Unit tests: Probes use exec handler when Tailscale serve/funnel is enabled
- [x] Unit tests: Probes use TCPSocket when Tailscale is disabled
- [x] E2E test: Verifies `gateway.bind=loopback` in ConfigMap
- [x] E2E test: Verifies exec probes on StatefulSet
- [x] All existing Tailscale and non-Tailscale tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)