### PR TITLE
feat(storage): validate existing PVC and improve resource parsing

### DIFF
--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -723,6 +723,20 @@ func (r *OpenClawInstanceReconciler) reconcilePVC(ctx context.Context, instance 
 
 	// Check if using existing claim
 	if instance.Spec.Storage.Persistence.ExistingClaim != "" {
+		existing := &corev1.PersistentVolumeClaim{}
+		if err := r.Get(ctx, types.NamespacedName{Name: instance.Spec.Storage.Persistence.ExistingClaim, Namespace: instance.Namespace}, existing); err != nil {
+			if apierrors.IsNotFound(err) {
+				meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+					Type:               openclawv1alpha1.ConditionTypeStorageReady,
+					Status:             metav1.ConditionFalse,
+					Reason:             "ExistingClaimNotFound",
+					Message:            fmt.Sprintf("Existing PVC %q not found", instance.Spec.Storage.Persistence.ExistingClaim),
+					ObservedGeneration: instance.Generation,
+				})
+				return fmt.Errorf("existing PVC %q not found", instance.Spec.Storage.Persistence.ExistingClaim)
+			}
+			return err
+		}
 		instance.Status.ManagedResources.PVC = instance.Spec.Storage.Persistence.ExistingClaim
 		return nil
 	}

--- a/internal/controller/openclawinstance_controller_test.go
+++ b/internal/controller/openclawinstance_controller_test.go
@@ -27,6 +27,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -162,6 +163,92 @@ var _ = Describe("OpenClawInstance Controller", func() {
 
 			By("Cleaning up")
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+	})
+
+	Context("When using an existing PVC", func() {
+		It("Should fail if the existing PVC does not exist", func() {
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-pvc-test",
+					Namespace: "default",
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Storage: openclawv1alpha1.StorageSpec{
+						Persistence: openclawv1alpha1.PersistenceSpec{
+							ExistingClaim: "non-existent-pvc",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			instanceLookupKey := types.NamespacedName{Name: "existing-pvc-test", Namespace: "default"}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, instanceLookupKey, instance)
+				if err != nil {
+					return false
+				}
+				for _, cond := range instance.Status.Conditions {
+					if cond.Type == openclawv1alpha1.ConditionTypeStorageReady &&
+						cond.Status == metav1.ConditionFalse &&
+						cond.Reason == "ExistingClaimNotFound" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+
+		It("Should succeed if the existing PVC exists", func() {
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-existing-pvc",
+					Namespace: "default",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pvc)).Should(Succeed())
+
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-pvc-success",
+					Namespace: "default",
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Storage: openclawv1alpha1.StorageSpec{
+						Persistence: openclawv1alpha1.PersistenceSpec{
+							ExistingClaim: "my-existing-pvc",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			instanceLookupKey := types.NamespacedName{Name: "existing-pvc-success", Namespace: "default"}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, instanceLookupKey, instance)
+				if err != nil {
+					return false
+				}
+				return instance.Status.ManagedResources.PVC == "my-existing-pvc"
+			}, timeout, interval).Should(BeTrue())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, pvc)).Should(Succeed())
 		})
 	})
 

--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -256,6 +256,9 @@ func isJobFinished(job *batchv1.Job) (bool, batchv1.JobConditionType) {
 
 // pvcName returns the PVC name for the instance (delegates to resources package)
 func pvcNameForInstance(instance *openclawv1alpha1.OpenClawInstance) string {
+	if instance.Spec.Storage.Persistence.ExistingClaim != "" {
+		return instance.Spec.Storage.Persistence.ExistingClaim
+	}
 	return resources.PVCName(instance)
 }
 

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -25,9 +25,40 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openclawv1alpha1 "github.com/openclawrocks/k8s-operator/api/v1alpha1"
+	"github.com/openclawrocks/k8s-operator/internal/resources"
 )
 
 var _ = Describe("S3 Helpers", func() {
+	Context("pvcNameForInstance", func() {
+		It("Should return the existing claim name when specified", func() {
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "default",
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Storage: openclawv1alpha1.StorageSpec{
+						Persistence: openclawv1alpha1.PersistenceSpec{
+							ExistingClaim: "my-existing-pvc",
+						},
+					},
+				},
+			}
+			Expect(pvcNameForInstance(instance)).To(Equal("my-existing-pvc"))
+		})
+
+		It("Should return default PVC name when no existing claim is specified", func() {
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "default",
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{},
+			}
+			Expect(pvcNameForInstance(instance)).To(Equal(resources.PVCName(instance)))
+		})
+	})
+
 	Context("getTenantID", func() {
 		It("Should return the tenant label value when present", func() {
 			instance := &openclawv1alpha1.OpenClawInstance{

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	openclawv1alpha1 "github.com/openclawrocks/k8s-operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -269,4 +270,17 @@ func MetricsPort(instance *openclawv1alpha1.OpenClawInstance) int32 {
 // Ptr returns a pointer to the given value
 func Ptr[T any](v T) *T {
 	return &v
+}
+
+// ParseQuantity parses a string into a resource.Quantity, falling back to
+// the default if parsing fails. Prevents panics from resource.MustParse.
+func ParseQuantity(s string, defaultValue string) resource.Quantity {
+	if s == "" {
+		return resource.MustParse(defaultValue)
+	}
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return resource.MustParse(defaultValue)
+	}
+	return q
 }

--- a/internal/resources/pvc.go
+++ b/internal/resources/pvc.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	openclawv1alpha1 "github.com/openclawrocks/k8s-operator/api/v1alpha1"
@@ -29,10 +28,7 @@ func BuildPVC(instance *openclawv1alpha1.OpenClawInstance) *corev1.PersistentVol
 	labels := Labels(instance)
 
 	// Get storage size with default
-	size := instance.Spec.Storage.Persistence.Size
-	if size == "" {
-		size = "10Gi"
-	}
+	size := ParseQuantity(instance.Spec.Storage.Persistence.Size, "10Gi")
 
 	// Get access modes with default
 	accessModes := instance.Spec.Storage.Persistence.AccessModes
@@ -53,7 +49,7 @@ func BuildPVC(instance *openclawv1alpha1.OpenClawInstance) *corev1.PersistentVol
 			AccessModes: accessModes,
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(size),
+					corev1.ResourceStorage: size,
 				},
 			},
 		},

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1060,29 +1060,10 @@ func buildTailscaleResourceRequirements(instance *openclawv1alpha1.OpenClawInsta
 		Limits:   corev1.ResourceList{},
 	}
 
-	cpuReq := instance.Spec.Tailscale.Resources.Requests.CPU
-	if cpuReq == "" {
-		cpuReq = "50m"
-	}
-	req.Requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
-
-	memReq := instance.Spec.Tailscale.Resources.Requests.Memory
-	if memReq == "" {
-		memReq = "64Mi"
-	}
-	req.Requests[corev1.ResourceMemory] = resource.MustParse(memReq)
-
-	cpuLim := instance.Spec.Tailscale.Resources.Limits.CPU
-	if cpuLim == "" {
-		cpuLim = "200m"
-	}
-	req.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLim)
-
-	memLim := instance.Spec.Tailscale.Resources.Limits.Memory
-	if memLim == "" {
-		memLim = "256Mi"
-	}
-	req.Limits[corev1.ResourceMemory] = resource.MustParse(memLim)
+	req.Requests[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Tailscale.Resources.Requests.CPU, "50m")
+	req.Requests[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Tailscale.Resources.Requests.Memory, "64Mi")
+	req.Limits[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Tailscale.Resources.Limits.CPU, "200m")
+	req.Limits[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Tailscale.Resources.Limits.Memory, "256Mi")
 
 	return req
 }
@@ -1505,30 +1486,12 @@ func buildOllamaResourceRequirements(instance *openclawv1alpha1.OpenClawInstance
 	}
 
 	// Requests
-	cpuReq := instance.Spec.Ollama.Resources.Requests.CPU
-	if cpuReq == "" {
-		cpuReq = "500m"
-	}
-	req.Requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
-
-	memReq := instance.Spec.Ollama.Resources.Requests.Memory
-	if memReq == "" {
-		memReq = "1Gi"
-	}
-	req.Requests[corev1.ResourceMemory] = resource.MustParse(memReq)
+	req.Requests[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Ollama.Resources.Requests.CPU, "500m")
+	req.Requests[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Ollama.Resources.Requests.Memory, "1Gi")
 
 	// Limits
-	cpuLim := instance.Spec.Ollama.Resources.Limits.CPU
-	if cpuLim == "" {
-		cpuLim = "2000m"
-	}
-	req.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLim)
-
-	memLim := instance.Spec.Ollama.Resources.Limits.Memory
-	if memLim == "" {
-		memLim = "4Gi"
-	}
-	req.Limits[corev1.ResourceMemory] = resource.MustParse(memLim)
+	req.Limits[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Ollama.Resources.Limits.CPU, "2000m")
+	req.Limits[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Ollama.Resources.Limits.Memory, "4Gi")
 
 	// GPU support
 	if instance.Spec.Ollama.GPU != nil && *instance.Spec.Ollama.GPU > 0 {
@@ -1832,30 +1795,12 @@ func buildResourceRequirements(instance *openclawv1alpha1.OpenClawInstance) core
 	}
 
 	// Requests
-	cpuReq := instance.Spec.Resources.Requests.CPU
-	if cpuReq == "" {
-		cpuReq = "500m"
-	}
-	req.Requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
-
-	memReq := instance.Spec.Resources.Requests.Memory
-	if memReq == "" {
-		memReq = "1Gi"
-	}
-	req.Requests[corev1.ResourceMemory] = resource.MustParse(memReq)
+	req.Requests[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Resources.Requests.CPU, "500m")
+	req.Requests[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Resources.Requests.Memory, "1Gi")
 
 	// Limits
-	cpuLim := instance.Spec.Resources.Limits.CPU
-	if cpuLim == "" {
-		cpuLim = "2000m"
-	}
-	req.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLim)
-
-	memLim := instance.Spec.Resources.Limits.Memory
-	if memLim == "" {
-		memLim = "4Gi"
-	}
-	req.Limits[corev1.ResourceMemory] = resource.MustParse(memLim)
+	req.Limits[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Resources.Limits.CPU, "2000m")
+	req.Limits[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Resources.Limits.Memory, "4Gi")
 
 	return req
 }
@@ -1868,30 +1813,12 @@ func buildChromiumResourceRequirements(instance *openclawv1alpha1.OpenClawInstan
 	}
 
 	// Requests
-	cpuReq := instance.Spec.Chromium.Resources.Requests.CPU
-	if cpuReq == "" {
-		cpuReq = "250m"
-	}
-	req.Requests[corev1.ResourceCPU] = resource.MustParse(cpuReq)
-
-	memReq := instance.Spec.Chromium.Resources.Requests.Memory
-	if memReq == "" {
-		memReq = "512Mi"
-	}
-	req.Requests[corev1.ResourceMemory] = resource.MustParse(memReq)
+	req.Requests[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Chromium.Resources.Requests.CPU, "250m")
+	req.Requests[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Chromium.Resources.Requests.Memory, "512Mi")
 
 	// Limits
-	cpuLim := instance.Spec.Chromium.Resources.Limits.CPU
-	if cpuLim == "" {
-		cpuLim = "1000m"
-	}
-	req.Limits[corev1.ResourceCPU] = resource.MustParse(cpuLim)
-
-	memLim := instance.Spec.Chromium.Resources.Limits.Memory
-	if memLim == "" {
-		memLim = "2Gi"
-	}
-	req.Limits[corev1.ResourceMemory] = resource.MustParse(memLim)
+	req.Limits[corev1.ResourceCPU] = ParseQuantity(instance.Spec.Chromium.Resources.Limits.CPU, "1000m")
+	req.Limits[corev1.ResourceMemory] = ParseQuantity(instance.Spec.Chromium.Resources.Limits.Memory, "2Gi")
 
 	return req
 }

--- a/internal/webhook/openclawinstance_webhook.go
+++ b/internal/webhook/openclawinstance_webhook.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -198,6 +199,11 @@ func (v *OpenClawInstanceValidator) validate(instance *openclawv1alpha1.OpenClaw
 		}
 	}
 
+	// 11b. Validate storage size and resource quantities
+	if err := validateResourceQuantities(instance); err != nil {
+		return nil, err
+	}
+
 	// 12. Validate auto-update spec
 	if instance.Spec.AutoUpdate.CheckInterval != "" {
 		d, err := time.ParseDuration(instance.Spec.AutoUpdate.CheckInterval)
@@ -284,6 +290,87 @@ func validateWorkspaceSpec(ws *openclawv1alpha1.WorkspaceSpec) error {
 			return fmt.Errorf("workspace initialDirectories entry %q: %w", dir, err)
 		}
 	}
+	return nil
+}
+
+// validateResourceQuantities checks that all storage and compute resource
+// strings are valid Kubernetes quantities (e.g. "10Gi", "500m").
+func validateResourceQuantities(instance *openclawv1alpha1.OpenClawInstance) error {
+	check := func(path, val string) error {
+		if val == "" {
+			return nil
+		}
+		if _, err := resource.ParseQuantity(val); err != nil {
+			return fmt.Errorf("%s %q is not a valid Kubernetes quantity: %w", path, val, err)
+		}
+		return nil
+	}
+
+	// Storage size
+	if err := check("spec.storage.persistence.size", instance.Spec.Storage.Persistence.Size); err != nil {
+		return err
+	}
+
+	// Main container resources
+	r := instance.Spec.Resources
+	if err := check("spec.resources.requests.cpu", r.Requests.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.resources.requests.memory", r.Requests.Memory); err != nil {
+		return err
+	}
+	if err := check("spec.resources.limits.cpu", r.Limits.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.resources.limits.memory", r.Limits.Memory); err != nil {
+		return err
+	}
+
+	// Chromium resources
+	cr := instance.Spec.Chromium.Resources
+	if err := check("spec.chromium.resources.requests.cpu", cr.Requests.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.chromium.resources.requests.memory", cr.Requests.Memory); err != nil {
+		return err
+	}
+	if err := check("spec.chromium.resources.limits.cpu", cr.Limits.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.chromium.resources.limits.memory", cr.Limits.Memory); err != nil {
+		return err
+	}
+
+	// Tailscale resources
+	tr := instance.Spec.Tailscale.Resources
+	if err := check("spec.tailscale.resources.requests.cpu", tr.Requests.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.tailscale.resources.requests.memory", tr.Requests.Memory); err != nil {
+		return err
+	}
+	if err := check("spec.tailscale.resources.limits.cpu", tr.Limits.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.tailscale.resources.limits.memory", tr.Limits.Memory); err != nil {
+		return err
+	}
+
+	// Ollama resources
+	or := instance.Spec.Ollama.Resources
+	if err := check("spec.ollama.resources.requests.cpu", or.Requests.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.ollama.resources.requests.memory", or.Requests.Memory); err != nil {
+		return err
+	}
+	if err := check("spec.ollama.resources.limits.cpu", or.Limits.CPU); err != nil {
+		return err
+	}
+	if err := check("spec.ollama.resources.limits.memory", or.Limits.Memory); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Add validation for existing PVC references to ensure they exist before use, and add a safe ParseQuantity utility to prevent panics from invalid resource strings. Also validate all resource quantity fields in the webhook.

- Check existing PVC exists in reconcilePVC and set appropriate status
- Add ParseQuantity helper with fallback to default
- Use ParseQuantity for all resource parsing in statefulset and PVC builders
- Validate all resource quantity strings in admission webhook
- Add unit tests for existing PVC scenarios