### PR TITLE
fix: add attachOnly=true to browser profiles for sidecar mode

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -278,6 +278,12 @@ func enrichConfigWithBrowser(configJSON []byte) ([]byte, error) {
 			}
 		}
 
+		// Explicitly mark as attach-only so OpenClaw never tries to
+		// launch or manage a local browser process for this profile.
+		if _, ok := profile["attachOnly"]; !ok {
+			profile["attachOnly"] = true
+		}
+
 		// color is required by OpenClaw's config validation
 		if _, hasColor := profile["color"]; !hasColor {
 			profile["color"] = "#4285F4"

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -6108,6 +6108,9 @@ func TestBuildConfigMap_ChromiumBrowserConfig(t *testing.T) {
 		if p["color"] != "#4285F4" {
 			t.Errorf("browser.profiles.%s.color = %v, want %q", name, p["color"], "#4285F4")
 		}
+		if p["attachOnly"] != true {
+			t.Errorf("browser.profiles.%s.attachOnly = %v, want true", name, p["attachOnly"])
+		}
 	}
 }
 
@@ -6205,6 +6208,33 @@ func TestBuildConfigMap_ChromiumUserOverrideCdpPort(t *testing.T) {
 	// cdpPort should be preserved
 	if defaultProfile["cdpPort"] != float64(18800) {
 		t.Errorf("user-set cdpPort should be preserved, got %v", defaultProfile["cdpPort"])
+	}
+}
+
+func TestBuildConfigMap_ChromiumUserOverrideAttachOnly(t *testing.T) {
+	instance := newTestInstance("cr-override-attach")
+	instance.Spec.Chromium.Enabled = true
+	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{"browser":{"profiles":{"default":{"attachOnly":false}}}}`),
+		},
+	}
+
+	cm := BuildConfigMap(instance, "")
+	content := cm.Data["openclaw.json"]
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config JSON: %v", err)
+	}
+
+	browser := parsed["browser"].(map[string]interface{})
+	profiles := browser["profiles"].(map[string]interface{})
+	defaultProfile := profiles["default"].(map[string]interface{})
+
+	// User-set attachOnly=false should be preserved
+	if defaultProfile["attachOnly"] != false {
+		t.Errorf("user-set attachOnly should be preserved, got %v", defaultProfile["attachOnly"])
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1295,6 +1295,8 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				Expect(ok).To(BeTrue(), "profiles should have %s key", profileName)
 				Expect(profile["cdpUrl"]).To(Equal(expectedCDP),
 					"browser.profiles.%s.cdpUrl should use env var reference for pod IP", profileName)
+				Expect(profile["attachOnly"]).To(Equal(true),
+					"browser.profiles.%s.attachOnly should be true for sidecar mode", profileName)
 			}
 
 			// Verify Service has chromium port


### PR DESCRIPTION
## Summary

Follow-up to #183. Addresses the `browser open` CLI error reported in [#180 (comment)](https://github.com/openclaw-rocks/k8s-operator/issues/180#issuecomment-3955618753):

```
Error: Port 9222 is in use for profile "default" but not by openclaw.
Run action=reset-profile profile=default to kill the process.
```

### Root cause

The `browser open` CLI command checks local port ownership before connecting. Since the chromium sidecar occupies port 9222 (not launched by OpenClaw), the ownership check fails. The agent tools (`browser_navigate`, `browser_snapshot`) bypass this check and work correctly.

### Fix

Sets `attachOnly: true` on both `default` and `chrome` browser profiles. This explicitly tells OpenClaw to never launch or manage a local browser process -- just connect to the remote CDP endpoint. Respects user overrides (if `attachOnly` is already set, we don't overwrite it).

### Files changed

| File | Change |
|------|--------|
| `internal/resources/configmap.go` | Add `attachOnly: true` to browser profile enrichment |
| `internal/resources/resources_test.go` | Assert `attachOnly` on profiles + user-override test |
| `test/e2e/e2e_suite_test.go` | Assert `attachOnly` in e2e chromium test |

## Test plan

- [x] Unit tests pass (`go test ./internal/resources/ -v`)
- [x] New test: `TestBuildConfigMap_ChromiumUserOverrideAttachOnly` verifies user override is preserved
- [x] E2e test updated to verify `attachOnly: true` on browser profiles
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)