### PR TITLE
docs: update OperatorHub and ArtifactHub documentation links

### DIFF
--- a/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
+++ b/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
@@ -177,7 +177,7 @@ spec:
     - Kubernetes 1.28+
 
     For full documentation, visit the
-    [OpenClaw Operator docs](https://openclaw.rocks/blog/deploy-openclaw-kubernetes).
+    [OpenClaw Operator docs](https://openclaw.rocks/docs/operator/0.10).
   maturity: alpha
   version: 0.9.0
   minKubeVersion: 1.28.0
@@ -203,7 +203,7 @@ spec:
     - name: Website
       url: https://openclaw.rocks
     - name: Operator Documentation
-      url: https://openclaw.rocks/blog/deploy-openclaw-kubernetes
+      url: https://openclaw.rocks/docs/operator/0.10
     - name: API Reference
       url: https://github.com/OpenClaw-rocks/k8s-operator/blob/main/docs/api-reference.md
     - name: GitHub Repository

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -34,7 +34,7 @@ annotations:
     - name: Website
       url: https://openclaw.rocks
     - name: Documentation
-      url: https://openclaw.rocks/blog/deploy-openclaw-kubernetes
+      url: https://openclaw.rocks/docs/operator/0.10
     - name: OperatorHub
       url: https://operatorhub.io/operator/openclaw-operator
     - name: Artifact Hub


### PR DESCRIPTION
## Summary

- Update "Operator Documentation" link in the OLM bundle CSV from the old blog post to the new dedicated docs at `https://openclaw.rocks/docs/operator/0.10`
- Update "Documentation" link in the Helm chart ArtifactHub annotations to match

## Test plan

- [ ] Verify links resolve correctly after merge
- No code changes - documentation metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)