### PR TITLE
feat: persist Tailscale state across pod restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ spec:
 
 When enabled, the operator runs a **Tailscale sidecar** (`tailscaled`) that handles serve/funnel declaratively via `TS_SERVE_CONFIG`. An **init container** copies the `tailscale` CLI binary to a shared volume so the main container can call `tailscale whois` for SSO authentication. The sidecar runs in userspace mode (`TS_USERSPACE=true`) - no `NET_ADMIN` capability needed.
 
+**State persistence:** Tailscale node identity and TLS certificates are automatically persisted to a Kubernetes Secret (`<instance>-ts-state`) via `TS_KUBE_SECRET`. This prevents hostname incrementing (device-1, device-2, ...) and Let's Encrypt certificate re-issuance across pod restarts. The operator pre-creates the state Secret, grants the pod's ServiceAccount `get/update/patch` access to it, and mounts the SA token automatically.
+
 Use ephemeral+reusable auth keys from the [Tailscale admin console](https://login.tailscale.com/admin/settings/keys). When `authSSO` is enabled, tailnet members can authenticate without a gateway token.
 
 ### Config merge mode
@@ -707,6 +709,7 @@ These behaviors are always applied - no configuration needed:
 | `OPENCLAW_DISABLE_BONJOUR=1` | Always set (mDNS does not work in Kubernetes) |
 | Browser profiles | When Chromium is enabled, `"default"` and `"chrome"` profiles are auto-configured with the sidecar's CDP endpoint |
 | Tailscale serve config | When Tailscale is enabled, a `tailscale-serve.json` key is added to the ConfigMap for the sidecar's `TS_SERVE_CONFIG` |
+| Tailscale state persistence | When Tailscale is enabled, node identity and TLS certs are persisted to a `<instance>-ts-state` Secret via `TS_KUBE_SECRET` |
 | Config hash rollouts | Config changes trigger rolling updates via SHA-256 hash annotation |
 | Config restoration | The init container restores config on every pod restart (overwrite or merge mode) |
 

--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -1342,6 +1342,11 @@ type ManagedResourcesStatus struct {
 	// BackupCronJob is the name of the managed periodic backup CronJob
 	// +optional
 	BackupCronJob string `json:"backupCronJob,omitempty"`
+
+	// TailscaleStateSecret is the name of the Secret used to persist Tailscale
+	// node identity and TLS certificate state across pod restarts
+	// +optional
+	TailscaleStateSecret string `json:"tailscaleStateSecret,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
+++ b/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
@@ -9587,6 +9587,11 @@ spec:
                   statefulSet:
                     description: StatefulSet is the name of the managed StatefulSet
                     type: string
+                  tailscaleStateSecret:
+                    description: |-
+                      TailscaleStateSecret is the name of the Secret used to persist Tailscale
+                      node identity and TLS certificate state across pod restarts
+                    type: string
                 type: object
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed

--- a/config/crd/bases/openclaw.rocks_openclawinstances.yaml
+++ b/config/crd/bases/openclaw.rocks_openclawinstances.yaml
@@ -9581,6 +9581,11 @@ spec:
                   statefulSet:
                     description: StatefulSet is the name of the managed StatefulSet
                     type: string
+                  tailscaleStateSecret:
+                    description: |-
+                      TailscaleStateSecret is the name of the Secret used to persist Tailscale
+                      node identity and TLS certificate state across pod restarts
+                    type: string
                 type: object
               observedGeneration:
                 description: ObservedGeneration is the most recent generation observed

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -269,6 +269,8 @@ When enabled, the operator:
 
 - Adds a **Tailscale sidecar** running `tailscaled` in userspace mode (`TS_USERSPACE=true`). The sidecar handles serve/funnel declaratively via `TS_SERVE_CONFIG`.
 - Adds an **init container** (`init-tailscale-bin`) that copies the `tailscale` CLI binary to a shared volume (`/tailscale-bin`), making it available to the main container for `tailscale whois` (SSO auth).
+- Creates a **state Secret** (`<instance>-ts-state`) and sets `TS_KUBE_SECRET` so Tailscale persists node identity and TLS certificates across pod restarts. This prevents hostname incrementing and Let's Encrypt certificate re-issuance.
+- Grants the pod's ServiceAccount `get/update/patch` on the state Secret and enables `AutomountServiceAccountToken` so containerboot can access the Kubernetes API.
 - Sets `TS_SOCKET` on the main container pointing to the sidecar's Unix socket.
 - Prepends `/tailscale-bin` to the main container's `PATH`.
 - Adds `tailscale-serve.json` to the ConfigMap with the serve/funnel configuration.
@@ -869,6 +871,7 @@ Standard `metav1.Condition` array. Condition types:
 | `grafanaDashboardInstance` | `string` | Name of the instance detail dashboard ConfigMap. |
 | `horizontalPodAutoscaler` | `string` | Name of the managed HorizontalPodAutoscaler. |
 | `backupCronJob`      | `string` | Name of the managed periodic backup CronJob. |
+| `tailscaleStateSecret` | `string` | Name of the Secret used to persist Tailscale node identity and TLS certificate state. |
 
 ### status.backup and restore
 

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -307,7 +307,15 @@ func (r *OpenClawInstanceReconciler) reconcileResources(ctx context.Context, ins
 	}
 	logger.V(1).Info("Gateway token secret reconciled")
 
-	// 2c. Resolve skill packs from GitHub (non-blocking - failures degrade but don't block provisioning)
+	// 2c. Reconcile Tailscale state Secret (must precede StatefulSet)
+	if instance.Spec.Tailscale.Enabled {
+		if err := r.reconcileTailscaleStateSecret(ctx, instance); err != nil {
+			return fmt.Errorf("failed to reconcile Tailscale state secret: %w", err)
+		}
+		logger.V(1).Info("Tailscale state secret reconciled")
+	}
+
+	// 2d. Resolve skill packs from GitHub (non-blocking - failures degrade but don't block provisioning)
 	var skillPacks *resources.ResolvedSkillPacks
 	packNames := resources.ExtractPackSkills(instance.Spec.Skills)
 	if len(packNames) > 0 && r.SkillPackResolver != nil {
@@ -607,6 +615,30 @@ func (r *OpenClawInstanceReconciler) reconcileGatewayTokenSecret(ctx context.Con
 	r.Recorder.Event(instance, corev1.EventTypeNormal, "GatewayTokenCreated", "Auto-generated gateway authentication token")
 
 	return tokenHex, nil
+}
+
+// reconcileTailscaleStateSecret ensures an empty Secret exists for Tailscale to
+// persist node identity and TLS certificate state. The containerboot process
+// reads and writes state to this Secret via the Kubernetes API (TS_KUBE_SECRET).
+// The operator pre-creates the Secret so that the pod's ServiceAccount only needs
+// get/update/patch (not create) permissions, keeping RBAC minimal.
+func (r *OpenClawInstanceReconciler) reconcileTailscaleStateSecret(ctx context.Context, instance *openclawv1alpha1.OpenClawInstance) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.TailscaleStateSecretName(instance),
+			Namespace: instance.Namespace,
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		desired := resources.BuildTailscaleStateSecret(instance)
+		secret.Labels = desired.Labels
+		// Do not overwrite Data - containerboot manages the content
+		return controllerutil.SetControllerReference(instance, secret, r.Scheme)
+	}); err != nil {
+		return fmt.Errorf("failed to reconcile Tailscale state secret: %w", err)
+	}
+	instance.Status.ManagedResources.TailscaleStateSecret = secret.Name
+	return nil
 }
 
 // reconcileConfigMap reconciles the operator-managed ConfigMap for openclaw.json.

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -210,6 +210,11 @@ func BasicAuthSecretName(instance *openclawv1alpha1.OpenClawInstance) string {
 	return instance.Name + "-basic-auth"
 }
 
+// TailscaleStateSecretName returns the name of the Tailscale state Secret
+func TailscaleStateSecretName(instance *openclawv1alpha1.OpenClawInstance) string {
+	return instance.Name + "-ts-state"
+}
+
 // GetImageRepository returns the image repository with defaults
 func GetImageRepository(instance *openclawv1alpha1.OpenClawInstance) string {
 	if instance.Spec.Image.Repository != "" {

--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -37,7 +37,7 @@ func BuildServiceAccount(instance *openclawv1alpha1.OpenClawInstance) *corev1.Se
 			Labels:      labels,
 			Annotations: instance.Spec.Security.RBAC.ServiceAccountAnnotations,
 		},
-		AutomountServiceAccountToken: Ptr(instance.Spec.SelfConfigure.Enabled),
+		AutomountServiceAccountToken: Ptr(instance.Spec.SelfConfigure.Enabled || instance.Spec.Tailscale.Enabled),
 	}
 }
 
@@ -83,6 +83,16 @@ func BuildRole(instance *openclawv1alpha1.OpenClawInstance) *rbacv1.Role {
 				Verbs:         []string{"get"},
 			})
 		}
+	}
+
+	// Tailscale state Secret - containerboot needs to read/write its state
+	if instance.Spec.Tailscale.Enabled {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups:     []string{""},
+			Resources:     []string{"secrets"},
+			ResourceNames: []string{TailscaleStateSecretName(instance)},
+			Verbs:         []string{"get", "update", "patch"},
+		})
 	}
 
 	// Add additional rules from spec

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -5991,11 +5991,12 @@ func TestBuildStatefulSet_TailscaleSidecar(t *testing.T) {
 	if envMap["TS_HOSTNAME"].Value != "ts-sidecar" {
 		t.Errorf("TS_HOSTNAME = %q, want %q", envMap["TS_HOSTNAME"].Value, "ts-sidecar")
 	}
-	if envMap["TS_KUBE_SECRET"].Value != "" {
-		t.Errorf("TS_KUBE_SECRET = %q, want empty string", envMap["TS_KUBE_SECRET"].Value)
+	expectedStateSecret := TailscaleStateSecretName(instance)
+	if envMap["TS_KUBE_SECRET"].Value != expectedStateSecret {
+		t.Errorf("TS_KUBE_SECRET = %q, want %q", envMap["TS_KUBE_SECRET"].Value, expectedStateSecret)
 	}
-	if envMap["KUBERNETES_SERVICE_HOST"].Value != "" {
-		t.Errorf("KUBERNETES_SERVICE_HOST = %q, want empty string", envMap["KUBERNETES_SERVICE_HOST"].Value)
+	if _, hasKSH := envMap["KUBERNETES_SERVICE_HOST"]; hasKSH {
+		t.Error("KUBERNETES_SERVICE_HOST should not be set (containerboot needs kube API access)")
 	}
 
 	tsAuthKey, ok := envMap["TS_AUTHKEY"]
@@ -6631,6 +6632,100 @@ func TestBuildStatefulSet_TailscaleFunnel_UsesHTTPProbes(t *testing.T) {
 	}
 	if container.StartupProbe.HTTPGet == nil {
 		t.Fatal("startup probe should use HTTPGet handler when Tailscale funnel is enabled")
+	}
+}
+
+func TestBuildStatefulSet_TailscaleStateSecretName(t *testing.T) {
+	instance := newTestInstance("ts-state")
+	got := TailscaleStateSecretName(instance)
+	want := "ts-state-ts-state"
+	if got != want {
+		t.Errorf("TailscaleStateSecretName = %q, want %q", got, want)
+	}
+}
+
+func TestBuildTailscaleStateSecret(t *testing.T) {
+	instance := newTestInstance("ts-secret")
+	secret := BuildTailscaleStateSecret(instance)
+
+	if secret.Name != TailscaleStateSecretName(instance) {
+		t.Errorf("secret name = %q, want %q", secret.Name, TailscaleStateSecretName(instance))
+	}
+	if secret.Namespace != instance.Namespace {
+		t.Errorf("secret namespace = %q, want %q", secret.Namespace, instance.Namespace)
+	}
+	if secret.Data != nil {
+		t.Error("state secret should have nil Data (containerboot manages content)")
+	}
+}
+
+func TestBuildStatefulSet_TailscaleAutoMountToken(t *testing.T) {
+	instance := newTestInstance("ts-automount")
+	instance.Spec.Tailscale.Enabled = true
+
+	sts := BuildStatefulSet(instance, "", nil)
+	token := sts.Spec.Template.Spec.AutomountServiceAccountToken
+	if token == nil || !*token {
+		t.Error("AutomountServiceAccountToken should be true when Tailscale is enabled")
+	}
+}
+
+func TestBuildServiceAccount_TailscaleAutoMountToken(t *testing.T) {
+	instance := newTestInstance("ts-sa-token")
+	instance.Spec.Tailscale.Enabled = true
+
+	sa := BuildServiceAccount(instance)
+	if sa.AutomountServiceAccountToken == nil || !*sa.AutomountServiceAccountToken {
+		t.Error("AutomountServiceAccountToken should be true when Tailscale is enabled")
+	}
+}
+
+func TestBuildRole_TailscaleStateSecretRule(t *testing.T) {
+	instance := newTestInstance("ts-role")
+	instance.Spec.Tailscale.Enabled = true
+
+	role := BuildRole(instance)
+
+	var found bool
+	for _, rule := range role.Rules {
+		for _, res := range rule.Resources {
+			if res == "secrets" {
+				for _, name := range rule.ResourceNames {
+					if name == TailscaleStateSecretName(instance) {
+						found = true
+						// Verify verbs
+						verbSet := make(map[string]bool)
+						for _, v := range rule.Verbs {
+							verbSet[v] = true
+						}
+						if !verbSet["get"] || !verbSet["update"] || !verbSet["patch"] {
+							t.Errorf("expected get/update/patch verbs, got %v", rule.Verbs)
+						}
+					}
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("Role should include a rule for the Tailscale state Secret")
+	}
+}
+
+func TestBuildRole_NoTailscaleRule_WhenDisabled(t *testing.T) {
+	instance := newTestInstance("no-ts-role")
+
+	role := BuildRole(instance)
+
+	for _, rule := range role.Rules {
+		for _, res := range rule.Resources {
+			if res == "secrets" {
+				for _, name := range rule.ResourceNames {
+					if name == TailscaleStateSecretName(instance) {
+						t.Error("Role should not include Tailscale state Secret rule when Tailscale is disabled")
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/internal/resources/secret.go
+++ b/internal/resources/secret.go
@@ -80,3 +80,18 @@ func BuildGatewayTokenSecret(instance *openclawv1alpha1.OpenClawInstance, tokenH
 		},
 	}
 }
+
+// BuildTailscaleStateSecret creates an empty Secret for Tailscale to persist
+// node identity and certificate state across pod restarts. The containerboot
+// process reads and writes state to this Secret via the Kubernetes API when
+// TS_KUBE_SECRET is set. This prevents hostname incrementing and Let's Encrypt
+// certificate re-issuance on every restart.
+func BuildTailscaleStateSecret(instance *openclawv1alpha1.OpenClawInstance) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TailscaleStateSecretName(instance),
+			Namespace: instance.Namespace,
+			Labels:    Labels(instance),
+		},
+	}
+}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -76,7 +76,7 @@ func BuildStatefulSet(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenS
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            ServiceAccountName(instance),
 					DeprecatedServiceAccount:      ServiceAccountName(instance),
-					AutomountServiceAccountToken:  Ptr(instance.Spec.SelfConfigure.Enabled),
+					AutomountServiceAccountToken:  Ptr(instance.Spec.SelfConfigure.Enabled || instance.Spec.Tailscale.Enabled),
 					SecurityContext:               buildPodSecurityContext(instance),
 					InitContainers:                buildInitContainers(instance, skillPacks),
 					Containers:                    buildContainers(instance, gwSecretName),
@@ -895,14 +895,11 @@ func buildTailscaleContainer(instance *openclawv1alpha1.OpenClawInstance) corev1
 		{Name: "TS_SOCKET", Value: TailscaleSocketPath},
 		{Name: "TS_SERVE_CONFIG", Value: "/etc/tailscale/serve/" + TailscaleServeConfigKey},
 		{Name: "TS_HOSTNAME", Value: hostname},
-		// Disable Kubernetes Secret-based state storage so containerboot
-		// does not try to create a kube client (which requires a service
-		// account token the pod intentionally does not mount).
-		{Name: "TS_KUBE_SECRET", Value: ""},
-		// Override the auto-injected KUBERNETES_SERVICE_HOST so containerboot
-		// does not attempt kube client init (tailscale/tailscale#8188).
-		// State is persisted to TS_STATE_DIR on the emptyDir volume instead.
-		{Name: "KUBERNETES_SERVICE_HOST", Value: ""},
+		// Persist Tailscale node identity and TLS certificates to a
+		// Kubernetes Secret so state survives pod restarts. This prevents
+		// hostname incrementing (device-1, device-2, ...) and Let's Encrypt
+		// certificate re-issuance on every restart.
+		{Name: "TS_KUBE_SECRET", Value: TailscaleStateSecretName(instance)},
 	}
 
 	// Inject TS_AUTHKEY from Secret

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -31,6 +31,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1150,6 +1151,60 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			}
 			Expect(foundSTUN).To(BeTrue(), "NetworkPolicy should have STUN egress (UDP 3478)")
 			Expect(foundWG).To(BeTrue(), "NetworkPolicy should have WireGuard egress (UDP 41641)")
+
+			// Verify Tailscale state Secret is created
+			tsStateSecret := &corev1.Secret{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.TailscaleStateSecretName(instance),
+					Namespace: namespace,
+				}, tsStateSecret)
+			}, timeout, interval).Should(Succeed())
+
+			// Verify TS_KUBE_SECRET env var points to the state Secret
+			var foundTSKubeSecret bool
+			for _, env := range tsSidecar.Env {
+				if env.Name == "TS_KUBE_SECRET" {
+					foundTSKubeSecret = true
+					Expect(env.Value).To(Equal(resources.TailscaleStateSecretName(instance)),
+						"TS_KUBE_SECRET should point to the state Secret")
+				}
+			}
+			Expect(foundTSKubeSecret).To(BeTrue(), "TS_KUBE_SECRET should be set on sidecar")
+
+			// Verify KUBERNETES_SERVICE_HOST is NOT set (containerboot needs kube API access)
+			for _, env := range tsSidecar.Env {
+				Expect(env.Name).NotTo(Equal("KUBERNETES_SERVICE_HOST"),
+					"KUBERNETES_SERVICE_HOST should not be set when using TS_KUBE_SECRET")
+			}
+
+			// Verify AutomountServiceAccountToken is enabled
+			Expect(statefulSet.Spec.Template.Spec.AutomountServiceAccountToken).NotTo(BeNil())
+			Expect(*statefulSet.Spec.Template.Spec.AutomountServiceAccountToken).To(BeTrue(),
+				"AutomountServiceAccountToken should be true when Tailscale is enabled")
+
+			// Verify Role includes Tailscale state Secret rule
+			role := &rbacv1.Role{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.RoleName(instance),
+					Namespace: namespace,
+				}, role)
+			}, timeout, interval).Should(Succeed())
+
+			var foundTSSecretRule bool
+			for _, rule := range role.Rules {
+				for _, res := range rule.Resources {
+					if res == "secrets" {
+						for _, name := range rule.ResourceNames {
+							if name == resources.TailscaleStateSecretName(instance) {
+								foundTSSecretRule = true
+							}
+						}
+					}
+				}
+			}
+			Expect(foundTSSecretRule).To(BeTrue(), "Role should include Tailscale state Secret rule")
 
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})


### PR DESCRIPTION
## Summary

- Switches Tailscale sidecar from ephemeral `emptyDir` state to **Kubernetes Secret-backed persistence** via `TS_KUBE_SECRET`, the idiomatic Tailscale-on-K8s approach
- Pre-creates an empty `<instance>-ts-state` Secret with owner reference (garbage-collected on CR deletion)
- Grants the pod's ServiceAccount `get/update/patch` on the state Secret and enables `AutomountServiceAccountToken`
- Removes `KUBERNETES_SERVICE_HOST=""` override so containerboot can talk to the kube API

This prevents **hostname incrementing** (device-1, device-2, ...) and **Let's Encrypt certificate re-issuance** on every pod restart.

Closes #262

## What changed

| File | Change |
|------|--------|
| `internal/resources/common.go` | Added `TailscaleStateSecretName()` helper |
| `internal/resources/secret.go` | Added `BuildTailscaleStateSecret()` builder |
| `internal/resources/rbac.go` | Enable SA token mount for Tailscale; add state Secret RBAC rule |
| `internal/resources/statefulset.go` | Set `TS_KUBE_SECRET` to state Secret name; remove `KUBERNETES_SERVICE_HOST=""` |
| `internal/controller/` | Added `reconcileTailscaleStateSecret()` using `CreateOrUpdate` |
| `api/v1alpha1/` | Added `TailscaleStateSecret` to `ManagedResourcesStatus` |
| CRD + Helm chart | Regenerated via `make manifests && make sync-chart-crds` |
| `README.md` + `docs/api-reference.md` | Documented state persistence behavior |

## Test plan

- [x] 6 new unit tests: state secret naming, builder, automount token (SA + pod), Role rules (enabled + disabled)
- [x] Updated existing `TestBuildStatefulSet_TailscaleSidecar` to verify `TS_KUBE_SECRET` value and absence of `KUBERNETES_SERVICE_HOST`
- [x] E2E assertions: state Secret creation, `TS_KUBE_SECRET` env var, no `KUBERNETES_SERVICE_HOST`, `AutomountServiceAccountToken`, Role rules
- [x] `make build && make lint` pass
- [x] Full `go test ./internal/resources/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)