### PR TITLE
fix: add configurable timeout for BackingUp phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,7 +652,7 @@ Compatible with AWS S3, Backblaze B2, Cloudflare R2, MinIO, Wasabi, and any S3-c
 
 **When backups run automatically:**
 
-- **On delete** - the operator backs up the PVC before removing any resources. Add the annotation `openclaw.rocks/skip-backup: "true"` to skip and delete immediately.
+- **On delete** - the operator backs up the PVC before removing any resources. Subject to `spec.backup.timeout` (default: 30m) - if the backup does not complete in time, it is skipped automatically. Add `openclaw.rocks/skip-backup: "true"` to skip immediately.
 - **Before auto-update** - when `spec.autoUpdate.backupBeforeUpdate: true` (the default).
 - **On a schedule** - when `spec.backup.schedule` is set (cron expression).
 
@@ -666,6 +666,7 @@ spec:
     schedule: "0 2 * * *"   # Daily at 2 AM UTC
     historyLimit: 3          # Successful job runs to retain (default: 3)
     failedHistoryLimit: 1    # Failed job runs to retain (default: 1)
+    timeout: "30m"           # Max time for pre-delete backup (default: 30m, min: 5m, max: 24h)
 ```
 
 The operator creates a Kubernetes CronJob that runs rclone to sync PVC data to S3. The CronJob mounts the PVC read-only (hot backup - no downtime) and uses pod affinity to co-locate on the same node as the StatefulSet pod (required for RWO PVCs). Each run stores data under a unique timestamped path: `backups/<tenantId>/<instanceName>/periodic/<timestamp>`.

--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -469,6 +469,15 @@ type BackupSpec struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	FailedHistoryLimit *int32 `json:"failedHistoryLimit,omitempty"`
+
+	// Timeout is the maximum duration to wait for a pre-delete backup to complete
+	// before giving up and proceeding with deletion (Go duration string, e.g. "30m", "1h").
+	// Covers all phases: StatefulSet scale-down, pod termination, Job execution, and
+	// Job failure retries. When the timeout elapses the operator logs a warning,
+	// emits a BackupTimedOut event, and removes the finalizer so deletion can proceed.
+	// Minimum: 5m, Maximum: 24h, Default: 30m.
+	// +optional
+	Timeout string `json:"timeout,omitempty"`
 }
 
 // ChromiumSpec defines the Chromium sidecar configuration
@@ -1224,6 +1233,12 @@ type OpenClawInstanceStatus struct {
 	// ManagedResources tracks the resources created by the operator
 	// +optional
 	ManagedResources ManagedResourcesStatus `json:"managedResources,omitempty"`
+
+	// BackingUpSince is the timestamp when the instance entered the BackingUp phase.
+	// Used to enforce spec.backup.timeout. Set once when the phase transitions to BackingUp
+	// and cleared when the phase changes.
+	// +optional
+	BackingUpSince *metav1.Time `json:"backingUpSince,omitempty"`
 
 	// BackupJobName is the name of the active backup Job
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -925,6 +925,10 @@ func (in *OpenClawInstanceStatus) DeepCopyInto(out *OpenClawInstanceStatus) {
 		*out = (*in).DeepCopy()
 	}
 	out.ManagedResources = in.ManagedResources
+	if in.BackingUpSince != nil {
+		in, out := &in.BackingUpSince, &out.BackingUpSince
+		*out = (*in).DeepCopy()
+	}
 	if in.LastBackupTime != nil {
 		in, out := &in.LastBackupTime, &out.LastBackupTime
 		*out = (*in).DeepCopy()

--- a/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
+++ b/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
@@ -1322,6 +1322,15 @@ spec:
                       Requires persistence to be enabled and the s3-backup-credentials Secret
                       in the operator namespace.
                     type: string
+                  timeout:
+                    description: |-
+                      Timeout is the maximum duration to wait for a pre-delete backup to complete
+                      before giving up and proceeding with deletion (Go duration string, e.g. "30m", "1h").
+                      Covers all phases: StatefulSet scale-down, pod termination, Job execution, and
+                      Job failure retries. When the timeout elapses the operator logs a warning,
+                      emits a BackupTimedOut event, and removes the finalizer so deletion can proceed.
+                      Minimum: 5m, Maximum: 24h, Default: 30m.
+                    type: string
                 type: object
               chromium:
                 description: Chromium enables the Chromium sidecar for browser automation
@@ -9419,6 +9428,13 @@ spec:
                     - RollingBack
                     type: string
                 type: object
+              backingUpSince:
+                description: |-
+                  BackingUpSince is the timestamp when the instance entered the BackingUp phase.
+                  Used to enforce spec.backup.timeout. Set once when the phase transitions to BackingUp
+                  and cleared when the phase changes.
+                format: date-time
+                type: string
               backupJobName:
                 description: BackupJobName is the name of the active backup Job
                 type: string

--- a/config/crd/bases/openclaw.rocks_openclawinstances.yaml
+++ b/config/crd/bases/openclaw.rocks_openclawinstances.yaml
@@ -1316,6 +1316,15 @@ spec:
                       Requires persistence to be enabled and the s3-backup-credentials Secret
                       in the operator namespace.
                     type: string
+                  timeout:
+                    description: |-
+                      Timeout is the maximum duration to wait for a pre-delete backup to complete
+                      before giving up and proceeding with deletion (Go duration string, e.g. "30m", "1h").
+                      Covers all phases: StatefulSet scale-down, pod termination, Job execution, and
+                      Job failure retries. When the timeout elapses the operator logs a warning,
+                      emits a BackupTimedOut event, and removes the finalizer so deletion can proceed.
+                      Minimum: 5m, Maximum: 24h, Default: 30m.
+                    type: string
                 type: object
               chromium:
                 description: Chromium enables the Chromium sidecar for browser automation
@@ -9413,6 +9422,13 @@ spec:
                     - RollingBack
                     type: string
                 type: object
+              backingUpSince:
+                description: |-
+                  BackingUpSince is the timestamp when the instance entered the BackingUp phase.
+                  Used to enforce spec.backup.timeout. Set once when the phase transitions to BackingUp
+                  and cleared when the phase changes.
+                format: date-time
+                type: string
               backupJobName:
                 description: BackupJobName is the name of the active backup Job
                 type: string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -704,6 +704,7 @@ Configures periodic scheduled backups to S3-compatible storage. Requires the `s3
 | `schedule`           | `string` | --      | Cron expression for periodic backups (e.g., `"0 2 * * *"` for daily at 2 AM). When set, the operator creates a CronJob that runs rclone to sync PVC data to S3. |
 | `historyLimit`       | `*int32` | `3`     | Number of successful CronJob runs to retain.                                                       |
 | `failedHistoryLimit` | `*int32` | `1`     | Number of failed CronJob runs to retain.                                                           |
+| `timeout`            | `string` | `30m`   | Maximum duration to wait for a pre-delete backup to complete before giving up and proceeding with deletion (Go duration string, e.g. `"30m"`, `"1h"`). Covers all phases: StatefulSet scale-down, pod termination, Job execution, and Job failure retries. Minimum: `5m`, Maximum: `24h`. |
 
 The CronJob mounts the PVC read-only (hot backup - no downtime) and uses pod affinity to schedule on the same node as the StatefulSet pod (required for RWO PVCs). Each run stores data under a unique timestamped path: `backups/<tenantId>/<instanceName>/periodic/<timestamp>`.
 
@@ -713,6 +714,7 @@ spec:
     schedule: "0 2 * * *"   # Daily at 2 AM UTC
     historyLimit: 5          # Keep last 5 successful runs
     failedHistoryLimit: 2    # Keep last 2 failed runs
+    timeout: "30m"           # Max time for pre-delete backup (default: 30m)
 ```
 
 ### spec.restoreFrom
@@ -855,6 +857,7 @@ Standard `metav1.Condition` array. Condition types:
 
 | Field            | Type           | Description                                              |
 |------------------|----------------|----------------------------------------------------------|
+| `backingUpSince` | `*metav1.Time` | Timestamp when the instance entered the BackingUp phase. Used to enforce `spec.backup.timeout`. Cleared when the phase changes. |
 | `backupJobName`  | `string`       | Name of the active backup Job.                           |
 | `restoreJobName` | `string`       | Name of the active restore Job.                          |
 | `lastBackupPath` | `string`       | S3 path of the last successful backup.                   |
@@ -917,7 +920,7 @@ The first four keys are required. The operator uses rclone's S3 backend (`--s3-p
 
 | Trigger | Condition |
 |---------|-----------|
-| **Pre-delete backup** | Always runs when a CR is deleted, unless `openclaw.rocks/skip-backup: "true"` annotation is set or persistence is disabled. |
+| **Pre-delete backup** | Always runs when a CR is deleted, unless `openclaw.rocks/skip-backup: "true"` annotation is set or persistence is disabled. Subject to `spec.backup.timeout` (default: 30m) - if the backup does not complete within the timeout, it is skipped and deletion proceeds. |
 | **Pre-update backup** | Runs before each auto-update when `spec.autoUpdate.backupBeforeUpdate: true` (the default). |
 | **Periodic (scheduled)** | Runs on a cron schedule when `spec.backup.schedule` is set. See [Periodic scheduled backups](#periodic--scheduled-backups) below. |
 
@@ -938,9 +941,21 @@ Where:
 
 The path of the last successful backup is recorded in `status.lastBackupPath`.
 
+### Backup timeout
+
+Pre-delete backups are subject to a configurable timeout (default: 30 minutes). If the backup does not complete within the timeout -- whether due to a stuck Job, pod termination issues, or S3 credential errors -- the operator logs a warning, emits a `BackupTimedOut` event, sets the `BackupComplete=False` condition with reason `BackupTimedOut`, and proceeds with deletion.
+
+Configure the timeout via `spec.backup.timeout`:
+
+```yaml
+spec:
+  backup:
+    timeout: "1h"  # Allow up to 1 hour for pre-delete backups (default: 30m, min: 5m, max: 24h)
+```
+
 ### Skip backup on delete
 
-To delete an instance without waiting for a backup (e.g., the S3 backend is unavailable):
+To delete an instance immediately without waiting for a backup (e.g., the S3 backend is unavailable):
 
 ```bash
 kubectl annotate openclawinstance my-agent openclaw.rocks/skip-backup=true

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -197,6 +197,51 @@ kubectl describe openclawinstance my-assistant -n openclaw
      curl -v http://my-assistant:18789
    ```
 
+### Instance Stuck in BackingUp Phase
+
+**Symptoms**: After deleting an instance, it remains in `BackingUp` phase and is not deleted.
+
+**Diagnosis**:
+
+```bash
+# Check the instance status
+kubectl get openclawinstance my-agent -o jsonpath='{.status.phase}'
+kubectl get openclawinstance my-agent -o jsonpath='{.status.backingUpSince}'
+
+# Check if a backup Job exists and its status
+kubectl get jobs -l openclaw.rocks/instance=my-agent
+kubectl describe job my-agent-backup -n <namespace>
+
+# Check events for timeout or failure
+kubectl describe openclawinstance my-agent | grep -A5 Events
+```
+
+**Possible causes and solutions**:
+
+1. **Backup timeout will resolve it automatically**: By default, the operator waits up to 30 minutes (`spec.backup.timeout`) before giving up and proceeding with deletion. Check `status.backingUpSince` to see when the phase started and how much time remains.
+
+2. **Backup Job failed**: The Job may have failed due to S3 connectivity issues, incorrect credentials, or insufficient permissions. The operator retries until the timeout elapses. Check the Job logs:
+   ```bash
+   kubectl logs job/my-agent-backup -n <namespace>
+   ```
+
+3. **Pods stuck terminating**: The StatefulSet was scaled to 0 but pods are stuck. Check for finalizers or PodDisruptionBudgets:
+   ```bash
+   kubectl get pods -l openclaw.rocks/instance=my-agent -o yaml | grep finalizers
+   ```
+
+4. **Skip backup immediately**: To bypass the backup and delete immediately:
+   ```bash
+   kubectl annotate openclawinstance my-agent openclaw.rocks/skip-backup=true
+   ```
+
+5. **Increase or decrease the timeout**: Adjust `spec.backup.timeout` (min: 5m, max: 24h):
+   ```yaml
+   spec:
+     backup:
+       timeout: "1h"
+   ```
+
 ### PVC Not Binding
 
 **Symptoms**: The pod is stuck in `Pending` with `FailedScheduling` or the PVC shows `Pending`.

--- a/internal/controller/backup.go
+++ b/internal/controller/backup.go
@@ -37,19 +37,28 @@ import (
 	"github.com/openclawrocks/k8s-operator/internal/resources"
 )
 
+const (
+	// defaultBackupTimeout is the maximum time the operator waits for a pre-delete
+	// backup to complete before giving up and proceeding with deletion.
+	defaultBackupTimeout = 30 * time.Minute
+)
+
 // reconcileDeleteWithBackup implements the backup-before-delete state machine:
-//  1. Check skip-backup annotation → if set, remove finalizer immediately
-//  2. Scale down StatefulSet to 0 → requeue 5s
-//  3. Wait for pods to terminate → requeue 5s
-//  4. Create/check backup Job
-//  5. On success: remove finalizer → K8s GCs all owned resources
+//  1. Check skip-backup annotation -> if set, remove finalizer immediately
+//  2. Check backup timeout -> if elapsed, skip backup and proceed with deletion
+//  3. Scale down StatefulSet to 0 -> requeue 5s
+//  4. Wait for pods to terminate -> requeue 5s
+//  5. Create/check backup Job
+//  6. On success: remove finalizer -> K8s GCs all owned resources
 func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Context, instance *openclawv1alpha1.OpenClawInstance) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Handling deletion with backup", "instance", instance.Name, "namespace", instance.Namespace)
 
-	// Step 0: Update phase to BackingUp (if not already terminating/backing up)
+	// Step 0: Update phase to BackingUp and record start time (if not already terminating/backing up)
 	if instance.Status.Phase != openclawv1alpha1.PhaseBackingUp && instance.Status.Phase != openclawv1alpha1.PhaseTerminating {
+		now := metav1.Now()
 		instance.Status.Phase = openclawv1alpha1.PhaseBackingUp
+		instance.Status.BackingUpSince = &now
 		if err := r.Status().Update(ctx, instance); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -76,7 +85,32 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 		return r.removeFinalizer(ctx, instance)
 	}
 
-	// Step 2: Scale down StatefulSet to 0
+	// Step 2: Check backup timeout
+	if instance.Status.BackingUpSince != nil {
+		timeout := parseBackupTimeout(instance.Spec.Backup.Timeout)
+		elapsed := time.Since(instance.Status.BackingUpSince.Time)
+		if elapsed >= timeout {
+			logger.Info("Backup timeout exceeded, skipping backup and proceeding with deletion",
+				"elapsed", elapsed.Round(time.Second), "timeout", timeout)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "BackupTimedOut",
+				fmt.Sprintf("Backup did not complete within %s - skipping backup and proceeding with deletion", timeout))
+
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:    openclawv1alpha1.ConditionTypeBackupComplete,
+				Status:  metav1.ConditionFalse,
+				Reason:  "BackupTimedOut",
+				Message: fmt.Sprintf("Backup did not complete within %s", timeout),
+			})
+			instance.Status.Phase = openclawv1alpha1.PhaseTerminating
+			instance.Status.BackingUpSince = nil
+			if err := r.Status().Update(ctx, instance); err != nil {
+				return ctrl.Result{}, err
+			}
+			return r.removeFinalizer(ctx, instance)
+		}
+	}
+
+	// Step 3: Scale down StatefulSet to 0
 	sts := &appsv1.StatefulSet{}
 	stsKey := client.ObjectKey{Name: resources.StatefulSetName(instance), Namespace: instance.Namespace}
 	if err := r.Get(ctx, stsKey, sts); err != nil {
@@ -98,7 +132,7 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 		}
 
-		// Step 3: Wait for pods to terminate
+		// Step 4: Wait for pods to terminate
 		podList := &corev1.PodList{}
 		if err := r.List(ctx, podList,
 			client.InNamespace(instance.Namespace),
@@ -112,7 +146,7 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 		}
 	}
 
-	// Step 4: Create/check backup Job
+	// Step 5: Create/check backup Job
 	creds, err := r.getS3Credentials(ctx)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -185,9 +219,9 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 	}
 
 	if condType == batchv1.JobFailed {
-		logger.Error(nil, "Backup Job failed — keeping finalizer for manual intervention", "job", jobName)
+		logger.Error(nil, "Backup Job failed - retrying until timeout", "job", jobName)
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "BackupFailed",
-			fmt.Sprintf("Backup Job %s failed. Fix and delete the Job to retry, or annotate %s=true to skip.", jobName, AnnotationSkipBackup))
+			fmt.Sprintf("Backup Job %s failed. Will retry until backup timeout elapses. To skip immediately: annotate %s=true.", jobName, AnnotationSkipBackup))
 
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:    openclawv1alpha1.ConditionTypeBackupComplete,
@@ -201,7 +235,7 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	// Step 5: Backup succeeded — record and remove finalizer
+	// Step 6: Backup succeeded - record and remove finalizer
 	logger.Info("Backup Job completed successfully", "job", jobName, "remotePath", instance.Status.LastBackupPath)
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "BackupComplete",
 		fmt.Sprintf("Backup completed to %s", instance.Status.LastBackupPath))
@@ -209,6 +243,7 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 	now := metav1.Now()
 	instance.Status.LastBackupTime = &now
 	instance.Status.Phase = openclawv1alpha1.PhaseTerminating
+	instance.Status.BackingUpSince = nil
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:    openclawv1alpha1.ConditionTypeBackupComplete,
@@ -221,6 +256,25 @@ func (r *OpenClawInstanceReconciler) reconcileDeleteWithBackup(ctx context.Conte
 	}
 
 	return r.removeFinalizer(ctx, instance)
+}
+
+// parseBackupTimeout parses the backup timeout string with min/max bounds.
+// Returns defaultBackupTimeout (30m) when empty. Minimum: 5m, Maximum: 24h.
+func parseBackupTimeout(s string) time.Duration {
+	if s == "" {
+		return defaultBackupTimeout
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return defaultBackupTimeout
+	}
+	if d < 5*time.Minute {
+		return 5 * time.Minute
+	}
+	if d > 24*time.Hour {
+		return 24 * time.Hour
+	}
+	return d
 }
 
 // removeFinalizer removes the operator finalizer, allowing K8s to GC the resource.

--- a/internal/controller/backup_timeout_test.go
+++ b/internal/controller/backup_timeout_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseBackupTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+	}{
+		{
+			name:     "empty string returns default",
+			input:    "",
+			expected: 30 * time.Minute,
+		},
+		{
+			name:     "valid 15 minutes",
+			input:    "15m",
+			expected: 15 * time.Minute,
+		},
+		{
+			name:     "valid 1 hour",
+			input:    "1h",
+			expected: 1 * time.Hour,
+		},
+		{
+			name:     "valid 2 hours",
+			input:    "2h",
+			expected: 2 * time.Hour,
+		},
+		{
+			name:     "valid 30 minutes (default value explicitly)",
+			input:    "30m",
+			expected: 30 * time.Minute,
+		},
+		{
+			name:     "below minimum clamps to 5 minutes",
+			input:    "1m",
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "zero clamps to 5 minutes",
+			input:    "0s",
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "above maximum clamps to 24 hours",
+			input:    "48h",
+			expected: 24 * time.Hour,
+		},
+		{
+			name:     "exactly at minimum boundary",
+			input:    "5m",
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "exactly at maximum boundary",
+			input:    "24h",
+			expected: 24 * time.Hour,
+		},
+		{
+			name:     "invalid string returns default",
+			input:    "invalid",
+			expected: 30 * time.Minute,
+		},
+		{
+			name:     "negative duration clamps to minimum",
+			input:    "-10m",
+			expected: 5 * time.Minute,
+		},
+		{
+			name:     "mixed duration format",
+			input:    "1h30m",
+			expected: 90 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseBackupTimeout(tt.input)
+			if got != tt.expected {
+				t.Errorf("parseBackupTimeout(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `spec.backup.timeout` field (default: 30m, min: 5m, max: 24h) to configure how long the operator waits for a pre-delete backup before giving up
- Records `status.backingUpSince` timestamp when entering BackingUp phase to track elapsed time
- On timeout: emits `BackupTimedOut` event, sets `BackupComplete=False` condition, removes finalizer so deletion proceeds
- Previously, instances could get stuck in BackingUp phase indefinitely if the backup Job failed, pods wouldn't terminate, or S3 credentials were unavailable

Closes #224

## Changes

| File | What |
|------|------|
| `api/v1alpha1/openclawinstance_types.go` | Add `Timeout` to `BackupSpec`, `BackingUpSince` to status |
| `internal/controller/backup.go` | Timeout check in `reconcileDeleteWithBackup`, `parseBackupTimeout` helper |
| `internal/controller/backup_timeout_test.go` | Unit tests for `parseBackupTimeout` (boundary, clamping, invalid input) |
| `config/crd/`, `charts/` | Regenerated CRD YAML |
| `README.md` | Document timeout in backup section |
| `docs/api-reference.md` | Document new fields, add "Backup timeout" section |
| `docs/troubleshooting.md` | Add "Instance Stuck in BackingUp Phase" section |

## Test plan

- [x] `parseBackupTimeout` unit tests pass (13 cases covering empty, valid, clamped, invalid, negative)
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [x] Resource builder unit tests pass
- [ ] CI envtest integration tests pass
- [ ] CI e2e tests pass (existing backup tests cover skip-backup, no-S3, scale-down flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)