### PR TITLE
fix: store plaintext credentials in auto-generated basic auth secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ spec:
           realm: "My Agent"        # default: "OpenClaw"
 ```
 
-The generated htpasswd Secret is named `<name>-basic-auth` and tracked in `status.managedResources.basicAuthSecret`. To use your own credentials, provide a pre-formatted htpasswd Secret:
+The generated Secret is named `<name>-basic-auth` and contains three keys: `auth` (htpasswd format for ingress controllers), `username`, and `password` (plaintext, for retrieving the auto-generated credentials). It is tracked in `status.managedResources.basicAuthSecret`. To use your own credentials, provide a pre-formatted htpasswd Secret:
 
 ```yaml
 spec:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -565,18 +565,21 @@ networking:
 
 When `enabled: true` and no `existingSecret` is provided, the operator:
 - Generates a random 40-hex-character password
-- Creates a `<name>-basic-auth` Secret with an htpasswd-formatted `auth` key
+- Creates a `<name>-basic-auth` Secret with three keys:
+  - `auth` - htpasswd-formatted line (used by ingress controllers)
+  - `username` - plaintext username
+  - `password` - plaintext password
 - Tracks the secret name in `status.managedResources.basicAuthSecret`
 
 **nginx-ingress:** The `auth-type`, `auth-secret`, and `auth-realm` annotations are set automatically.
 
 **Traefik:** A `traefik.io/v1alpha1/Middleware` resource named `<name>-basic-auth` is created in the same namespace (requires Traefik CRDs to be installed), and the `traefik.ingress.kubernetes.io/router.middlewares` annotation is set to reference it.
 
-**Retrieve the auto-generated password:**
+**Retrieve the auto-generated credentials:**
 
 ```bash
-kubectl get secret my-agent-basic-auth -o jsonpath='{.data.auth}' | base64 -d
-# admin:{SHA}UaJat...  (htpasswd format — the plaintext password is not recoverable)
+kubectl get secret my-agent-basic-auth -o jsonpath='{.data.username}' | base64 -d
+kubectl get secret my-agent-basic-auth -o jsonpath='{.data.password}' | base64 -d
 ```
 
 To rotate credentials, delete the Secret and the operator will generate a new one on next reconcile.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -8489,6 +8489,35 @@ func TestBuildBasicAuthSecret(t *testing.T) {
 	if !strings.HasPrefix(string(auth), "testuser:{SHA}") {
 		t.Errorf("auth value should start with 'testuser:{SHA}', got %q", string(auth))
 	}
+
+	// Verify plaintext username and password keys
+	username, ok := secret.Data["username"]
+	if !ok {
+		t.Fatal("secret missing 'username' key")
+	}
+	if string(username) != "testuser" {
+		t.Errorf("username = %q, want %q", string(username), "testuser")
+	}
+	pw, ok := secret.Data["password"]
+	if !ok {
+		t.Fatal("secret missing 'password' key")
+	}
+	if string(pw) != "mypassword" {
+		t.Errorf("password = %q, want %q", string(pw), "mypassword")
+	}
+}
+
+func TestBuildBasicAuthSecret_DefaultUsername(t *testing.T) {
+	instance := newTestInstance("ba-default")
+	instance.Spec.Networking.Ingress.Security.BasicAuth = &openclawv1alpha1.IngressBasicAuthSpec{}
+	secret := BuildBasicAuthSecret(instance, "randompw")
+
+	if string(secret.Data["username"]) != AppName {
+		t.Errorf("username = %q, want default %q", string(secret.Data["username"]), AppName)
+	}
+	if string(secret.Data["password"]) != "randompw" {
+		t.Errorf("password = %q, want %q", string(secret.Data["password"]), "randompw")
+	}
 }
 
 func TestBuildIngress_BasicAuth_Nginx(t *testing.T) {

--- a/internal/resources/secret.go
+++ b/internal/resources/secret.go
@@ -38,7 +38,13 @@ func HtpasswdEntry(username, password string) string {
 }
 
 // BuildBasicAuthSecret creates a Secret containing htpasswd content for Ingress Basic Authentication.
-// The Secret holds an "auth" key whose value is an htpasswd-formatted line.
+// The Secret holds three keys:
+//   - "auth": htpasswd-formatted line (used by ingress controllers)
+//   - "username": plaintext username
+//   - "password": plaintext password
+//
+// The plaintext keys allow users to retrieve the auto-generated credentials,
+// since the hashed htpasswd value in "auth" cannot be reversed.
 func BuildBasicAuthSecret(instance *openclawv1alpha1.OpenClawInstance, password string) *corev1.Secret {
 	username := AppName
 	if instance.Spec.Networking.Ingress.Security.BasicAuth != nil &&
@@ -52,7 +58,9 @@ func BuildBasicAuthSecret(instance *openclawv1alpha1.OpenClawInstance, password 
 			Labels:    Labels(instance),
 		},
 		Data: map[string][]byte{
-			"auth": []byte(HtpasswdEntry(username, password)),
+			"auth":     []byte(HtpasswdEntry(username, password)),
+			"username": []byte(username),
+			"password": []byte(password),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `username` and `password` keys to the auto-generated basic auth Secret alongside the existing htpasswd-formatted `auth` key
- Previously only the hashed `auth` value was stored, making it impossible to retrieve the auto-generated credentials
- Updates README and API reference documentation with the new Secret structure

Closes #201

## Test plan
- [x] Unit tests pass (`go test ./internal/resources/ -v`)
- [x] New test `TestBuildBasicAuthSecret_DefaultUsername` verifies default username case
- [x] Existing `TestBuildBasicAuthSecret` extended to verify `username` and `password` keys
- [ ] E2E test (CI will run on kind cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)