### PR TITLE
fix: use localhost for Chromium CDP URL to support IPv6 clusters

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -303,10 +303,9 @@ func enrichConfigWithBrowser(configJSON []byte) ([]byte, error) {
 	}
 
 	// Use ${OPENCLAW_CHROMIUM_CDP} env var (resolved at runtime by OpenClaw)
-	// which contains the pod IP, and set attachOnly=true on each profile.
-	// attachOnly explicitly tells OpenClaw to attach to the existing sidecar
-	// instead of trying to launch/manage the browser process locally - this
-	// is deterministic regardless of whether the pod IP is loopback or not.
+	// which points to the Chromium sidecar via localhost (127.0.0.1).
+	// attachOnly=true tells OpenClaw to attach to the existing sidecar
+	// instead of trying to launch/manage the browser process locally.
 	cdpURL := "${OPENCLAW_CHROMIUM_CDP}"
 
 	// Configure both "default" and "chrome" profiles to point at the sidecar.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -447,45 +447,47 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 		t.Fatal("chromium container not found")
 	}
 
-	// Main container should have POD_IP (Downward API) and OPENCLAW_CHROMIUM_CDP env vars
+	// Main container should have OPENCLAW_CHROMIUM_CDP using localhost (IPv6-safe)
 	mainContainer := containers[0]
-	foundPodIP := false
 	foundChromiumCDP := false
 	for _, env := range mainContainer.Env {
 		if env.Name == "POD_IP" {
-			foundPodIP = true
-			if env.ValueFrom == nil || env.ValueFrom.FieldRef == nil || env.ValueFrom.FieldRef.FieldPath != "status.podIP" {
-				t.Error("POD_IP should use Downward API fieldRef to status.podIP")
-			}
+			t.Error("POD_IP env var should no longer be set (replaced by localhost)")
 		}
 		if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 			foundChromiumCDP = true
-			expected := fmt.Sprintf("http://$(POD_IP):%d", ChromiumPort)
+			expected := fmt.Sprintf("http://127.0.0.1:%d", ChromiumPort)
 			if env.Value != expected {
 				t.Errorf("OPENCLAW_CHROMIUM_CDP = %q, want %q", env.Value, expected)
 			}
 		}
 	}
-	if !foundPodIP {
-		t.Error("main container should have POD_IP env var (Downward API) when chromium is enabled")
-	}
 	if !foundChromiumCDP {
 		t.Error("main container should have OPENCLAW_CHROMIUM_CDP env var when chromium is enabled")
 	}
 
-	// Chromium PORT env var overrides the default listening port (3000)
+	// Chromium PORT and HOST env vars
 	foundPortEnv := false
+	foundHostEnv := false
 	for _, env := range chromium.Env {
 		if env.Name == "PORT" {
 			foundPortEnv = true
 			if env.Value != fmt.Sprintf("%d", ChromiumPort) {
 				t.Errorf("chromium PORT env = %q, want %q", env.Value, fmt.Sprintf("%d", ChromiumPort))
 			}
-			break
+		}
+		if env.Name == "HOST" {
+			foundHostEnv = true
+			if env.Value != "::" {
+				t.Errorf("chromium HOST env = %q, want %q", env.Value, "::")
+			}
 		}
 	}
 	if !foundPortEnv {
 		t.Error("chromium container should have PORT env var to override default listening port")
+	}
+	if !foundHostEnv {
+		t.Error("chromium container should have HOST=:: env var for dual-stack listening")
 	}
 
 	// Chromium image defaults
@@ -6599,8 +6601,7 @@ func TestBuildConfigMap_ChromiumBrowserConfig(t *testing.T) {
 	}
 
 	// Both "default" and "chrome" profiles must use the env var reference.
-	// ${OPENCLAW_CHROMIUM_CDP} resolves at runtime to the pod IP, which is
-	// non-loopback and triggers the remote/attach-only code path.
+	// ${OPENCLAW_CHROMIUM_CDP} resolves at runtime to the localhost CDP URL.
 	for _, name := range []string{"default", "chrome"} {
 		p, ok := profiles[name].(map[string]interface{})
 		if !ok {

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -338,23 +338,17 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 	}
 
 	if instance.Spec.Chromium.Enabled {
-		// Inject the pod IP via Downward API so the config can reference
-		// ${OPENCLAW_CHROMIUM_CDP} with a non-loopback address. The OpenClaw
-		// browser control service treats 127.x.x.x as "local/managed" and
-		// only activates remote/attach-only mode for non-loopback addresses.
+		// The Chromium sidecar shares the pod network namespace, so we can
+		// reach it via localhost. Using 127.0.0.1 (explicit IPv4 loopback)
+		// avoids IPv6 URL formatting issues (IPv6 addresses need brackets
+		// in URLs, e.g. http://[::1]:9222, but Kubernetes env var
+		// interpolation cannot add them conditionally).
+		// The config sets attachOnly=true so OpenClaw attaches to the
+		// sidecar regardless of whether the address is loopback or not.
 		env = append(env,
 			corev1.EnvVar{
-				Name: "POD_IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						APIVersion: "v1",
-						FieldPath:  "status.podIP",
-					},
-				},
-			},
-			corev1.EnvVar{
 				Name:  "OPENCLAW_CHROMIUM_CDP",
-				Value: fmt.Sprintf("http://$(POD_IP):%d", ChromiumPort),
+				Value: fmt.Sprintf("http://127.0.0.1:%d", ChromiumPort),
 			},
 		)
 	}
@@ -1121,12 +1115,11 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 
 	// Override the default listening port (3000) to avoid conflicting with
 	// the OpenClaw gateway's built-in browser control service on port 3000.
-	// The sidecar listens on 0.0.0.0 so it's reachable via the pod IP.
-	// The cdpUrl in the config uses ${OPENCLAW_CHROMIUM_CDP} which resolves
-	// to the pod IP at runtime, triggering the remote/attach-only code path
-	// in the browser control service (any non-loopback address is "remote").
+	// HOST=:: enables dual-stack listening so the sidecar is reachable on
+	// both IPv4 (127.0.0.1) and IPv6 (::1) loopback addresses.
 	chromiumEnv := []corev1.EnvVar{
 		{Name: "PORT", Value: fmt.Sprintf("%d", ChromiumPort)},
+		{Name: "HOST", Value: "::"},
 	}
 
 	// Add CA bundle mount and env if configured

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1318,22 +1318,18 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			}
 			Expect(foundPortEnv).To(BeTrue(), "chromium container should have PORT env var")
 
-			// Verify main container has POD_IP and OPENCLAW_CHROMIUM_CDP env vars
+			// Verify main container has OPENCLAW_CHROMIUM_CDP using localhost (IPv6-safe)
 			mainContainer := statefulSet.Spec.Template.Spec.Containers[0]
-			var foundPodIP, foundChromiumCDP bool
+			var foundChromiumCDP bool
 			for _, env := range mainContainer.Env {
-				if env.Name == "POD_IP" {
-					foundPodIP = true
-					Expect(env.ValueFrom).NotTo(BeNil(), "POD_IP should use valueFrom")
-					Expect(env.ValueFrom.FieldRef).NotTo(BeNil(), "POD_IP should use fieldRef")
-					Expect(env.ValueFrom.FieldRef.FieldPath).To(Equal("status.podIP"))
-				}
+				Expect(env.Name).NotTo(Equal("POD_IP"),
+					"POD_IP env var should no longer be set (replaced by localhost)")
 				if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 					foundChromiumCDP = true
-					Expect(env.Value).To(Equal(fmt.Sprintf("http://$(POD_IP):%d", resources.ChromiumPort)))
+					Expect(env.Value).To(Equal(fmt.Sprintf("http://127.0.0.1:%d", resources.ChromiumPort)),
+						"OPENCLAW_CHROMIUM_CDP should use IPv4 loopback (IPv6-safe)")
 				}
 			}
-			Expect(foundPodIP).To(BeTrue(), "POD_IP env var should be set via Downward API")
 			Expect(foundChromiumCDP).To(BeTrue(), "OPENCLAW_CHROMIUM_CDP env var should be set")
 
 			// Verify ConfigMap has browser profiles with cdpUrl on port 9222


### PR DESCRIPTION
## Summary

- Replace `POD_IP`-based `OPENCLAW_CHROMIUM_CDP` (`http://$(POD_IP):9222`) with `http://127.0.0.1:9222` - the Chromium sidecar shares the pod network namespace, so localhost always works. This avoids IPv6 URL formatting issues where `http://fd00::1:9222` is invalid (IPv6 needs brackets: `http://[fd00::1]:9222`)
- Set `HOST=::` on the Chromium sidecar container for dual-stack listening (reachable on both `127.0.0.1` and `::1`)
- Remove the now-unnecessary `POD_IP` Downward API env var

This is safe because `attachOnly: true` (added in v0.10.20) explicitly tells OpenClaw to attach to the sidecar regardless of whether the address is loopback or not.

Fixes #228

## Test plan

- [x] Unit tests updated: verify `OPENCLAW_CHROMIUM_CDP=http://127.0.0.1:9222`, no `POD_IP`, `HOST=::` on chromium container
- [x] E2E tests updated: same assertions on real cluster
- [ ] CI: lint, unit tests, e2e on kind cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)