### PR TITLE
fix: add deadline safeguards to backup CronJob

### DIFF
--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -296,7 +296,9 @@ func buildBackupCronJob(
 	}
 
 	backoffLimit := int32(3)
-	ttl := int32(86400) // 24h
+	ttl := int32(86400)            // 24h
+	activeDeadline := int64(3600)  // 1h - kill stuck backup Jobs
+	startingDeadline := int64(600) // 10m - skip missed runs rather than firing all at once
 	gracePeriod := int64(30)
 
 	// Shell command: compute timestamped S3 path and run rclone sync
@@ -321,6 +323,7 @@ func buildBackupCronJob(
 		Spec: batchv1.CronJobSpec{
 			Schedule:                   instance.Spec.Backup.Schedule,
 			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
+			StartingDeadlineSeconds:    &startingDeadline,
 			SuccessfulJobsHistoryLimit: &historyLimit,
 			FailedJobsHistoryLimit:     &failedHistoryLimit,
 			JobTemplate: batchv1.JobTemplateSpec{
@@ -328,6 +331,7 @@ func buildBackupCronJob(
 					Labels: labels,
 				},
 				Spec: batchv1.JobSpec{
+					ActiveDeadlineSeconds:   &activeDeadline,
 					BackoffLimit:            &backoffLimit,
 					TTLSecondsAfterFinished: &ttl,
 					Template: corev1.PodTemplateSpec{

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -424,5 +424,17 @@ var _ = Describe("S3 Helpers", func() {
 			Expect(container.TerminationMessagePath).To(Equal("/dev/termination-log"))
 			Expect(container.TerminationMessagePolicy).To(Equal(corev1.TerminationMessageReadFile))
 		})
+
+		It("Should set activeDeadlineSeconds on the Job to kill stuck backups", func() {
+			cronJob := buildBackupCronJob(instance, creds)
+			Expect(cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds).NotTo(BeNil())
+			Expect(*cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds).To(Equal(int64(3600)))
+		})
+
+		It("Should set startingDeadlineSeconds on the CronJob to skip stale runs", func() {
+			cronJob := buildBackupCronJob(instance, creds)
+			Expect(cronJob.Spec.StartingDeadlineSeconds).NotTo(BeNil())
+			Expect(*cronJob.Spec.StartingDeadlineSeconds).To(Equal(int64(600)))
+		})
 	})
 })

--- a/test/e2e/e2e_backup_cronjob_test.go
+++ b/test/e2e/e2e_backup_cronjob_test.go
@@ -127,6 +127,10 @@ var _ = Describe("Periodic Backup CronJob", func() {
 
 			Expect(cronJob.Spec.Schedule).To(Equal("0 2 * * *"))
 			Expect(cronJob.Spec.ConcurrencyPolicy).To(Equal(batchv1.ForbidConcurrent))
+			Expect(cronJob.Spec.StartingDeadlineSeconds).NotTo(BeNil())
+			Expect(*cronJob.Spec.StartingDeadlineSeconds).To(Equal(int64(600)))
+			Expect(cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds).NotTo(BeNil())
+			Expect(*cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds).To(Equal(int64(3600)))
 
 			// Verify ScheduledBackupReady condition
 			Eventually(func() bool {


### PR DESCRIPTION
## Summary

- Adds `activeDeadlineSeconds: 3600` (1h) to the backup Job spec - automatically kills Jobs that hang due to volume contention, S3 timeouts, or scheduling issues
- Adds `startingDeadlineSeconds: 600` (10m) to the CronJob spec - skips missed runs rather than firing all at once after controller downtime
- The existing `concurrencyPolicy: Forbid` and history limits were already in place

Without these, stuck backup Jobs accumulate over time and can block the main StatefulSet pod from starting due to RWO volume contention (Multi-Attach errors).

## Test plan

- [ ] CI: unit tests verify both new fields are set with correct values
- [ ] CI: e2e test verifies `startingDeadlineSeconds` and `activeDeadlineSeconds` on a real cluster
- [ ] Existing backup CronJob tests continue to pass

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)