### PR TITLE
fix: add K8s API port 6443 egress when tailscale is enabled

### DIFF
--- a/internal/resources/networkpolicy.go
+++ b/internal/resources/networkpolicy.go
@@ -182,9 +182,11 @@ func buildEgressRules(instance *openclawv1alpha1.OpenClawInstance) []networkingv
 		},
 	})
 
-	// Allow K8s API server egress when self-configure is enabled (port 6443
-	// covers clusters with non-standard API server ports; 443 is already allowed above)
-	if instance.Spec.SelfConfigure.Enabled {
+	// Allow K8s API server egress when self-configure or tailscale is enabled.
+	// Port 6443 covers clusters where the API server listens on a non-standard
+	// port (e.g., K3s DNATs 443 -> 6443 before NetworkPolicy evaluation).
+	// Tailscale needs this to manage its state secret via the K8s API.
+	if instance.Spec.SelfConfigure.Enabled || instance.Spec.Tailscale.Enabled {
 		rules = append(rules, networkingv1.NetworkPolicyEgressRule{
 			To: []networkingv1.NetworkPolicyPeer{},
 			Ports: []networkingv1.NetworkPolicyPort{

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -6555,27 +6555,36 @@ func TestBuildNetworkPolicy_TailscaleEgress(t *testing.T) {
 
 	np := BuildNetworkPolicy(instance)
 
-	// Default egress: DNS (0), HTTPS (1), Tailscale STUN+WireGuard (2)
-	if len(np.Spec.Egress) < 3 {
-		t.Fatalf("expected at least 3 egress rules, got %d", len(np.Spec.Egress))
+	// Default egress: DNS (0), HTTPS (1), K8s API 6443 (2), Tailscale STUN+WireGuard (3)
+	if len(np.Spec.Egress) < 4 {
+		t.Fatalf("expected at least 4 egress rules, got %d", len(np.Spec.Egress))
 	}
 
-	tsRule := np.Spec.Egress[2]
-	if len(tsRule.Ports) != 2 {
-		t.Fatalf("expected 2 Tailscale egress ports, got %d", len(tsRule.Ports))
-	}
-
+	// Verify K8s API port 6443 is included (tailscale needs it for state secret)
+	found6443 := false
 	foundSTUN := false
 	foundWG := false
-	for _, p := range tsRule.Ports {
-		if p.Protocol != nil && *p.Protocol == corev1.ProtocolUDP && p.Port != nil {
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			if p.Port == nil {
+				continue
+			}
 			switch p.Port.IntValue() {
+			case 6443:
+				found6443 = true
 			case 3478:
-				foundSTUN = true
+				if p.Protocol != nil && *p.Protocol == corev1.ProtocolUDP {
+					foundSTUN = true
+				}
 			case 41641:
-				foundWG = true
+				if p.Protocol != nil && *p.Protocol == corev1.ProtocolUDP {
+					foundWG = true
+				}
 			}
 		}
+	}
+	if !found6443 {
+		t.Error("expected K8s API egress rule (TCP 6443) for tailscale state secret")
 	}
 	if !foundSTUN {
 		t.Error("expected STUN egress rule (UDP 3478)")
@@ -8032,13 +8041,14 @@ func TestBuildNetworkPolicy_SelfConfigureEgress(t *testing.T) {
 
 func TestBuildNetworkPolicy_SelfConfigureDisabledNo6443(t *testing.T) {
 	instance := newTestInstance("sc-netpol-off")
+	// Both selfConfigure and tailscale are disabled by default
 
 	np := BuildNetworkPolicy(instance)
 
 	for _, rule := range np.Spec.Egress {
 		for _, port := range rule.Ports {
 			if port.Port != nil && port.Port.IntValue() == 6443 {
-				t.Error("NetworkPolicy should NOT have port 6443 when self-configure is disabled")
+				t.Error("NetworkPolicy should NOT have port 6443 when both self-configure and tailscale are disabled")
 			}
 		}
 	}


### PR DESCRIPTION
Since #265 introduced \`TS_KUBE_SECRET\` for persistent tailscale state, the sidecar needs K8s API access to manage its state secret. Previously \`KUBERNETES_SERVICE_HOST\` was blanked out and no API access was needed.

The operator-generated NetworkPolicy allows egress on port 443, but on K3s (and potentially other distributions), the \`kubernetes\` ClusterIP service (10.43.0.1:443) is DNATed to the actual API server endpoint on port 6443 **before** NetworkPolicy evaluation. The tailscale container gets connection refused and CrashLoops:

```
  error setting up for running on Kubernetes: getting Tailscale state Secret <name>-ts-state:
    dial tcp 10.43.0.1:443: connect: connection refused
```

## Solution
The operator already injects a port 6443 egress rule when \`selfConfigure.enabled: true\`. This broadens the condition to also trigger when \`tailscale.enabled: true\`, since the sidecar now needs the same K8s API access for secret management.

## Workaround (pre-fix)

```yaml
  security:
    networkPolicy:
      additionalEgress:
        - ports:
            - port: 6443
              protocol: TCP
 ```

Verified: fix applied to cluster, gateway running 5/5 with 0 restarts.

Fixes #282 