### PR TITLE
fix: inject POD_NAMESPACE env via Downward API

### DIFF
--- a/charts/openclaw-operator/templates/deployment.yaml
+++ b/charts/openclaw-operator/templates/deployment.yaml
@@ -51,6 +51,11 @@ spec:
             {{- else }}
             - --metrics-bind-address=0
             {{- end }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,6 +40,11 @@ spec:
             - --health-probe-bind-address=:8081
           image: controller:latest
           name: manager
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
## Summary

- Adds `POD_NAMESPACE` env var to the operator's Deployment using the Kubernetes Downward API (`fieldRef: metadata.namespace`) in both the Helm chart and kustomize manifests
- Without this, the operator falls back to the hardcoded `"openclaw-operator-system"` default, causing S3 backup credential lookups to fail when installed in a custom namespace

## Test plan

- [ ] `helm template` renders the env var correctly (verified locally)
- [ ] CI: lint, unit tests, e2e pass
- [ ] Deploy operator to a non-default namespace and verify backup CronJob creation finds the S3 secret

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)