### PR TITLE
fix: make Probes a pointer type to accept null/omitted values

### DIFF
--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -101,7 +101,7 @@ type OpenClawInstanceSpec struct {
 
 	// Probes configures health probes for the OpenClaw container
 	// +optional
-	Probes ProbesSpec `json:"probes,omitempty"`
+	Probes *ProbesSpec `json:"probes,omitempty"`
 
 	// Observability configures metrics and logging
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -817,7 +817,11 @@ func (in *OpenClawInstanceSpec) DeepCopyInto(out *OpenClawInstanceSpec) {
 		}
 	}
 	in.Networking.DeepCopyInto(&out.Networking)
-	in.Probes.DeepCopyInto(&out.Probes)
+	if in.Probes != nil {
+		in, out := &in.Probes, &out.Probes
+		*out = new(ProbesSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	in.Observability.DeepCopyInto(&out.Observability)
 	in.Availability.DeepCopyInto(&out.Availability)
 	out.RuntimeDeps = in.RuntimeDeps

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -587,7 +587,7 @@ func TestBuildStatefulSet_ImageDigest(t *testing.T) {
 
 func TestBuildStatefulSet_ProbesDisabled(t *testing.T) {
 	instance := newTestInstance("probes-disabled")
-	instance.Spec.Probes = openclawv1alpha1.ProbesSpec{
+	instance.Spec.Probes = &openclawv1alpha1.ProbesSpec{
 		Liveness: &openclawv1alpha1.ProbeSpec{
 			Enabled: Ptr(false),
 		},
@@ -615,7 +615,7 @@ func TestBuildStatefulSet_ProbesDisabled(t *testing.T) {
 
 func TestBuildStatefulSet_CustomProbeValues(t *testing.T) {
 	instance := newTestInstance("probes-custom")
-	instance.Spec.Probes = openclawv1alpha1.ProbesSpec{
+	instance.Spec.Probes = &openclawv1alpha1.ProbesSpec{
 		Liveness: &openclawv1alpha1.ProbeSpec{
 			InitialDelaySeconds: Ptr(int32(60)),
 			PeriodSeconds:       Ptr(int32(20)),

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1742,7 +1742,10 @@ func buildProbeHandler(_ *openclawv1alpha1.OpenClawInstance) corev1.ProbeHandler
 
 // buildLivenessProbe creates the liveness probe
 func buildLivenessProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Probe {
-	spec := instance.Spec.Probes.Liveness
+	var spec *openclawv1alpha1.ProbeSpec
+	if instance.Spec.Probes != nil {
+		spec = instance.Spec.Probes.Liveness
+	}
 	if spec != nil && spec.Enabled != nil && !*spec.Enabled {
 		return nil
 	}
@@ -1776,7 +1779,10 @@ func buildLivenessProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Pro
 
 // buildReadinessProbe creates the readiness probe
 func buildReadinessProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Probe {
-	spec := instance.Spec.Probes.Readiness
+	var spec *openclawv1alpha1.ProbeSpec
+	if instance.Spec.Probes != nil {
+		spec = instance.Spec.Probes.Readiness
+	}
 	if spec != nil && spec.Enabled != nil && !*spec.Enabled {
 		return nil
 	}
@@ -1810,7 +1816,10 @@ func buildReadinessProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Pr
 
 // buildStartupProbe creates the startup probe
 func buildStartupProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Probe {
-	spec := instance.Spec.Probes.Startup
+	var spec *openclawv1alpha1.ProbeSpec
+	if instance.Spec.Probes != nil {
+		spec = instance.Spec.Probes.Startup
+	}
 	if spec != nil && spec.Enabled != nil && !*spec.Enabled {
 		return nil
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1407,7 +1407,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 						Repository: "ghcr.io/openclaw/openclaw",
 						Tag:        "latest",
 					},
-					Probes: openclawv1alpha1.ProbesSpec{
+					Probes: &openclawv1alpha1.ProbesSpec{
 						Liveness:  &openclawv1alpha1.ProbeSpec{Enabled: &falseVal},
 						Readiness: &openclawv1alpha1.ProbeSpec{Enabled: &falseVal},
 						Startup:   &openclawv1alpha1.ProbeSpec{Enabled: &falseVal},


### PR DESCRIPTION
## Summary

- Make `Probes` field a pointer type (`*ProbesSpec`) so omitted/null values pass CRD validation
- Add nil-guards in `buildLivenessProbe`, `buildReadinessProbe`, `buildStartupProbe`
- Regenerate deepcopy methods to handle nil pointer
- Update unit and e2e tests for pointer assignment

Fixes #179

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/resources/ -v` passes
- [x] `make test` passes (unit + envtest)
- [x] `make lint` passes
- [ ] E2E: deploy CR without `spec.probes` -- should be accepted and get default probes
- [ ] E2E: deploy CR with `probes:` set to null -- should be accepted
- [ ] E2E: deploy CR with custom probe values -- should apply overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)