### PR TITLE
fix: make skill pack resolution non-blocking

### DIFF
--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -1390,6 +1390,9 @@ const (
 
 	// ConditionTypeSecretsReady indicates all referenced secrets exist
 	ConditionTypeSecretsReady = "SecretsReady"
+
+	// ConditionTypeSkillPacksReady indicates skill packs were resolved successfully
+	ConditionTypeSkillPacksReady = "SkillPacksReady"
 )
 
 // Phase constants

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -810,6 +810,7 @@ Standard `metav1.Condition` array. Condition types:
 | `ScheduledBackupReady`| The periodic backup CronJob is configured and ready.           |
 | `AutoUpdateAvailable` | A newer version is available in the OCI registry.              |
 | `SecretsReady`        | All referenced Secrets exist and are accessible.               |
+| `SkillPacksReady`     | Skill packs resolved successfully from GitHub. `False` with reason `ResolutionFailed` when GitHub is unreachable - instance runs without skill packs (phase `Degraded`). Retried on next reconcile. |
 
 ### status.endpoints
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ The `status.phase` field represents the high-level lifecycle state of the instan
 | `Pending`      | The resource has been created but reconciliation has not started.     |
 | `Provisioning` | The controller is actively creating or updating managed resources.   |
 | `Running`      | All resources are reconciled successfully.                           |
-| `Degraded`     | Reserved for future use (e.g., partial readiness).                   |
+| `Degraded`     | Instance is running but with reduced functionality (e.g., skill packs unavailable). |
 | `Failed`       | A reconciliation error occurred. The controller will retry.          |
 | `Terminating`  | The instance is being deleted. Finalizer cleanup is in progress.     |
 
@@ -104,10 +104,10 @@ Phase transitions follow this flow:
 Pending --> Provisioning --> Running
                 |               |
                 v               v
-             Failed         Degraded
-                |
-                v
-           (retry: Provisioning)
+             Failed         Degraded (e.g., skill packs unavailable)
+                |               |
+                v               v
+           (retry)          (retry --> Running when resolved)
 
 Deletion from any phase:
   * --> Terminating --> (removed)
@@ -126,6 +126,12 @@ The controller maintains fine-grained conditions using the standard `metav1.Cond
 | `NetworkPolicyReady` | The NetworkPolicy has been applied.               |
 | `RBACReady`          | ServiceAccount, Role, and RoleBinding exist.      |
 | `StorageReady`       | The PVC has been created (or an existing one set).|
+| `BackupComplete`     | The backup job completed successfully.            |
+| `RestoreComplete`    | The restore job completed successfully.           |
+| `ScheduledBackupReady`| The periodic backup CronJob is configured.       |
+| `AutoUpdateAvailable`| A newer version is available in the OCI registry. |
+| `SecretsReady`       | All referenced Secrets exist and are accessible.  |
+| `SkillPacksReady`    | Skill packs resolved from GitHub. `False` when GitHub is unreachable - instance runs without skill packs. |
 
 ### Endpoints
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -152,6 +152,34 @@ kubectl describe openclawinstance my-assistant -n openclaw
    kubectl get secret <name> -n openclaw
    ```
 
+### Instance in Degraded State (Skill Packs Unavailable)
+
+**Symptoms**: The instance phase is `Degraded`. The `SkillPacksReady` condition shows `status: "False"` with reason `ResolutionFailed`. The instance is running but without skill packs.
+
+**Diagnosis**:
+
+```bash
+# Check the SkillPacksReady condition
+kubectl get openclawinstance my-assistant -n openclaw \
+  -o jsonpath='{.status.conditions[?(@.type=="SkillPacksReady")]}'
+
+# Check events for details
+kubectl describe openclawinstance my-assistant -n openclaw | grep SkillPack
+```
+
+**Common causes**:
+
+1. **GitHub API unreachable**: The operator fetches skill packs from GitHub. If GitHub is down or the cluster has no egress access, resolution fails. The instance provisions without skill packs and retries on the next reconcile (30s).
+
+2. **Invalid pack reference**: Verify the `pack:` skill references are valid `owner/repo/path[@ref]` format:
+   ```bash
+   kubectl get openclawinstance my-assistant -n openclaw -o jsonpath='{.spec.skills}'
+   ```
+
+3. **Missing GITHUB_TOKEN**: Private skill pack repositories require a GitHub token. Verify the operator has the `GITHUB_TOKEN` environment variable set.
+
+**Resolution**: The operator automatically retries skill pack resolution on every reconcile. Once GitHub is reachable again, the instance transitions from `Degraded` to `Running`. The operator also uses stale cache - if a previous successful resolution exists, it will use that data even after the cache TTL expires.
+
 ### NetworkPolicy Blocking Traffic
 
 **Symptoms**: The instance is `Running` but cannot reach external APIs or other pods cannot reach the instance.

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -217,19 +217,29 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 
-	// Update status to Running
-	instance.Status.Phase = openclawv1alpha1.PhaseRunning
+	// Determine phase based on condition health
+	skillPacksCondition := meta.FindStatusCondition(instance.Status.Conditions, openclawv1alpha1.ConditionTypeSkillPacksReady)
+	if skillPacksCondition != nil && skillPacksCondition.Status == metav1.ConditionFalse {
+		instance.Status.Phase = openclawv1alpha1.PhaseDegraded
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    openclawv1alpha1.ConditionTypeReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  "ReconcileSucceededDegraded",
+			Message: "Resources reconciled but skill packs unavailable - instance running without skill packs",
+		})
+	} else {
+		instance.Status.Phase = openclawv1alpha1.PhaseRunning
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    openclawv1alpha1.ConditionTypeReady,
+			Status:  metav1.ConditionTrue,
+			Reason:  "ReconcileSucceeded",
+			Message: "All resources reconciled successfully",
+		})
+	}
 	if instance.Status.ObservedGeneration != instance.Generation {
 		instance.Status.LastReconcileTime = &metav1.Time{Time: time.Now()}
 	}
 	instance.Status.ObservedGeneration = instance.Generation
-
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:    openclawv1alpha1.ConditionTypeReady,
-		Status:  metav1.ConditionTrue,
-		Reason:  "ReconcileSucceeded",
-		Message: "All resources reconciled successfully",
-	})
 
 	// Check for auto-updates (non-fatal — errors are logged and evented)
 	autoUpdateResult, autoUpdateErr := r.reconcileAutoUpdate(ctx, instance)
@@ -297,16 +307,34 @@ func (r *OpenClawInstanceReconciler) reconcileResources(ctx context.Context, ins
 	}
 	logger.V(1).Info("Gateway token secret reconciled")
 
-	// 2c. Resolve skill packs from GitHub (if any pack: skills defined)
+	// 2c. Resolve skill packs from GitHub (non-blocking - failures degrade but don't block provisioning)
 	var skillPacks *resources.ResolvedSkillPacks
 	packNames := resources.ExtractPackSkills(instance.Spec.Skills)
 	if len(packNames) > 0 && r.SkillPackResolver != nil {
 		resolved, err := r.SkillPackResolver.Resolve(ctx, packNames)
 		if err != nil {
-			return fmt.Errorf("failed to resolve skill packs: %w", err)
+			logger.Error(err, "Failed to resolve skill packs, continuing without them", "packs", packNames)
+			r.Recorder.Event(instance, corev1.EventTypeWarning, "SkillPackResolutionFailed",
+				fmt.Sprintf("Failed to resolve skill packs: %v. Instance will start without skill packs.", err))
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:               openclawv1alpha1.ConditionTypeSkillPacksReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             "ResolutionFailed",
+				Message:            fmt.Sprintf("Failed to resolve skill packs: %v", err),
+				ObservedGeneration: instance.Generation,
+			})
+			// Continue with skillPacks = nil - instance will provision without skill packs
+		} else {
+			skillPacks = resolved
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:               openclawv1alpha1.ConditionTypeSkillPacksReady,
+				Status:             metav1.ConditionTrue,
+				Reason:             "Resolved",
+				Message:            fmt.Sprintf("Successfully resolved %d skill pack(s)", len(packNames)),
+				ObservedGeneration: instance.Generation,
+			})
+			logger.V(1).Info("Skill packs resolved", "packs", packNames)
 		}
-		skillPacks = resolved
-		logger.V(1).Info("Skill packs resolved", "packs", packNames)
 	}
 
 	// 3. Reconcile ConfigMap (always - enrichment pipeline runs on all config sources)

--- a/internal/skillpacks/resolver.go
+++ b/internal/skillpacks/resolver.go
@@ -132,6 +132,8 @@ func (r *Resolver) Resolve(ctx context.Context, packNames []string) (*resources.
 }
 
 // resolvePack resolves a single pack reference, using cache if valid.
+// If fetching fails and a stale cache entry exists, returns the stale data
+// instead of an error so that transient GitHub outages do not block reconciliation.
 func (r *Resolver) resolvePack(ctx context.Context, name string) (*resources.ResolvedSkillPacks, error) {
 	r.mu.RLock()
 	if entry, ok := r.cache[name]; ok && time.Since(entry.fetchedAt) < r.cacheTTL {
@@ -143,6 +145,14 @@ func (r *Resolver) resolvePack(ctx context.Context, name string) (*resources.Res
 
 	resolved, err := r.fetchPack(ctx, name)
 	if err != nil {
+		// Stale cache fallback - return expired data rather than failing
+		r.mu.RLock()
+		if entry, ok := r.cache[name]; ok {
+			stale := entry.resolved
+			r.mu.RUnlock()
+			return stale, nil
+		}
+		r.mu.RUnlock()
 		return nil, err
 	}
 

--- a/internal/skillpacks/resolver_test.go
+++ b/internal/skillpacks/resolver_test.go
@@ -319,3 +319,66 @@ func TestResolve_InvalidRef(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestResolve_StaleCacheFallback(t *testing.T) {
+	manifestJSON := `{"files": {}, "directories": ["skills/test"], "config": {"test-skill": {"enabled": true}}}`
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount > 1 {
+			// Simulate GitHub outage on subsequent requests
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(ghFile(manifestJSON)))
+	}))
+	defer server.Close()
+
+	// Use a very short TTL so the cache expires quickly
+	resolver := &Resolver{
+		cacheTTL:   1 * time.Millisecond,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		baseURL:    server.URL,
+		cache:      make(map[string]*cacheEntry),
+	}
+
+	// First call succeeds and populates cache
+	resolved, err := resolver.Resolve(context.Background(), []string{"owner/repo/test"})
+	if err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	if len(resolved.Directories) != 1 || resolved.Directories[0] != "skills/test" {
+		t.Errorf("unexpected directories: %v", resolved.Directories)
+	}
+
+	// Wait for cache to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call fails but returns stale cache instead of error
+	resolved, err = resolver.Resolve(context.Background(), []string{"owner/repo/test"})
+	if err != nil {
+		t.Fatalf("expected stale cache fallback, got error: %v", err)
+	}
+	if resolved == nil {
+		t.Fatal("expected stale cached result, got nil")
+	}
+	if len(resolved.Directories) != 1 || resolved.Directories[0] != "skills/test" {
+		t.Errorf("unexpected stale directories: %v", resolved.Directories)
+	}
+}
+
+func TestResolve_NoCacheFallbackOnFirstFailure(t *testing.T) {
+	// When there is no cached data at all, errors should propagate
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	resolver := newTestResolver(server, "")
+
+	_, err := resolver.Resolve(context.Background(), []string{"owner/repo/test"})
+	if err == nil {
+		t.Fatal("expected error when no cache exists and fetch fails")
+	}
+}


### PR DESCRIPTION
## Summary

- **Non-blocking skill pack resolution**: When GitHub is unreachable, the instance now provisions without skill packs instead of failing entirely. Skill packs are retried on the next reconcile cycle.
- **Stale cache fallback**: If a fresh fetch from GitHub fails but expired cache data exists, the resolver returns the stale data instead of erroring.
- **`SkillPacksReady` status condition**: New condition type tracks skill pack resolution health, enabling dashboard warnings and diagnostic queries.
- **`Degraded` phase**: Instances with failed skill pack resolution use `Degraded` phase instead of `Failed`, accurately reflecting that the instance is running but with reduced functionality.

Closes #225

## Test plan

- [x] Resolver stale cache fallback test (`TestResolve_StaleCacheFallback`)
- [x] No-cache first failure still propagates error (`TestResolve_NoCacheFallbackOnFirstFailure`)
- [x] All existing resolver tests pass
- [x] All resource builder tests pass
- [x] `go vet ./...` clean
- [x] `make lint` clean
- [ ] CI: unit + integration tests
- [ ] CI: e2e tests on kind cluster
- [ ] CI: reconcile guard check

🤖 Generated with [Claude Code](https://claude.com/claude-code)