### PR TITLE
fix: propagate nodeSelector and tolerations to backup CronJob pods

### DIFF
--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -339,6 +339,8 @@ func buildBackupCronJob(
 							DNSPolicy:                     corev1.DNSClusterFirst,
 							SchedulerName:                 "default-scheduler",
 							TerminationGracePeriodSeconds: &gracePeriod,
+							NodeSelector:                  instance.Spec.Availability.NodeSelector,
+							Tolerations:                   instance.Spec.Availability.Tolerations,
 							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:  int64Ptr(1000),
 								RunAsGroup: int64Ptr(1000),

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -382,6 +382,36 @@ var _ = Describe("S3 Helpers", func() {
 			Expect(cronJob.Labels["openclaw.rocks/job-type"]).To(Equal("periodic-backup"))
 		})
 
+		It("Should propagate nodeSelector and tolerations from spec.availability", func() {
+			instance.Spec.Availability.NodeSelector = map[string]string{
+				"openclaw.rocks/nodepool": "openclaw",
+			}
+			instance.Spec.Availability.Tolerations = []corev1.Toleration{
+				{
+					Key:      "openclaw.rocks/dedicated",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "openclaw",
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			}
+			cronJob := buildBackupCronJob(instance, creds)
+			podSpec := cronJob.Spec.JobTemplate.Spec.Template.Spec
+			Expect(podSpec.NodeSelector).To(Equal(map[string]string{
+				"openclaw.rocks/nodepool": "openclaw",
+			}))
+			Expect(podSpec.Tolerations).To(HaveLen(1))
+			Expect(podSpec.Tolerations[0].Key).To(Equal("openclaw.rocks/dedicated"))
+			Expect(podSpec.Tolerations[0].Value).To(Equal("openclaw"))
+			Expect(podSpec.Tolerations[0].Effect).To(Equal(corev1.TaintEffectNoSchedule))
+		})
+
+		It("Should leave nodeSelector and tolerations nil when not set", func() {
+			cronJob := buildBackupCronJob(instance, creds)
+			podSpec := cronJob.Spec.JobTemplate.Spec.Template.Spec
+			Expect(podSpec.NodeSelector).To(BeNil())
+			Expect(podSpec.Tolerations).To(BeNil())
+		})
+
 		It("Should set explicit Kubernetes default fields", func() {
 			cronJob := buildBackupCronJob(instance, creds)
 			spec := cronJob.Spec.JobTemplate.Spec.Template.Spec

--- a/test/e2e/e2e_backup_cronjob_test.go
+++ b/test/e2e/e2e_backup_cronjob_test.go
@@ -214,5 +214,64 @@ var _ = Describe("Periodic Backup CronJob", func() {
 			// Clean up
 			Expect(k8sClient.Delete(ctx, updatedInstance)).Should(Succeed())
 		})
+
+		It("Should propagate nodeSelector and tolerations to CronJob pod template", func() {
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instanceName := "backup-cron-nodeselector"
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Backup: openclawv1alpha1.BackupSpec{
+						Schedule: "0 4 * * *",
+					},
+					Availability: openclawv1alpha1.AvailabilitySpec{
+						NodeSelector: map[string]string{
+							"openclaw.rocks/nodepool": "openclaw",
+						},
+						Tolerations: []corev1.Toleration{
+							{
+								Key:      "openclaw.rocks/dedicated",
+								Operator: corev1.TolerationOpEqual,
+								Value:    "openclaw",
+								Effect:   corev1.TaintEffectNoSchedule,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Verify CronJob is created with nodeSelector and tolerations
+			cronJob := &batchv1.CronJob{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instanceName + "-backup-periodic",
+					Namespace: namespace,
+				}, cronJob)
+			}, timeout, interval).Should(Succeed())
+
+			podSpec := cronJob.Spec.JobTemplate.Spec.Template.Spec
+			Expect(podSpec.NodeSelector).To(HaveKeyWithValue("openclaw.rocks/nodepool", "openclaw"))
+			Expect(podSpec.Tolerations).To(HaveLen(1))
+			Expect(podSpec.Tolerations[0].Key).To(Equal("openclaw.rocks/dedicated"))
+			Expect(podSpec.Tolerations[0].Value).To(Equal("openclaw"))
+			Expect(podSpec.Tolerations[0].Effect).To(Equal(corev1.TaintEffectNoSchedule))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
## Summary

- Backup CronJob pods now inherit `nodeSelector` and `tolerations` from `spec.availability`, matching the StatefulSet behavior
- Without this fix, backup pods schedule on the wrong node pool and cannot mount the instance's RWO PVC, causing backups to never complete

Closes #244

## Test plan

- [x] Unit test: `buildBackupCronJob` propagates nodeSelector/tolerations when set
- [x] Unit test: `buildBackupCronJob` leaves nodeSelector/tolerations nil when not set
- [x] E2E test: CronJob pod template contains nodeSelector/tolerations from spec.availability
- [ ] CI passes (lint, test, e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)