### PR TITLE
feat: add Operator SDK scorecard testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,6 +213,17 @@ jobs:
       - name: Run E2E tests
         run: make test-e2e
 
+      - name: Install operator-sdk
+        run: |
+          export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+          export OS=$(uname | awk '{print tolower($0)}')
+          curl -sSLo /usr/local/bin/operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/v1.38.0/operator-sdk_${OS}_${ARCH}"
+          chmod +x /usr/local/bin/operator-sdk
+          operator-sdk version
+
+      - name: Run scorecard tests
+        run: operator-sdk scorecard bundle --wait-time 120s || true
+
       - name: Dump operator logs
         if: failure()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 test-e2e: ## Run end-to-end tests.
 	go test ./test/e2e/... -v -count=1
 
+.PHONY: scorecard
+scorecard: operator-sdk ## Run operator-sdk scorecard tests.
+	$(OPERATOR_SDK) scorecard bundle --wait-time 120s
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.
 	$(GOLANGCI_LINT) run
@@ -124,12 +128,14 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.64.5
+OPERATOR_SDK_VERSION ?= v1.38.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -150,6 +156,17 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: operator-sdk
+operator-sdk: $(OPERATOR_SDK) ## Download operator-sdk locally if necessary.
+$(OPERATOR_SDK): $(LOCALBIN)
+	@[ -f $(OPERATOR_SDK) ] || { \
+	set -e; \
+	OS=$$(go env GOOS); ARCH=$$(go env GOARCH); \
+	echo "Downloading operator-sdk $(OPERATOR_SDK_VERSION)"; \
+	curl -sSLo $(OPERATOR_SDK) "https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH}"; \
+	chmod +x $(OPERATOR_SDK); \
+	}
 
 # go-install-tool will 'go install' any package with custom target and target version.
 define go-install-tool

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -1,0 +1,49 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+  - parallel: true
+    tests:
+      - entrypoint:
+          - scorecard-test
+          - basic-check-spec
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: basic
+          test: basic-check-spec-test
+      - entrypoint:
+          - scorecard-test
+          - olm-bundle-validation
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-bundle-validation-test
+      - entrypoint:
+          - scorecard-test
+          - olm-crds-have-validation
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-crds-have-validation-test
+      - entrypoint:
+          - scorecard-test
+          - olm-crds-have-resources
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-crds-have-resources-test
+      - entrypoint:
+          - scorecard-test
+          - olm-spec-descriptors
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-spec-descriptors-test
+      - entrypoint:
+          - scorecard-test
+          - olm-status-descriptors
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-status-descriptors-test


### PR DESCRIPTION
## Summary
- Add `bundle/tests/scorecard/config.yaml` with basic and OLM test suites (6 tests)
- Add `OPERATOR_SDK` binary download target and `make scorecard` to Makefile
- Add scorecard test steps to CI e2e job (informational -- uses `|| true` initially)

## Test plan
- [x] `make scorecard` target works against local kind cluster
- [x] CI e2e job includes scorecard steps
- [ ] CI: lint, test, e2e pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)