### PR TITLE
fix: add optional S3_REGION support for MinIO backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ stringData:
   S3_BUCKET: "my-openclaw-backups"
   S3_ACCESS_KEY_ID: "<key-id>"
   S3_SECRET_ACCESS_KEY: "<secret-key>"
+  # S3_REGION: "us-east-1"  # optional - needed for MinIO or providers with custom regions
 ```
 
 Compatible with AWS S3, Backblaze B2, Cloudflare R2, MinIO, Wasabi, and any S3-compatible API.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -871,9 +871,18 @@ stringData:
   S3_BUCKET: "my-openclaw-backups"
   S3_ACCESS_KEY_ID: "<key-id>"
   S3_SECRET_ACCESS_KEY: "<secret-key>"
+  # S3_REGION: "us-east-1"  # optional - see below
 ```
 
-All four keys are required. The operator uses rclone's S3 backend (`--s3-provider=Other`), which is compatible with AWS S3, Backblaze B2, MinIO, Cloudflare R2, Wasabi, and any other S3-compatible service.
+The first four keys are required. The operator uses rclone's S3 backend (`--s3-provider=Other`), which is compatible with AWS S3, Backblaze B2, MinIO, Cloudflare R2, Wasabi, and any other S3-compatible service.
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `S3_ENDPOINT` | Yes | S3-compatible endpoint URL (e.g., `https://s3.us-east-1.amazonaws.com`) |
+| `S3_BUCKET` | Yes | Bucket name for backups |
+| `S3_ACCESS_KEY_ID` | Yes | Access key ID |
+| `S3_SECRET_ACCESS_KEY` | Yes | Secret access key |
+| `S3_REGION` | No | S3 region (e.g., `us-east-1`). Required for MinIO instances configured with a custom region. Without this, rclone defaults to `us-east-1`, which causes authentication failures on providers using a different region. |
 
 ### When backups run automatically
 


### PR DESCRIPTION
## Summary

- Add optional `S3_REGION` key to the `s3-backup-credentials` Secret
- When set, passes `--s3-region` to rclone so MinIO instances with custom regions authenticate correctly
- Without this, rclone defaults to `us-east-1`, causing auth failures on providers configured with a different region

Closes #205

## Changes

- **`internal/controller/s3.go`** - Add `Region` field to `s3Credentials`, read optional `S3_REGION` from Secret, conditionally append `--s3-region` flag and env var to rclone jobs
- **`internal/controller/s3_test.go`** - Verify region flag/env absent when empty, new test for region present when set
- **`README.md`** - Add commented `S3_REGION` to backup Secret example
- **`docs/api-reference.md`** - Add `S3_REGION` to Secret example and key reference table

## Test plan

- [ ] Existing S3 backup tests pass (no `--s3-region` when Region is empty)
- [ ] New test verifies `--s3-region` flag and `S3_REGION` env var when Region is set
- [ ] `go vet` and `make lint` pass
- [ ] CI e2e tests pass (existing backup tests use no region - backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)