### PR TITLE
fix: add attachOnly to browser profiles and disable device auth in K8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ The operator automatically generates a gateway token Secret for each instance an
 - The token is generated once and never overwritten - rotate it by editing the Secret directly
 - If you set `gateway.auth.token` in your config or `OPENCLAW_GATEWAY_TOKEN` in `spec.env`, your value takes precedence
 - To bring your own token Secret, set `spec.gateway.existingSecret` - the operator will use it instead of auto-generating one (the Secret must have a key named `token`)
+- The operator automatically sets `gateway.controlUi.dangerouslyDisableDeviceAuth: true` - device pairing is incompatible with Kubernetes (users cannot approve pairing from inside a container, connections are always proxied, and mDNS is unavailable)
+- Since v2026.2.24, OpenClaw restricts `gateway.allowedOrigins` to same-origin by default - if accessing via a non-default hostname (e.g. Ingress), set `gateway.allowedOrigins: ["*"]` in your config
 
 ### Chromium sidecar
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -749,6 +749,12 @@ Configures the gateway authentication token.
 
 When `existingSecret` is not set, the operator automatically generates a random gateway token Secret, which is tracked in `status.managedResources.gatewayTokenSecret`.
 
+**Auto-injected settings:**
+
+The operator always injects `gateway.controlUi.dangerouslyDisableDeviceAuth: true` into the config JSON. Device pairing (introduced in OpenClaw v2026.3.2) is fundamentally incompatible with Kubernetes because users cannot approve pairing from inside a container, connections always come through the nginx proxy sidecar (non-local), and mDNS is unavailable. If you explicitly set `gateway.controlUi.dangerouslyDisableDeviceAuth` in your config, your value takes precedence.
+
+**Note:** Since OpenClaw v2026.2.24, `gateway.allowedOrigins` defaults to same-origin only. If you access the Control UI through an Ingress or other non-default hostname, set `gateway.allowedOrigins: ["*"]` in your config to avoid blocked WebSocket connections.
+
 ```yaml
 spec:
   gateway:

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -44,8 +44,8 @@ func BuildConfigMap(instance *openclawv1alpha1.OpenClawInstance, gatewayToken st
 // BuildConfigMapFromBytes creates a ConfigMap for the OpenClawInstance using
 // the provided base config bytes. This allows the controller to pass config
 // from any source (inline raw, external ConfigMap, or empty default).
-// The enrichment pipeline (gateway auth, tailscale, browser, gateway bind)
-// always runs on the provided bytes.
+// The enrichment pipeline (gateway auth, device auth, tailscale, browser,
+// gateway bind, skill packs) always runs on the provided bytes.
 func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseConfig []byte, gatewayToken string, skillPacks *ResolvedSkillPacks) *corev1.ConfigMap {
 	labels := Labels(instance)
 
@@ -54,11 +54,14 @@ func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseCo
 		configBytes = []byte("{}")
 	}
 
-	// Enrichment pipeline: gateway auth -> tailscale -> browser -> gateway bind
+	// Enrichment pipeline: gateway auth -> device auth -> tailscale -> browser -> gateway bind -> skill packs
 	if gatewayToken != "" {
 		if enriched, err := enrichConfigWithGatewayAuth(configBytes, gatewayToken); err == nil {
 			configBytes = enriched
 		}
+	}
+	if enriched, err := enrichConfigWithDeviceAuth(configBytes); err == nil {
+		configBytes = enriched
 	}
 	if instance.Spec.Tailscale.Enabled {
 		if enriched, err := enrichConfigWithTailscale(configBytes, instance); err == nil {
@@ -136,6 +139,39 @@ func enrichConfigWithGatewayAuth(configJSON []byte, token string) ([]byte, error
 	auth["mode"] = "token" //nolint:goconst // OpenClaw auth mode, not k8s Secret key
 	auth["token"] = token
 	gw["auth"] = auth
+	config["gateway"] = gw
+
+	return json.Marshal(config)
+}
+
+// enrichConfigWithDeviceAuth injects gateway.controlUi.dangerouslyDisableDeviceAuth=true
+// into the config JSON. Device pairing is fundamentally incompatible with Kubernetes
+// because (1) users cannot approve pairing from inside a container, (2) connections
+// always come through the nginx proxy sidecar (non-local), and (3) mDNS does not work
+// in K8s. If the user has already set the field, the config is returned unchanged.
+func enrichConfigWithDeviceAuth(configJSON []byte) ([]byte, error) {
+	var config map[string]interface{}
+	if err := json.Unmarshal(configJSON, &config); err != nil {
+		return configJSON, nil // not a JSON object, return unchanged
+	}
+
+	gw, _ := config["gateway"].(map[string]interface{})
+	if gw == nil {
+		gw = make(map[string]interface{})
+	}
+
+	controlUI, _ := gw["controlUi"].(map[string]interface{})
+	if controlUI == nil {
+		controlUI = make(map[string]interface{})
+	}
+
+	// If the user already set dangerouslyDisableDeviceAuth, don't override
+	if _, ok := controlUI["dangerouslyDisableDeviceAuth"]; ok {
+		return configJSON, nil
+	}
+
+	controlUI["dangerouslyDisableDeviceAuth"] = true
+	gw["controlUi"] = controlUI
 	config["gateway"] = gw
 
 	return json.Marshal(config)
@@ -234,7 +270,9 @@ func BuildTailscaleServeConfig(instance *openclawv1alpha1.OpenClawInstance) stri
 // enrichConfigWithBrowser injects browser config into the config JSON so the
 // agent uses the Chromium sidecar instead of the Chrome extension relay.
 // Configures both "default" and "chrome" profiles to point at the sidecar CDP
-// port. The "chrome" profile must be redirected because LLMs frequently pass
+// port and sets attachOnly=true so OpenClaw attaches to the existing sidecar
+// instead of trying to launch/manage a browser process locally.
+// The "chrome" profile must be redirected because LLMs frequently pass
 // profile="chrome" explicitly in browser tool calls, bypassing defaultProfile.
 // Without this override the built-in "chrome" profile falls back to the
 // extension relay which does not work in a headless container.
@@ -261,10 +299,10 @@ func enrichConfigWithBrowser(configJSON []byte) ([]byte, error) {
 	}
 
 	// Use ${OPENCLAW_CHROMIUM_CDP} env var (resolved at runtime by OpenClaw)
-	// which contains the pod IP. The browser control service treats any
-	// 127.x.x.x address as "local/managed" and tries to bind the port.
-	// A non-loopback pod IP activates remote/attach-only mode so the
-	// service just connects to the existing chromium sidecar.
+	// which contains the pod IP, and set attachOnly=true on each profile.
+	// attachOnly explicitly tells OpenClaw to attach to the existing sidecar
+	// instead of trying to launch/manage the browser process locally - this
+	// is deterministic regardless of whether the pod IP is loopback or not.
 	cdpURL := "${OPENCLAW_CHROMIUM_CDP}"
 
 	// Configure both "default" and "chrome" profiles to point at the sidecar.
@@ -286,6 +324,12 @@ func enrichConfigWithBrowser(configJSON []byte) ([]byte, error) {
 		// color is required by OpenClaw's config validation
 		if _, hasColor := profile["color"]; !hasColor {
 			profile["color"] = "#4285F4"
+		}
+
+		// attachOnly tells OpenClaw to attach to the existing sidecar
+		// instead of trying to launch/manage the browser process locally.
+		if _, hasAttachOnly := profile["attachOnly"]; !hasAttachOnly {
+			profile["attachOnly"] = true
 		}
 
 		profiles[profileName] = profile

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2093,6 +2093,15 @@ func TestBuildConfigMapFromBytes_EnrichesExternalConfig(t *testing.T) {
 	if gw["bind"] != "loopback" {
 		t.Errorf("gateway.bind = %v, want %q", gw["bind"], "loopback")
 	}
+
+	// Verify device auth was injected
+	controlUI, ok := gw["controlUi"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway.controlUi key after enrichment")
+	}
+	if controlUI["dangerouslyDisableDeviceAuth"] != true {
+		t.Errorf("gateway.controlUi.dangerouslyDisableDeviceAuth = %v, want true", controlUI["dangerouslyDisableDeviceAuth"])
+	}
 }
 
 func TestBuildConfigMapFromBytes_PreservesUserConfig(t *testing.T) {
@@ -2232,6 +2241,95 @@ func TestEnrichConfigWithGatewayBind_InvalidJSON(t *testing.T) {
 	input := []byte(`not valid json`)
 	instance := newTestInstance("bind-invalid-json")
 	out, err := enrichConfigWithGatewayBind(input, instance)
+	if err != nil {
+		t.Fatal("should not error on invalid JSON")
+	}
+
+	if !bytes.Equal(out, input) {
+		t.Errorf("invalid JSON should be returned unchanged")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// enrichConfigWithDeviceAuth tests
+// ---------------------------------------------------------------------------
+
+func TestEnrichConfigWithDeviceAuth(t *testing.T) {
+	input := []byte(`{}`)
+	out, err := enrichConfigWithDeviceAuth(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	gw, ok := cfg["gateway"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway key")
+	}
+	controlUI, ok := gw["controlUi"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway.controlUi key")
+	}
+	if controlUI["dangerouslyDisableDeviceAuth"] != true {
+		t.Errorf("gateway.controlUi.dangerouslyDisableDeviceAuth = %v, want true", controlUI["dangerouslyDisableDeviceAuth"])
+	}
+}
+
+func TestEnrichConfigWithDeviceAuth_PreservesUserOverride(t *testing.T) {
+	input := []byte(`{"gateway":{"controlUi":{"dangerouslyDisableDeviceAuth":false}}}`)
+	out, err := enrichConfigWithDeviceAuth(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	gw := cfg["gateway"].(map[string]interface{})
+	controlUI := gw["controlUi"].(map[string]interface{})
+	if controlUI["dangerouslyDisableDeviceAuth"] != false {
+		t.Errorf("gateway.controlUi.dangerouslyDisableDeviceAuth = %v, want false (user override)", controlUI["dangerouslyDisableDeviceAuth"])
+	}
+}
+
+func TestEnrichConfigWithDeviceAuth_PreservesOtherFields(t *testing.T) {
+	input := []byte(`{"gateway":{"auth":{"mode":"token","token":"secret"}}}`)
+	out, err := enrichConfigWithDeviceAuth(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	gw := cfg["gateway"].(map[string]interface{})
+	controlUI, ok := gw["controlUi"].(map[string]interface{})
+	if !ok {
+		t.Fatal("gateway.controlUi should be created")
+	}
+	if controlUI["dangerouslyDisableDeviceAuth"] != true {
+		t.Errorf("gateway.controlUi.dangerouslyDisableDeviceAuth = %v, want true", controlUI["dangerouslyDisableDeviceAuth"])
+	}
+	auth, ok := gw["auth"].(map[string]interface{})
+	if !ok {
+		t.Fatal("gateway.auth should be preserved")
+	}
+	if auth["token"] != "secret" {
+		t.Errorf("gateway.auth.token = %v, want %q", auth["token"], "secret")
+	}
+}
+
+func TestEnrichConfigWithDeviceAuth_InvalidJSON(t *testing.T) {
+	input := []byte(`not valid json`)
+	out, err := enrichConfigWithDeviceAuth(input)
 	if err != nil {
 		t.Fatal("should not error on invalid JSON")
 	}
@@ -6274,6 +6372,35 @@ func TestBuildConfigMap_ChromiumBrowserConfig(t *testing.T) {
 		if p["color"] != "#4285F4" {
 			t.Errorf("browser.profiles.%s.color = %v, want %q", name, p["color"], "#4285F4")
 		}
+		if p["attachOnly"] != true {
+			t.Errorf("browser.profiles.%s.attachOnly = %v, want true", name, p["attachOnly"])
+		}
+	}
+}
+
+func TestBuildConfigMap_ChromiumUserOverrideAttachOnly(t *testing.T) {
+	instance := newTestInstance("cr-override-attachonly")
+	instance.Spec.Chromium.Enabled = true
+	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{"browser":{"profiles":{"default":{"attachOnly":false}}}}`),
+		},
+	}
+
+	cm := BuildConfigMap(instance, "", nil)
+	content := cm.Data["openclaw.json"]
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config JSON: %v", err)
+	}
+
+	browser := parsed["browser"].(map[string]interface{})
+	profiles := browser["profiles"].(map[string]interface{})
+	defaultProfile := profiles["default"].(map[string]interface{})
+
+	if defaultProfile["attachOnly"] != false {
+		t.Errorf("user-set attachOnly should be preserved, got %v", defaultProfile["attachOnly"])
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -458,6 +458,12 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(ok).To(BeTrue(), "config should have gateway key")
 			Expect(gw["bind"]).To(Equal("loopback"), "gateway.bind should be loopback")
 
+			// Device auth should be disabled (incompatible with K8s)
+			controlUI, ok := gw["controlUi"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "gateway should have controlUi key")
+			Expect(controlUI["dangerouslyDisableDeviceAuth"]).To(Equal(true),
+				"gateway.controlUi.dangerouslyDisableDeviceAuth should be true")
+
 			// Clean up via owner-reference garbage collection
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})
@@ -1351,6 +1357,8 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				Expect(ok).To(BeTrue(), "profiles should have %s key", profileName)
 				Expect(profile["cdpUrl"]).To(Equal(expectedCDP),
 					"browser.profiles.%s.cdpUrl should use env var reference for pod IP", profileName)
+				Expect(profile["attachOnly"]).To(BeTrue(),
+					"browser.profiles.%s.attachOnly should be true for sidecar mode", profileName)
 			}
 
 			// Verify Service has chromium port
@@ -1800,6 +1808,12 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(ok).To(BeTrue(), "gateway should have auth key (injected by operator)")
 			Expect(auth["mode"]).To(Equal("token"), "gateway.auth.mode should be token")
 			Expect(auth["token"]).NotTo(BeEmpty(), "gateway.auth.token should be set")
+
+			// Device auth should be disabled (incompatible with K8s)
+			controlUI, ok := gw["controlUi"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "gateway should have controlUi key (injected by operator)")
+			Expect(controlUI["dangerouslyDisableDeviceAuth"]).To(Equal(true),
+				"gateway.controlUi.dangerouslyDisableDeviceAuth should be true")
 
 			// Verify StatefulSet config volume points to operator-managed CM (not external)
 			statefulSet := &appsv1.StatefulSet{}


### PR DESCRIPTION
## Summary

- Set `attachOnly: true` on both `default` and `chrome` browser profiles so OpenClaw attaches to the Chromium sidecar instead of trying to launch a local browser process
- Auto-inject `gateway.controlUi.dangerouslyDisableDeviceAuth: true` - device pairing is incompatible with Kubernetes (no interactive approval, proxied connections, no mDNS)
- Both settings respect user overrides (not injected if already set)

Fixes #241

## Test plan

- [x] Unit tests for `attachOnly` injection and user override preservation
- [x] Unit tests for `enrichConfigWithDeviceAuth` (injection, user override, field preservation, invalid JSON)
- [x] E2E tests verify `attachOnly` on browser profiles and `dangerouslyDisableDeviceAuth` on gateway config
- [ ] CI: lint, unit tests, e2e on kind cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)