### PR TITLE
fix: auto-inject 127.0.0.0/8 into gateway.trustedProxies

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -55,7 +55,7 @@ func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseCo
 		configBytes = []byte("{}")
 	}
 
-	// Enrichment pipeline: gateway auth -> device auth -> tailscale -> browser -> gateway bind -> skill packs
+	// Enrichment pipeline: gateway auth -> device auth -> tailscale -> browser -> gateway bind -> trusted proxies -> control UI origins -> skill packs
 	if gatewayToken != "" {
 		if enriched, err := enrichConfigWithGatewayAuth(configBytes, gatewayToken); err == nil {
 			configBytes = enriched
@@ -75,6 +75,9 @@ func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseCo
 		}
 	}
 	if enriched, err := enrichConfigWithGatewayBind(configBytes, instance); err == nil {
+		configBytes = enriched
+	}
+	if enriched, err := enrichConfigWithTrustedProxies(configBytes); err == nil {
 		configBytes = enriched
 	}
 	if enriched, err := enrichConfigWithControlUIOrigins(configBytes, instance); err == nil {
@@ -360,6 +363,44 @@ func enrichConfigWithGatewayBind(configJSON []byte, instance *openclawv1alpha1.O
 	}
 
 	gw["bind"] = GatewayBindLoopback
+	config["gateway"] = gw
+
+	return json.Marshal(config)
+}
+
+// enrichConfigWithTrustedProxies ensures 127.0.0.0/8 is present in
+// gateway.trustedProxies. The nginx proxy sidecar forwards all traffic from
+// 127.0.0.1, so the gateway must trust that CIDR to honor proxy headers
+// (X-Forwarded-For, etc.). Unlike other enrichments this merges with any
+// user-supplied entries rather than skipping when the field is already set.
+func enrichConfigWithTrustedProxies(configJSON []byte) ([]byte, error) {
+	const loopbackCIDR = "127.0.0.0/8"
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(configJSON, &config); err != nil {
+		return configJSON, nil // not a JSON object, return unchanged
+	}
+
+	gw, _ := config["gateway"].(map[string]interface{})
+	if gw == nil {
+		gw = make(map[string]interface{})
+	}
+
+	// Read existing trustedProxies (may be user-set)
+	var proxies []interface{}
+	if existing, ok := gw["trustedProxies"].([]interface{}); ok {
+		proxies = existing
+	}
+
+	// Check if loopback CIDR is already present
+	for _, p := range proxies {
+		if s, ok := p.(string); ok && s == loopbackCIDR {
+			return configJSON, nil
+		}
+	}
+
+	proxies = append(proxies, loopbackCIDR)
+	gw["trustedProxies"] = proxies
 	config["gateway"] = gw
 
 	return json.Marshal(config)

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2344,6 +2344,171 @@ func TestEnrichConfigWithDeviceAuth_InvalidJSON(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// enrichConfigWithTrustedProxies tests
+// ---------------------------------------------------------------------------
+
+func TestEnrichConfigWithTrustedProxies(t *testing.T) {
+	input := []byte(`{}`)
+	out, err := enrichConfigWithTrustedProxies(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	gw, ok := cfg["gateway"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway key")
+	}
+	proxies, ok := gw["trustedProxies"].([]interface{})
+	if !ok {
+		t.Fatal("expected gateway.trustedProxies array")
+	}
+	if len(proxies) != 1 || proxies[0] != "127.0.0.0/8" {
+		t.Errorf("gateway.trustedProxies = %v, want [127.0.0.0/8]", proxies)
+	}
+}
+
+func TestEnrichConfigWithTrustedProxies_MergesWithUserEntries(t *testing.T) {
+	input := []byte(`{"gateway":{"trustedProxies":["10.0.0.0/8"]}}`)
+	out, err := enrichConfigWithTrustedProxies(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	gw := cfg["gateway"].(map[string]interface{})
+	proxies := gw["trustedProxies"].([]interface{})
+	if len(proxies) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(proxies), proxies)
+	}
+	if proxies[0] != "10.0.0.0/8" {
+		t.Errorf("proxies[0] = %v, want 10.0.0.0/8", proxies[0])
+	}
+	if proxies[1] != "127.0.0.0/8" {
+		t.Errorf("proxies[1] = %v, want 127.0.0.0/8", proxies[1])
+	}
+}
+
+func TestEnrichConfigWithTrustedProxies_SkipsIfAlreadyPresent(t *testing.T) {
+	input := []byte(`{"gateway":{"trustedProxies":["127.0.0.0/8","10.0.0.0/8"]}}`)
+	out, err := enrichConfigWithTrustedProxies(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	gw := cfg["gateway"].(map[string]interface{})
+	proxies := gw["trustedProxies"].([]interface{})
+	if len(proxies) != 2 {
+		t.Errorf("expected 2 entries (no duplicate), got %d: %v", len(proxies), proxies)
+	}
+}
+
+func TestEnrichConfigWithTrustedProxies_PreservesOtherFields(t *testing.T) {
+	input := []byte(`{"gateway":{"bind":"loopback","auth":{"mode":"token"}},"mcpServers":{}}`)
+	out, err := enrichConfigWithTrustedProxies(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	gw := cfg["gateway"].(map[string]interface{})
+	if gw["bind"] != "loopback" {
+		t.Errorf("gateway.bind should be preserved, got %v", gw["bind"])
+	}
+	if _, ok := gw["auth"].(map[string]interface{}); !ok {
+		t.Error("gateway.auth should be preserved")
+	}
+	if _, ok := cfg["mcpServers"]; !ok {
+		t.Error("mcpServers should be preserved")
+	}
+}
+
+func TestEnrichConfigWithTrustedProxies_InvalidJSON(t *testing.T) {
+	input := []byte(`not valid json`)
+	out, err := enrichConfigWithTrustedProxies(input)
+	if err != nil {
+		t.Fatal("should not error on invalid JSON")
+	}
+
+	if !bytes.Equal(out, input) {
+		t.Errorf("invalid JSON should be returned unchanged")
+	}
+}
+
+func TestBuildConfigMap_TrustedProxiesInjected(t *testing.T) {
+	instance := newTestInstance("cm-proxies-inject")
+	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{}`),
+		},
+	}
+
+	cm := BuildConfigMap(instance, "", nil)
+	content := cm.Data["openclaw.json"]
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	gw, ok := parsed["gateway"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway key")
+	}
+	proxies, ok := gw["trustedProxies"].([]interface{})
+	if !ok {
+		t.Fatal("expected gateway.trustedProxies")
+	}
+	if len(proxies) != 1 || proxies[0] != "127.0.0.0/8" {
+		t.Errorf("gateway.trustedProxies = %v, want [127.0.0.0/8]", proxies)
+	}
+}
+
+func TestBuildConfigMap_TrustedProxiesMergesWithUserConfig(t *testing.T) {
+	instance := newTestInstance("cm-proxies-merge")
+	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{"gateway":{"trustedProxies":["10.0.0.0/8"]}}`),
+		},
+	}
+
+	cm := BuildConfigMap(instance, "", nil)
+	content := cm.Data["openclaw.json"]
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	gw := parsed["gateway"].(map[string]interface{})
+	proxies := gw["trustedProxies"].([]interface{})
+	if len(proxies) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(proxies), proxies)
+	}
+	// User entry preserved, loopback appended
+	if proxies[0] != "10.0.0.0/8" || proxies[1] != "127.0.0.0/8" {
+		t.Errorf("gateway.trustedProxies = %v, want [10.0.0.0/8 127.0.0.0/8]", proxies)
+	}
+}
+
 func TestBuildConfigMap_RawConfig_GatewayBindInjected(t *testing.T) {
 	instance := newTestInstance("cm-bind-inject")
 	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{


### PR DESCRIPTION
## Summary
- Adds `enrichConfigWithTrustedProxies` to the config enrichment pipeline
- Ensures `127.0.0.0/8` is always present in `gateway.trustedProxies` since the nginx proxy sidecar forwards all traffic from `127.0.0.1`
- **Merges** with user-supplied entries rather than skipping when the field is set (unlike other enrichments) - the loopback CIDR is always required
- Deduplicates: skips injection if `127.0.0.0/8` is already present

Closes #274

## Test plan
- [x] `TestEnrichConfigWithTrustedProxies` - injects into empty config
- [x] `TestEnrichConfigWithTrustedProxies_MergesWithUserEntries` - appends to user-set proxies
- [x] `TestEnrichConfigWithTrustedProxies_SkipsIfAlreadyPresent` - no duplicate when user already includes it
- [x] `TestEnrichConfigWithTrustedProxies_PreservesOtherFields` - other config keys untouched
- [x] `TestEnrichConfigWithTrustedProxies_InvalidJSON` - graceful no-op on bad input
- [x] `TestBuildConfigMap_TrustedProxiesInjected` - full pipeline integration test
- [x] `TestBuildConfigMap_TrustedProxiesMergesWithUserConfig` - full pipeline merge test
- [ ] CI lint + test
- [ ] E2E (verifies ConfigMap content on real cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)