### PR TITLE
fix: move CRDs to Helm templates for upgrade support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,15 @@ jobs:
       - name: Check Helm chart RBAC matches kubebuilder markers
         run: bash hack/check-helm-rbac-sync.sh
 
+  helm-crd-sync:
+    name: Helm CRD Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Helm chart CRD templates match generated CRDs
+        run: bash hack/sync-chart-crds.sh --check
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,8 +182,8 @@ All checks run on every push to main and every PR:
 
 ## Helm Chart
 
-- CRDs in `charts/openclaw-operator/crds/` — installed on `helm install`, but NOT upgraded by Helm
-- Users must `kubectl apply -f` CRDs before `helm upgrade` when CRD schema changes
+- CRDs are Helm templates in `charts/openclaw-operator/templates/crds/` -- updated on every `helm upgrade`
+- Run `make sync-chart-crds` after `make manifests` to sync CRDs into the Helm chart (CI enforces this)
 - `appVersion` in `Chart.yaml` uses plain semver (no `v` prefix); the deployment template prepends `v`
 - Chart version and appVersion are managed by release-please via `extra-files` in `release-please-config.json`
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+.PHONY: sync-chart-crds
+sync-chart-crds: manifests ## Sync CRDs from config/crd/bases/ into Helm chart templates.
+	bash hack/sync-chart-crds.sh
+
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/charts/openclaw-operator/templates/NOTES.txt
+++ b/charts/openclaw-operator/templates/NOTES.txt
@@ -7,6 +7,20 @@ To learn more about the release, try:
   $ helm status {{ .Release.Name }}
   $ helm get all {{ .Release.Name }}
 
+## Upgrading from versions that used crds/ directory
+
+If you are upgrading from a chart version that installed CRDs via the Helm
+crds/ directory (prior to this version), you must adopt the existing CRDs
+into Helm management before upgrading:
+
+  kubectl label crd openclawinstances.openclaw.rocks app.kubernetes.io/managed-by=Helm
+  kubectl annotate crd openclawinstances.openclaw.rocks meta.helm.sh/release-name={{ .Release.Name }} meta.helm.sh/release-namespace={{ .Release.Namespace }}
+  kubectl label crd openclawselfconfigs.openclaw.rocks app.kubernetes.io/managed-by=Helm
+  kubectl annotate crd openclawselfconfigs.openclaw.rocks meta.helm.sh/release-name={{ .Release.Name }} meta.helm.sh/release-namespace={{ .Release.Namespace }}
+
+This is only needed once. After this, CRDs will be updated automatically
+on every `helm upgrade`.
+
 ## Quick Start
 
 1. Create a secret with your API keys:

--- a/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
+++ b/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
@@ -1,10 +1,16 @@
+{{- if .Values.crds.install }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
   name: openclawinstances.openclaw.rocks
+  labels:
+    {{- include "openclaw-operator.labels" . | nindent 4 }}
 spec:
   group: openclaw.rocks
   names:
@@ -9161,3 +9167,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawselfconfigs.yaml
+++ b/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawselfconfigs.yaml
@@ -1,10 +1,16 @@
+{{- if .Values.crds.install }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    {{- if .Values.crds.keep }}
+    "helm.sh/resource-policy": keep
+    {{- end }}
   name: openclawselfconfigs.openclaw.rocks
+  labels:
+    {{- include "openclaw-operator.labels" . | nindent 4 }}
 spec:
   group: openclaw.rocks
   names:
@@ -146,3 +152,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,13 +62,19 @@ kubectl get openclawinstance my-assistant -n openclaw \
    ```
    Verify the operator pod is `Running` and ready. If it is in `CrashLoopBackOff`, check its logs.
 
-2. **CRD not installed**:
+2. **CRD not installed or outdated**:
    ```bash
    kubectl get crd openclawinstances.openclaw.rocks
    ```
    If the CRD is missing, install it:
    ```bash
-   kubectl apply -f charts/openclaw-operator/crds/
+   kubectl apply -f config/crd/bases/
+   ```
+   If you upgraded the operator but new fields (e.g. `selfConfigure`) are
+   rejected as "field not declared in schema", the CRD is outdated. Upgrade
+   the Helm chart or apply CRDs manually:
+   ```bash
+   kubectl apply --server-side -f config/crd/bases/
    ```
 
 3. **RBAC issues with the operator**:

--- a/hack/sync-chart-crds.sh
+++ b/hack/sync-chart-crds.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# sync-chart-crds.sh - Sync CRDs from config/crd/bases/ to Helm chart templates.
+#
+# Helm does not upgrade CRDs placed in the charts/crds/ directory on
+# `helm upgrade`. By placing them in templates/ instead, CRDs are managed
+# as regular Helm resources and get updated on every upgrade.
+#
+# Usage:
+#   bash hack/sync-chart-crds.sh          # generate chart CRD templates
+#   bash hack/sync-chart-crds.sh --check  # verify they are in sync (CI mode)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CRD_SRC="${REPO_ROOT}/config/crd/bases"
+CRD_DST="${REPO_ROOT}/charts/openclaw-operator/templates/crds"
+
+CHECK_MODE=false
+if [[ "${1:-}" == "--check" ]]; then
+    CHECK_MODE=true
+fi
+
+# Generate a Helm template from a raw CRD YAML.
+# Adds Helm template guards, resource-policy annotation, and chart labels.
+generate_template() {
+    local src="$1"
+    local dst="$2"
+
+    {
+        echo '{{- if .Values.crds.install }}'
+        # Process the CRD YAML:
+        # - After the controller-gen annotation line, inject helm resource-policy
+        # - After the name: line in metadata, inject chart labels
+        awk '
+        /^  annotations:$/ { print; getline; print; annotation_done=1; next }
+        annotation_done == 1 && /^  name:/ {
+            print "    {{- if .Values.crds.keep }}"
+            print "    \"helm.sh/resource-policy\": keep"
+            print "    {{- end }}"
+            print $0
+            print "  labels:"
+            print "    {{- include \"openclaw-operator.labels\" . | nindent 4 }}"
+            annotation_done=0
+            next
+        }
+        { print }
+        ' "$src"
+        echo '{{- end }}'
+    } > "$dst"
+}
+
+mkdir -p "$CRD_DST"
+
+if $CHECK_MODE; then
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    for crd_file in "$CRD_SRC"/*.yaml; do
+        name=$(basename "$crd_file")
+        generate_template "$crd_file" "$TMPDIR/$name"
+
+        if ! diff -q "$TMPDIR/$name" "$CRD_DST/$name" >/dev/null 2>&1; then
+            echo "::error::Helm chart CRD template is out of sync: $name"
+            echo "Run 'make sync-chart-crds' and commit the result."
+            diff -u "$CRD_DST/$name" "$TMPDIR/$name" || true
+            exit 1
+        fi
+    done
+
+    echo "Helm chart CRD templates are in sync."
+else
+    for crd_file in "$CRD_SRC"/*.yaml; do
+        name=$(basename "$crd_file")
+        generate_template "$crd_file" "$CRD_DST/$name"
+        echo "Generated: templates/crds/$name"
+    done
+fi


### PR DESCRIPTION
## Summary

- Fixes #168 - `selfConfigure` (and any future CRD field additions) rejected as "field not declared in schema" after `helm upgrade`
- Helm does not upgrade CRDs in the `crds/` directory on `helm upgrade` - only on initial `helm install`
- Moves CRDs to `templates/crds/` so they are managed as regular Helm resources and updated on every `helm upgrade`

## Changes

- **Helm chart**: Move CRD YAMLs from `charts/openclaw-operator/crds/` to `charts/openclaw-operator/templates/crds/`, gated by `crds.install` value and `helm.sh/resource-policy: keep` when `crds.keep` is true
- **Sync script**: `hack/sync-chart-crds.sh` generates templates from `config/crd/bases/` (supports `--check` for CI)
- **Makefile**: `make sync-chart-crds` target
- **CI**: New `Helm CRD Sync` job prevents template drift
- **E2E test**: Verifies `selfConfigure` field is accepted by API server and produces expected RBAC/env config
- **Docs**: Updated troubleshooting guide and NOTES.txt with CRD adoption instructions for existing users

## Upgrade note for existing users

Users upgrading from a chart version that used the `crds/` directory must adopt their CRDs into Helm management:

```bash
kubectl label crd openclawinstances.openclaw.rocks app.kubernetes.io/managed-by=Helm
kubectl annotate crd openclawinstances.openclaw.rocks meta.helm.sh/release-name=<release> meta.helm.sh/release-namespace=<namespace>
kubectl label crd openclawselfconfigs.openclaw.rocks app.kubernetes.io/managed-by=Helm
kubectl annotate crd openclawselfconfigs.openclaw.rocks meta.helm.sh/release-name=<release> meta.helm.sh/release-namespace=<namespace>
```

## Test plan

- [ ] CI: Lint, Test, Security Scan, Reconcile Guard pass
- [ ] CI: New `Helm CRD Sync` check passes
- [ ] CI: E2E tests pass (including new selfConfigure test)
- [ ] Verify `helm template` renders CRDs when `crds.install=true`
- [ ] Verify CRDs are omitted when `crds.install=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)