### PR TITLE
fix: increase chromium startup probe timeout to 5s

### DIFF
--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1321,7 +1321,7 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 			PeriodSeconds:       2,
 			FailureThreshold:    15,
 			SuccessThreshold:    1,
-			TimeoutSeconds:      2,
+			TimeoutSeconds:      5,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- Increases chromium sidecar startup probe `TimeoutSeconds` from 2s to 5s
- Fixes race condition where OpenClaw's CDP health check fails because the Service has no Ready endpoints during startup

## Problem

Browserless v2.42.0 launches a full Chrome process on the first `/json/version` request (~3s), then caches the result. With the previous 2s probe timeout:

1. First startup probe times out (3s response > 2s timeout)
2. Multiple probe cycles needed before one succeeds
3. Pod stays not-Ready during this window
4. ClusterIP Service has no endpoints
5. OpenClaw starts faster, tries to reach CDP via Service DNS, gets connection refused
6. `cdpHttp: false` permanently, all browser operations fail

With 5s timeout, the probe passes on the first attempt, the pod becomes Ready faster, and the Service DNS is available before OpenClaw checks.

## Test plan

- [x] `go test ./internal/resources/ -count=1` passes
- [ ] Deploy and verify browser works with browserless v2.42.0

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)