### PR TITLE
feat: idempotent ClawHub skill installs for persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ spec:
 
 ### Skill installation
 
-Install skills declaratively. The operator runs an init container that fetches each skill before the agent starts. Entries use ClawHub by default, or prefix with `npm:` to install from npmjs.com:
+Install skills declaratively. The operator runs an init container that fetches each skill before the agent starts. Entries use ClawHub by default, or prefix with `npm:` to install from npmjs.com. ClawHub installs are idempotent - if a skill is already installed (e.g., when using persistent storage), it is skipped rather than failing:
 
 ```yaml
 spec:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -82,7 +82,7 @@ spec:
 
 | Field    | Type       | Default | Description                                                                                       |
 |----------|------------|---------|---------------------------------------------------------------------------------------------------|
-| `skills` | `[]string` | --      | Skills to install. Three formats supported: ClawHub identifiers (e.g., `@anthropic/mcp-server-fetch`), npm packages with `npm:` prefix (e.g., `npm:@openclaw/matrix`), and GitHub-hosted skill packs with `pack:` prefix (e.g., `pack:openclaw-rocks/skills/image-gen`). npm lifecycle scripts are disabled for security. Max 20 items. |
+| `skills` | `[]string` | --      | Skills to install. Three formats supported: ClawHub identifiers (e.g., `@anthropic/mcp-server-fetch`), npm packages with `npm:` prefix (e.g., `npm:@openclaw/matrix`), and GitHub-hosted skill packs with `pack:` prefix (e.g., `pack:openclaw-rocks/skills/image-gen`). ClawHub installs are idempotent - already-installed skills are skipped gracefully, making restarts safe with persistent storage. npm lifecycle scripts are disabled for security. Max 20 items. |
 
 ```yaml
 spec:

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -4618,7 +4618,7 @@ func TestBuildInitScript_MergeMode_NoConfig(t *testing.T) {
 
 func TestParseSkillEntry_ClawHub(t *testing.T) {
 	got := parseSkillEntry("@anthropic/mcp-server-fetch")
-	want := "npx -y clawhub install '@anthropic/mcp-server-fetch'"
+	want := "_install_skill '@anthropic/mcp-server-fetch'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -4654,16 +4654,17 @@ func TestBuildSkillsScript_WithSkills(t *testing.T) {
 
 	script := BuildSkillsScript(instance)
 
-	// Skills should be sorted
-	lines := strings.Split(script, "\n")
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d: %q", len(lines), script)
+	if !strings.HasPrefix(script, "set -e\n") {
+		t.Error("script should start with set -e")
 	}
-	if lines[0] != "npx -y clawhub install '@anthropic/mcp-server-fetch'" {
-		t.Errorf("line 0: %q", lines[0])
+	if !strings.Contains(script, skillInstallWrapper) {
+		t.Error("script should contain the _install_skill wrapper")
 	}
-	if lines[1] != "npx -y clawhub install '@github/copilot-skill'" {
-		t.Errorf("line 1: %q", lines[1])
+	if !strings.Contains(script, "_install_skill '@anthropic/mcp-server-fetch'") {
+		t.Error("script should contain _install_skill for @anthropic/mcp-server-fetch")
+	}
+	if !strings.Contains(script, "_install_skill '@github/copilot-skill'") {
+		t.Error("script should contain _install_skill for @github/copilot-skill")
 	}
 }
 
@@ -4677,19 +4678,79 @@ func TestBuildSkillsScript_MixedPrefixes(t *testing.T) {
 
 	script := BuildSkillsScript(instance)
 
-	lines := strings.Split(script, "\n")
-	if len(lines) != 3 {
-		t.Fatalf("expected 3 lines, got %d: %q", len(lines), script)
+	if !strings.HasPrefix(script, "set -e\n") {
+		t.Error("script should start with set -e")
 	}
-	// Sorted: @anthropic/... < npm:@openclaw/... < npm:some-tool
-	if lines[0] != "npx -y clawhub install '@anthropic/mcp-server-fetch'" {
-		t.Errorf("line 0: %q", lines[0])
+	if !strings.Contains(script, skillInstallWrapper) {
+		t.Error("script should contain the _install_skill wrapper (has clawhub skills)")
 	}
-	if lines[1] != "cd /home/openclaw/.openclaw && npm install '@openclaw/matrix'" {
-		t.Errorf("line 1: %q", lines[1])
+	if !strings.Contains(script, "_install_skill '@anthropic/mcp-server-fetch'") {
+		t.Error("script should contain _install_skill for clawhub skill")
 	}
-	if lines[2] != "cd /home/openclaw/.openclaw && npm install 'some-tool'" {
-		t.Errorf("line 2: %q", lines[2])
+	if !strings.Contains(script, "cd /home/openclaw/.openclaw && npm install '@openclaw/matrix'") {
+		t.Error("script should contain npm install for @openclaw/matrix")
+	}
+	if !strings.Contains(script, "cd /home/openclaw/.openclaw && npm install 'some-tool'") {
+		t.Error("script should contain npm install for some-tool")
+	}
+}
+
+func TestBuildSkillsScript_OnlyNpmSkills_NoWrapper(t *testing.T) {
+	instance := newTestInstance("npm-only")
+	instance.Spec.Skills = []string{"npm:@openclaw/matrix", "npm:some-tool"}
+
+	script := BuildSkillsScript(instance)
+
+	if !strings.HasPrefix(script, "set -e\n") {
+		t.Error("script should start with set -e")
+	}
+	if strings.Contains(script, "_install_skill") {
+		t.Error("script should not contain _install_skill wrapper when only npm skills")
+	}
+	if !strings.Contains(script, "npm install") {
+		t.Error("script should contain npm install commands")
+	}
+}
+
+func TestHasClawHubSkills(t *testing.T) {
+	tests := []struct {
+		name   string
+		skills []string
+		want   bool
+	}{
+		{"empty", nil, false},
+		{"only npm", []string{"npm:foo", "npm:bar"}, false},
+		{"only clawhub", []string{"@anthropic/mcp-server-fetch"}, true},
+		{"mixed", []string{"npm:foo", "@anthropic/mcp-server-fetch"}, true},
+		{"only packs", []string{"pack:owner/repo/path"}, true}, // pack: is not npm:, so true
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasClawHubSkills(tt.skills); got != tt.want {
+				t.Errorf("hasClawHubSkills(%v) = %v, want %v", tt.skills, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSkillsScript_WrapperOrdering(t *testing.T) {
+	instance := newTestInstance("ordering")
+	instance.Spec.Skills = []string{"@anthropic/mcp-server-fetch"}
+
+	script := BuildSkillsScript(instance)
+
+	setEIdx := strings.Index(script, "set -e")
+	wrapperIdx := strings.Index(script, "_install_skill()")
+	installIdx := strings.Index(script, "_install_skill '@anthropic/mcp-server-fetch'")
+
+	if setEIdx == -1 || wrapperIdx == -1 || installIdx == -1 {
+		t.Fatalf("missing expected content in script:\n%s", script)
+	}
+	if setEIdx >= wrapperIdx {
+		t.Error("set -e must come before the wrapper function")
+	}
+	if wrapperIdx >= installIdx {
+		t.Error("wrapper function must come before install commands")
 	}
 }
 

--- a/internal/resources/skillpacks_test.go
+++ b/internal/resources/skillpacks_test.go
@@ -106,8 +106,8 @@ func TestBuildSkillsScript_FiltersPackEntries(t *testing.T) {
 	if !strings.Contains(script, "npm install") {
 		t.Error("script should contain npm install for @openclaw/matrix")
 	}
-	if !strings.Contains(script, "clawhub install") {
-		t.Error("script should contain clawhub install for @anthropic/mcp-server-fetch")
+	if !strings.Contains(script, "_install_skill") {
+		t.Error("script should contain _install_skill for @anthropic/mcp-server-fetch")
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -680,14 +680,40 @@ func BuildInitScript(instance *openclawv1alpha1.OpenClawInstance, skillPacks *Re
 	return strings.Join(lines, "\n")
 }
 
+// skillInstallWrapper is a shell function that wraps `clawhub install` to
+// tolerate "Already installed" errors, making the init container idempotent
+// when persistent storage is enabled (#258).
+const skillInstallWrapper = `_install_skill() {
+  local output
+  if output=$(npx -y clawhub install "$1" 2>&1); then
+    echo "$output"
+  elif echo "$output" | grep -q 'Already installed'; then
+    echo "Skill $1 already installed, skipping"
+  else
+    echo "$output" >&2
+    return 1
+  fi
+}`
+
 // parseSkillEntry returns the shell command to install a single skill entry.
 // Entries prefixed with "npm:" are installed via `npm install` into the PVC
-// node_modules. All other entries use `npx -y clawhub install`.
+// node_modules. All other entries use the _install_skill wrapper around
+// `npx -y clawhub install`.
 func parseSkillEntry(entry string) string {
 	if pkg, ok := strings.CutPrefix(entry, "npm:"); ok {
 		return fmt.Sprintf("cd /home/openclaw/.openclaw && npm install %s", shellQuote(pkg))
 	}
-	return fmt.Sprintf("npx -y clawhub install %s", shellQuote(entry))
+	return fmt.Sprintf("_install_skill %s", shellQuote(entry))
+}
+
+// hasClawHubSkills returns true if any entry is a ClawHub skill (not npm-prefixed).
+func hasClawHubSkills(skills []string) bool {
+	for _, s := range skills {
+		if !strings.HasPrefix(s, "npm:") {
+			return true
+		}
+	}
+	return false
 }
 
 // BuildSkillsScript generates the shell script for the skills init container.
@@ -705,6 +731,10 @@ func BuildSkillsScript(instance *openclawv1alpha1.OpenClawInstance) string {
 	sort.Strings(skills)
 
 	var lines []string
+	lines = append(lines, "set -e")
+	if hasClawHubSkills(skills) {
+		lines = append(lines, skillInstallWrapper)
+	}
 	for _, skill := range skills {
 		lines = append(lines, parseSkillEntry(skill))
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1703,8 +1703,8 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(script).To(ContainSubstring("npm install '@openclaw/matrix'"),
 				"npm: prefixed skill should use npm install")
 			// Script should also contain clawhub for non-prefixed skill
-			Expect(script).To(ContainSubstring("clawhub install '@anthropic/mcp-server-fetch'"),
-				"non-prefixed skill should use clawhub install")
+			Expect(script).To(ContainSubstring("_install_skill '@anthropic/mcp-server-fetch'"),
+				"non-prefixed skill should use _install_skill wrapper")
 
 			// NPM_CONFIG_IGNORE_SCRIPTS should be set (#91)
 			envMap := map[string]string{}


### PR DESCRIPTION
 ## Problem

When persistent storage is enabled, the \`init-skills\` container fails on pod restart because \`clawhub install\` exits non-zero for already-installed skills. This also affects skills flagged as suspicious by VirusTotal, which require \`--force\` in non-interactive mode.

## Solution

Wraps \`clawhub install\` in a shell function (\`_install_skill\`) that captures output and:

  - Succeeds normally on fresh installs
  - Detects \"Already installed\" in stderr and skips gracefully
  - Fails on any other error, preserving the original output

The wrapper is only included when the skills list contains ClawHub entries - npm-only lists are unaffected. The generated script also now starts with \`set -e\` for fail-fast behaviour.

## Changes

  - \`internal/resources/statefulset.go\` - added \`skillInstallWrapper\`, \`hasClawHubSkills()\`, updated \`parseSkillEntry()\` and \`BuildSkillsScript()\`
  - \`internal/resources/resources_test.go\` - added \`TestHasClawHubSkills\` (table-driven), \`TestBuildSkillsScript_WrapperOrdering\`, updated existing assertions
  - \`internal/resources/skillpacks_test.go\` - updated assertions
  - \`test/e2e/e2e_suite_test.go\` - updated e2e assertions
  - \`README.md\` + \`docs/api-reference.md\` - documented idempotent behaviour

## Note
First-time contributor - apologies if anything is off!

Fixes #258 

Hoping to see any failures in the e2e tests running in the CI. 