### PR TITLE
feat: switch probes from exec to httpGet

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -592,7 +592,7 @@ The operator automatically adds WebSocket-related annotations for nginx-ingress 
 
 ### spec.probes
 
-Health probe configuration for the main OpenClaw container. All probes use TCP socket checks against the gateway port (18789).
+Health probe configuration for the main OpenClaw container. All probes use HTTP GET requests through the nginx proxy sidecar on port 18790 - liveness and startup probes check `/healthz`, while readiness probes check `/readyz`.
 
 #### spec.probes.liveness
 

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -380,16 +380,15 @@ func TestBuildStatefulSet_Defaults(t *testing.T) {
 		t.Error("startup probe should not be nil by default")
 	}
 
-	// Liveness probe defaults (always exec since gateway binds to loopback)
-	if main.LivenessProbe.Exec == nil {
-		t.Fatal("liveness probe should use exec handler")
+	// Liveness probe defaults (HTTPGet via proxy sidecar)
+	if main.LivenessProbe.HTTPGet == nil {
+		t.Fatal("liveness probe should use HTTPGet handler")
 	}
-	cmd := strings.Join(main.LivenessProbe.Exec.Command, " ")
-	if !strings.Contains(cmd, "127.0.0.1") {
-		t.Errorf("liveness probe should target 127.0.0.1, got command: %s", cmd)
+	if main.LivenessProbe.HTTPGet.Path != "/healthz" {
+		t.Errorf("liveness probe path = %q, want %q", main.LivenessProbe.HTTPGet.Path, "/healthz")
 	}
-	if !strings.Contains(cmd, fmt.Sprintf("%d", GatewayPort)) {
-		t.Errorf("liveness probe should target port %d, got command: %s", GatewayPort, cmd)
+	if main.LivenessProbe.HTTPGet.Port.IntValue() != int(GatewayProxyPort) {
+		t.Errorf("liveness probe port = %d, want %d", main.LivenessProbe.HTTPGet.Port.IntValue(), GatewayProxyPort)
 	}
 	if main.LivenessProbe.InitialDelaySeconds != 30 {
 		t.Errorf("liveness probe initialDelaySeconds = %d, want 30", main.LivenessProbe.InitialDelaySeconds)
@@ -6143,8 +6142,8 @@ func TestBuildConfigMap_TailscaleLoopback_UserOverridePreserved(t *testing.T) {
 	}
 }
 
-func TestBuildStatefulSet_TailscaleServe_UsesExecProbes(t *testing.T) {
-	instance := newTestInstance("ts-exec-probes")
+func TestBuildStatefulSet_TailscaleServe_UsesHTTPProbes(t *testing.T) {
+	instance := newTestInstance("ts-http-probes")
 	instance.Spec.Tailscale.Enabled = true
 	instance.Spec.Tailscale.Mode = "serve"
 
@@ -6154,40 +6153,36 @@ func TestBuildStatefulSet_TailscaleServe_UsesExecProbes(t *testing.T) {
 	if container.LivenessProbe == nil {
 		t.Fatal("liveness probe should not be nil")
 	}
-	if container.LivenessProbe.Exec == nil {
-		t.Fatal("liveness probe should use exec handler when Tailscale serve is enabled")
+	if container.LivenessProbe.HTTPGet == nil {
+		t.Fatal("liveness probe should use HTTPGet handler when Tailscale serve is enabled")
 	}
-	if container.LivenessProbe.TCPSocket != nil {
-		t.Error("liveness probe should not use TCPSocket when Tailscale serve is enabled")
+	if container.LivenessProbe.Exec != nil {
+		t.Error("liveness probe should not use Exec when Tailscale serve is enabled")
 	}
 
 	if container.ReadinessProbe == nil {
 		t.Fatal("readiness probe should not be nil")
 	}
-	if container.ReadinessProbe.Exec == nil {
-		t.Fatal("readiness probe should use exec handler when Tailscale serve is enabled")
+	if container.ReadinessProbe.HTTPGet == nil {
+		t.Fatal("readiness probe should use HTTPGet handler when Tailscale serve is enabled")
 	}
 
 	if container.StartupProbe == nil {
 		t.Fatal("startup probe should not be nil")
 	}
-	if container.StartupProbe.Exec == nil {
-		t.Fatal("startup probe should use exec handler when Tailscale serve is enabled")
+	if container.StartupProbe.HTTPGet == nil {
+		t.Fatal("startup probe should use HTTPGet handler when Tailscale serve is enabled")
 	}
 
-	// Verify exec command targets localhost
-	cmd := strings.Join(container.LivenessProbe.Exec.Command, " ")
-	if !strings.Contains(cmd, "127.0.0.1") {
-		t.Errorf("exec probe should target 127.0.0.1, got command: %s", cmd)
-	}
-	if !strings.Contains(cmd, fmt.Sprintf("%d", GatewayPort)) {
-		t.Errorf("exec probe should target port %d, got command: %s", GatewayPort, cmd)
+	// Verify HTTP probe targets proxy port
+	if container.LivenessProbe.HTTPGet.Port.IntValue() != int(GatewayProxyPort) {
+		t.Errorf("liveness probe port = %d, want %d", container.LivenessProbe.HTTPGet.Port.IntValue(), GatewayProxyPort)
 	}
 }
 
-func TestBuildStatefulSet_AlwaysUsesExecProbes(t *testing.T) {
-	instance := newTestInstance("always-exec-probes")
-	// Tailscale not enabled - probes should still use exec (gateway always on loopback)
+func TestBuildStatefulSet_AlwaysUsesHTTPProbes(t *testing.T) {
+	instance := newTestInstance("always-http-probes")
+	// Tailscale not enabled - probes should still use HTTPGet via proxy
 
 	sts := BuildStatefulSet(instance, "hash", nil)
 	container := sts.Spec.Template.Spec.Containers[0]
@@ -6195,22 +6190,22 @@ func TestBuildStatefulSet_AlwaysUsesExecProbes(t *testing.T) {
 	if container.LivenessProbe == nil {
 		t.Fatal("liveness probe should not be nil")
 	}
-	if container.LivenessProbe.Exec == nil {
-		t.Fatal("liveness probe should always use exec handler")
+	if container.LivenessProbe.HTTPGet == nil {
+		t.Fatal("liveness probe should always use HTTPGet handler")
 	}
-	if container.LivenessProbe.TCPSocket != nil {
-		t.Error("liveness probe should not use TCPSocket")
+	if container.LivenessProbe.Exec != nil {
+		t.Error("liveness probe should not use Exec")
 	}
 
-	if container.ReadinessProbe.Exec == nil {
-		t.Fatal("readiness probe should always use exec handler")
+	if container.ReadinessProbe.HTTPGet == nil {
+		t.Fatal("readiness probe should always use HTTPGet handler")
 	}
-	if container.StartupProbe.Exec == nil {
-		t.Fatal("startup probe should always use exec handler")
+	if container.StartupProbe.HTTPGet == nil {
+		t.Fatal("startup probe should always use HTTPGet handler")
 	}
 }
 
-func TestBuildStatefulSet_TailscaleFunnel_UsesExecProbes(t *testing.T) {
+func TestBuildStatefulSet_TailscaleFunnel_UsesHTTPProbes(t *testing.T) {
 	instance := newTestInstance("ts-funnel-probes")
 	instance.Spec.Tailscale.Enabled = true
 	instance.Spec.Tailscale.Mode = "funnel"
@@ -6218,14 +6213,52 @@ func TestBuildStatefulSet_TailscaleFunnel_UsesExecProbes(t *testing.T) {
 	sts := BuildStatefulSet(instance, "hash", nil)
 	container := sts.Spec.Template.Spec.Containers[0]
 
-	if container.LivenessProbe.Exec == nil {
-		t.Fatal("liveness probe should use exec handler when Tailscale funnel is enabled")
+	if container.LivenessProbe.HTTPGet == nil {
+		t.Fatal("liveness probe should use HTTPGet handler when Tailscale funnel is enabled")
 	}
-	if container.ReadinessProbe.Exec == nil {
-		t.Fatal("readiness probe should use exec handler when Tailscale funnel is enabled")
+	if container.ReadinessProbe.HTTPGet == nil {
+		t.Fatal("readiness probe should use HTTPGet handler when Tailscale funnel is enabled")
 	}
-	if container.StartupProbe.Exec == nil {
-		t.Fatal("startup probe should use exec handler when Tailscale funnel is enabled")
+	if container.StartupProbe.HTTPGet == nil {
+		t.Fatal("startup probe should use HTTPGet handler when Tailscale funnel is enabled")
+	}
+}
+
+func TestBuildStatefulSet_ProbeEndpointPaths(t *testing.T) {
+	instance := newTestInstance("probe-paths")
+
+	sts := BuildStatefulSet(instance, "hash", nil)
+	container := sts.Spec.Template.Spec.Containers[0]
+
+	tests := []struct {
+		name     string
+		probe    *corev1.Probe
+		wantPath string
+		wantPort int
+	}{
+		{"liveness", container.LivenessProbe, "/healthz", int(GatewayProxyPort)},
+		{"readiness", container.ReadinessProbe, "/readyz", int(GatewayProxyPort)},
+		{"startup", container.StartupProbe, "/healthz", int(GatewayProxyPort)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.probe == nil {
+				t.Fatalf("%s probe should not be nil", tt.name)
+			}
+			if tt.probe.HTTPGet == nil {
+				t.Fatalf("%s probe should use HTTPGet handler", tt.name)
+			}
+			if tt.probe.HTTPGet.Path != tt.wantPath {
+				t.Errorf("%s probe path = %q, want %q", tt.name, tt.probe.HTTPGet.Path, tt.wantPath)
+			}
+			if tt.probe.HTTPGet.Port.IntValue() != tt.wantPort {
+				t.Errorf("%s probe port = %d, want %d", tt.name, tt.probe.HTTPGet.Port.IntValue(), tt.wantPort)
+			}
+			if tt.probe.HTTPGet.Scheme != corev1.URISchemeHTTP {
+				t.Errorf("%s probe scheme = %q, want %q", tt.name, tt.probe.HTTPGet.Scheme, corev1.URISchemeHTTP)
+			}
+		})
 	}
 }
 
@@ -8930,6 +8963,9 @@ func TestNormalizeStatefulSet_ProbeDefaults(t *testing.T) {
 	}
 	if main.StartupProbe.PeriodSeconds == 0 {
 		t.Error("startup probe PeriodSeconds should not be 0 after normalization")
+	}
+	if main.StartupProbe.HTTPGet != nil && main.StartupProbe.HTTPGet.Scheme == "" {
+		t.Error("startup probe HTTPGet.Scheme should not be empty after normalization")
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1806,22 +1806,17 @@ func buildChromiumResourceRequirements(instance *openclawv1alpha1.OpenClawInstan
 	return req
 }
 
-// buildProbeHandler returns an exec-based probe handler that checks the
-// gateway on loopback. The gateway always binds to 127.0.0.1 (the proxy
-// sidecar handles external access), which is unreachable from the kubelet
-// via TCPSocket probes (they connect to the pod IP). Exec probes run inside
-// the container and can reach localhost.
-//
-// Uses a Node.js TCP connect check instead of wget because the gateway
-// returns 404 on GET / (no HTTP health endpoint). Node.js is always
-// available in the OpenClaw container.
-func buildProbeHandler(_ *openclawv1alpha1.OpenClawInstance) corev1.ProbeHandler {
+// buildHTTPProbeHandler returns an HTTP GET probe handler that hits the
+// given path on the nginx proxy sidecar port. The gateway exposes /healthz
+// (liveness) and /readyz (readiness) on 127.0.0.1:18789; the proxy sidecar
+// forwards traffic from 0.0.0.0:18790, making the endpoints reachable by
+// the kubelet.
+func buildHTTPProbeHandler(path string) corev1.ProbeHandler {
 	return corev1.ProbeHandler{
-		Exec: &corev1.ExecAction{
-			Command: []string{
-				"node", "-e",
-				fmt.Sprintf("require('net').connect(%d,'127.0.0.1',()=>process.exit(0)).on('error',()=>process.exit(1));setTimeout(()=>process.exit(1),2000)", GatewayPort),
-			},
+		HTTPGet: &corev1.HTTPGetAction{
+			Path:   path,
+			Port:   intstr.FromInt32(GatewayProxyPort),
+			Scheme: corev1.URISchemeHTTP,
 		},
 	}
 }
@@ -1837,7 +1832,7 @@ func buildLivenessProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Pro
 	}
 
 	probe := &corev1.Probe{
-		ProbeHandler:        buildProbeHandler(instance),
+		ProbeHandler:        buildHTTPProbeHandler("/healthz"),
 		InitialDelaySeconds: 30,
 		PeriodSeconds:       10,
 		TimeoutSeconds:      5,
@@ -1874,7 +1869,7 @@ func buildReadinessProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Pr
 	}
 
 	probe := &corev1.Probe{
-		ProbeHandler:        buildProbeHandler(instance),
+		ProbeHandler:        buildHTTPProbeHandler("/readyz"),
 		InitialDelaySeconds: 5,
 		PeriodSeconds:       5,
 		TimeoutSeconds:      3,
@@ -1911,7 +1906,7 @@ func buildStartupProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Prob
 	}
 
 	probe := &corev1.Probe{
-		ProbeHandler:        buildProbeHandler(instance),
+		ProbeHandler:        buildHTTPProbeHandler("/healthz"),
 		InitialDelaySeconds: 0,
 		PeriodSeconds:       5,
 		TimeoutSeconds:      3,
@@ -2088,6 +2083,9 @@ func normalizeProbe(p *corev1.Probe) {
 	}
 	if p.FailureThreshold == 0 {
 		p.FailureThreshold = 3
+	}
+	if p.HTTPGet != nil && p.HTTPGet.Scheme == "" {
+		p.HTTPGet.Scheme = corev1.URISchemeHTTP
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1107,14 +1107,18 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			}
 			Expect(foundTSInit).To(BeTrue(), "init-tailscale-bin init container should be present")
 
-			// Verify probes use exec (not TCPSocket) for loopback-bound gateway
+			// Verify probes use HTTPGet via the nginx proxy sidecar
 			Expect(mainContainer.LivenessProbe).NotTo(BeNil(), "liveness probe should be set")
-			Expect(mainContainer.LivenessProbe.Exec).NotTo(BeNil(), "liveness probe should use exec")
-			Expect(mainContainer.LivenessProbe.TCPSocket).To(BeNil(), "liveness probe should not use TCPSocket")
+			Expect(mainContainer.LivenessProbe.HTTPGet).NotTo(BeNil(), "liveness probe should use HTTPGet")
+			Expect(mainContainer.LivenessProbe.HTTPGet.Path).To(Equal("/healthz"))
+			Expect(mainContainer.LivenessProbe.HTTPGet.Port.IntValue()).To(Equal(int(resources.GatewayProxyPort)))
 			Expect(mainContainer.ReadinessProbe).NotTo(BeNil(), "readiness probe should be set")
-			Expect(mainContainer.ReadinessProbe.Exec).NotTo(BeNil(), "readiness probe should use exec")
+			Expect(mainContainer.ReadinessProbe.HTTPGet).NotTo(BeNil(), "readiness probe should use HTTPGet")
+			Expect(mainContainer.ReadinessProbe.HTTPGet.Path).To(Equal("/readyz"))
+			Expect(mainContainer.ReadinessProbe.HTTPGet.Port.IntValue()).To(Equal(int(resources.GatewayProxyPort)))
 			Expect(mainContainer.StartupProbe).NotTo(BeNil(), "startup probe should be set")
-			Expect(mainContainer.StartupProbe.Exec).NotTo(BeNil(), "startup probe should use exec")
+			Expect(mainContainer.StartupProbe.HTTPGet).NotTo(BeNil(), "startup probe should use HTTPGet")
+			Expect(mainContainer.StartupProbe.HTTPGet.Path).To(Equal("/healthz"))
 
 			// Verify NetworkPolicy has STUN and WireGuard egress
 			np := &networkingv1.NetworkPolicy{}


### PR DESCRIPTION
## Summary

- Replace exec-based Node.js TCP probes with native HTTP GET probes through the nginx proxy sidecar (port 18790)
- Liveness and startup probes check `/healthz`, readiness probes check `/readyz`
- Add `HTTPGet.Scheme` defaulting in `normalizeProbe` to prevent spec drift

Closes #230

## Changes

| File | What changed |
|------|-------------|
| `internal/resources/statefulset.go` | `buildProbeHandler` -> `buildHTTPProbeHandler(path)`, updated all 3 probe builders, added scheme normalization |
| `internal/resources/resources_test.go` | Renamed 3 exec probe tests to HTTP, added `TestBuildStatefulSet_ProbeEndpointPaths`, updated defaults test |
| `test/e2e/e2e_suite_test.go` | Switched e2e assertions from `Exec` to `HTTPGet` with path/port validation |
| `docs/api-reference.md` | Updated probe description to reflect HTTP GET probes |

## Test plan

- [x] `go test ./internal/resources/ -v` - all probe tests pass
- [x] `go vet ./...` - clean
- [x] `make lint` - clean
- [x] `TestNormalizeStatefulSet_NoSpuriousDiff` - no reconciliation loop
- [ ] CI: unit + integration tests
- [ ] CI: e2e tests on kind cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)