### PR TITLE
ci: speed up PR builds by ~15min

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,7 +152,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # Only build arm64 on main (where we push). PRs only need amd64 to
+          # verify the build -- arm64 cross-compilation via QEMU adds ~15 min.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -161,7 +163,7 @@ jobs:
 
   e2e:
     name: E2E Tests
-    needs: build
+    needs: [lint, test, security-scan]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- **Build job**: Skip arm64 QEMU cross-compilation on PRs (amd64 only). The image is never pushed on PRs, so arm64 was ~15min of wasted compute. Main branch still builds both architectures.
- **E2E job**: Depend on `[lint, test, security-scan]` instead of `build`. E2E builds its own single-arch image anyway (`docker build` on line 184), so it was blocked on the multi-arch build for no reason.

### Before
```
lint ──┐
test ──┼── build (20min, multi-arch QEMU) ── e2e (6min)
scan ──┘
```
Total wall time: ~26min

### After
```
lint ──┐
test ──┼── build (5min, amd64 only on PRs)
scan ──┼── e2e (6min)  ← runs in parallel with build
       └──
```
Total wall time: ~8-10min

## Test plan

- [ ] This PR's own CI run validates the changes work (meta!)
- [ ] Verify main branch pushes still build both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)