### PR TITLE
fix: remove invalid llmConfig from webhook validation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ When enabled, the operator:
 - Configures GPU resource limits when `gpu` is set (`nvidia.com/gpu`)
 - Mounts a model cache volume (emptyDir by default, or an existing PVC via `storage.existingClaim`)
 
-See [Custom AI Providers](docs/custom-providers.md) for configuring OpenClaw to use Ollama models via `llmConfig`.
+See [Custom AI Providers](docs/custom-providers.md) for configuring OpenClaw to use Ollama models via environment variables.
 
 ### Web terminal sidecar
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1018,7 +1018,7 @@ The operator creates a Kubernetes CronJob (`<instance>-backup-periodic`) that:
 
 ## Related Guides
 
-- [Model Fallback Chains](model-fallback.md) - configure multi-provider fallback with `llmConfig`
+- [Model Fallback Chains](model-fallback.md) - configure multi-provider fallback via environment variables
 - [Custom AI Providers](custom-providers.md) - Ollama sidecar, vLLM, and other self-hosted models
 - [External Secrets Operator Integration](external-secrets.md) - sync API keys from AWS, Vault, GCP, etc.
 

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -11,19 +11,14 @@ This guide covers common patterns for connecting OpenClaw to self-hosted or alte
 
 Run Ollama alongside OpenClaw in the same pod. This is the simplest option when you want local model inference without network hops.
 
+Provider configuration is done entirely through environment variables. Set `OPENAI_BASE_URL` to point OpenClaw at your custom provider endpoint:
+
 ```yaml
 apiVersion: openclaw.rocks/v1alpha1
 kind: OpenClawInstance
 metadata:
   name: local-llm
 spec:
-  config:
-    raw:
-      llmConfig:
-        - provider: openai
-          model: llama3.2
-          baseURL: http://localhost:11434/v1
-
   sidecars:
     - name: ollama
       image: ollama/ollama:latest
@@ -39,10 +34,11 @@ spec:
       emptyDir:
         sizeLimit: 20Gi
 
-  # No external API keys needed for local inference
   env:
     - name: OPENAI_API_KEY
       value: "not-needed"
+    - name: OPENAI_BASE_URL
+      value: "http://localhost:11434/v1"
 
   resources:
     requests:
@@ -85,7 +81,7 @@ spec:
 
 ## Ollama as an External Service
 
-When Ollama runs as a separate Deployment or on bare metal, point OpenClaw to it via config and allow egress to the service.
+When Ollama runs as a separate Deployment or on bare metal, point OpenClaw to it via environment variables and allow egress to the service.
 
 ```yaml
 apiVersion: openclaw.rocks/v1alpha1
@@ -93,16 +89,11 @@ kind: OpenClawInstance
 metadata:
   name: external-ollama
 spec:
-  config:
-    raw:
-      llmConfig:
-        - provider: openai
-          model: llama3.2
-          baseURL: http://ollama.inference.svc:11434/v1
-
   env:
     - name: OPENAI_API_KEY
       value: "not-needed"
+    - name: OPENAI_BASE_URL
+      value: "http://ollama.inference.svc:11434/v1"
 
   security:
     networkPolicy:
@@ -130,16 +121,11 @@ kind: OpenClawInstance
 metadata:
   name: vllm-instance
 spec:
-  config:
-    raw:
-      llmConfig:
-        - provider: openai
-          model: meta-llama/Llama-3.2-8B-Instruct
-          baseURL: http://vllm.inference.svc:8000/v1
-
   env:
     - name: OPENAI_API_KEY
       value: "not-needed"
+    - name: OPENAI_BASE_URL
+      value: "http://vllm.inference.svc:8000/v1"
 
   security:
     networkPolicy:
@@ -168,29 +154,3 @@ The default NetworkPolicy allows egress only on port 443 (HTTPS) and port 53 (DN
 | vLLM external         | 8000  | `additionalEgress` with pod selector  |
 | Custom HTTPS endpoint | 443   | Already allowed by default            |
 | Custom non-443 HTTPS  | 8443  | `additionalEgress` with CIDR or selector |
-
-## Hybrid Fallback (Local + Cloud)
-
-Combine a local provider with cloud fallbacks for resilience:
-
-```yaml
-spec:
-  config:
-    raw:
-      llmConfig:
-        - provider: openai
-          model: llama3.2
-          baseURL: http://localhost:11434/v1
-        - provider: anthropic
-          model: claude-sonnet-4-5-20250929
-
-  envFrom:
-    - secretRef:
-        name: cloud-api-keys
-
-  env:
-    - name: OPENAI_API_KEY
-      value: "not-needed"
-```
-
-This tries local Ollama first and falls back to Anthropic Claude if the local model is unavailable or errors. See [Model Fallback Chains](model-fallback.md) for details on fallback behavior.

--- a/docs/model-fallback.md
+++ b/docs/model-fallback.md
@@ -1,12 +1,12 @@
 # Model Fallback Chains
 
-OpenClaw supports fallback chains for LLM providers via the `llmConfig` section of `openclaw.json`. When the primary provider is unavailable or returns an error, the application automatically tries the next provider in the chain.
+OpenClaw supports configuring multiple AI providers. Provider selection and fallback behavior are controlled entirely through environment variables - the operator's role is to inject the required API keys via `envFrom` or `env`.
 
 ## How It Works
 
-Fallback logic is **application behavior** — the operator does not intercept or manage LLM calls. The operator's role is to deliver the `openclaw.json` config and inject the required API keys via `envFrom` or `env`.
+Fallback logic is **application behavior** - the operator does not intercept or manage LLM calls. The operator delivers the `openclaw.json` config and injects the required API keys.
 
-The `llmConfig` section in `openclaw.json` accepts an ordered list of provider configurations. When a request fails (timeout, rate limit, 5xx), OpenClaw retries with the next provider in the list.
+When multiple provider API keys are present in the environment, OpenClaw can fall back between providers when a request fails (timeout, rate limit, 5xx).
 
 ## Example CR
 
@@ -16,17 +16,6 @@ kind: OpenClawInstance
 metadata:
   name: my-assistant
 spec:
-  config:
-    raw:
-      llmConfig:
-        - provider: anthropic
-          model: claude-sonnet-4-5-20250929
-        - provider: openai
-          model: gpt-4o
-          baseURL: https://api.openai.com/v1
-        - provider: google
-          model: gemini-2.0-flash
-
   envFrom:
     - secretRef:
         name: ai-provider-keys
@@ -63,6 +52,5 @@ stringData:
 ## Notes
 
 - The operator webhook warns if no known provider API keys are detected in `envFrom` or `env`.
-- Fallback ordering matters — place your preferred (fastest/cheapest) provider first.
-- Each provider in the chain must have its API key available in the pod environment.
+- Each provider must have its API key available in the pod environment.
 - Rate limits and quotas are per-provider. A fallback chain spreads load across providers during outages but does not pool quotas.

--- a/internal/webhook/openclawinstance_webhook.go
+++ b/internal/webhook/openclawinstance_webhook.go
@@ -57,7 +57,6 @@ var knownProviderEnvVars = map[string]bool{
 // knownConfigKeys lists known top-level keys in openclaw.json configuration.
 var knownConfigKeys = map[string]bool{
 	"mcpServers":         true,
-	"llmConfig":          true,
 	"skills":             true,
 	"apiKeys":            true,
 	"settings":           true,
@@ -397,7 +396,7 @@ func validateConfigSchema(instance *openclawv1alpha1.OpenClawInstance) admission
 	var warnings admission.Warnings
 	for key := range topLevel {
 		if !knownConfigKeys[key] {
-			warnings = append(warnings, fmt.Sprintf("Unknown config key %q in spec.config.raw — known keys are: mcpServers, llmConfig, skills, apiKeys, settings, tools, customInstructions", key))
+			warnings = append(warnings, fmt.Sprintf("Unknown config key %q in spec.config.raw — known keys are: mcpServers, skills, apiKeys, settings, tools, customInstructions", key))
 		}
 	}
 	return warnings

--- a/internal/webhook/openclawinstance_webhook_test.go
+++ b/internal/webhook/openclawinstance_webhook_test.go
@@ -1123,7 +1123,7 @@ func TestValidateCreate_ConfigSchema_ValidKeys(t *testing.T) {
 	instance := newTestInstance()
 	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
 		RawExtension: k8sruntime.RawExtension{
-			Raw: []byte(`{"mcpServers":{},"llmConfig":{},"settings":{}}`),
+			Raw: []byte(`{"mcpServers":{},"settings":{},"apiKeys":{}}`),
 		},
 	}
 


### PR DESCRIPTION
## Summary

Closes #257.

- `llmConfig` is not a valid OpenClaw config key -- the application rejects it with `Unrecognized key: "llmConfig"`
- Remove `llmConfig` from the webhook's `knownConfigKeys` map so it now correctly triggers an "unknown config key" warning
- Rewrite `docs/custom-providers.md` and `docs/model-fallback.md` to use environment variables (`OPENAI_BASE_URL`, etc.) instead of the invalid `llmConfig` config block
- Update references in `README.md` and `docs/api-reference.md`

## Test plan

- [x] `go test ./internal/webhook/ -run ConfigSchema` passes
- [ ] `make test` in CI
- [ ] Applying a CR with `llmConfig` in `spec.config.raw` now produces a webhook warning about an unknown key

🤖 Generated with [Claude Code](https://claude.com/claude-code)