### PR TITLE
fix: resolve chromium sidecar startup race and NetworkPolicy gaps

### DIFF
--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -413,6 +413,11 @@ func (r *OpenClawInstanceReconciler) reconcileResources(ctx context.Context, ins
 	}
 	logger.V(1).Info("Service reconciled")
 
+	// 7b. Reconcile Chromium CDP headless Service (if chromium is enabled)
+	if err := r.reconcileChromiumCDPService(ctx, instance); err != nil {
+		return fmt.Errorf("failed to reconcile Chromium CDP Service: %w", err)
+	}
+
 	// 8. Reconcile Ingress (if enabled)
 	if err := r.reconcileIngress(ctx, instance); err != nil {
 		return fmt.Errorf("failed to reconcile Ingress: %w", err)
@@ -1095,6 +1100,32 @@ func (r *OpenClawInstanceReconciler) reconcileService(ctx context.Context, insta
 		Reason:  "ServiceCreated",
 		Message: "Service created successfully",
 	})
+
+	return nil
+}
+
+// reconcileChromiumCDPService reconciles the headless Service used for the
+// Chromium CDP endpoint. When chromium is disabled, the Service is deleted.
+func (r *OpenClawInstanceReconciler) reconcileChromiumCDPService(ctx context.Context, instance *openclawv1alpha1.OpenClawInstance) error {
+	svc := &corev1.Service{}
+	svc.Name = resources.ChromiumCDPServiceName(instance)
+	svc.Namespace = instance.Namespace
+
+	if !instance.Spec.Chromium.Enabled {
+		if err := r.Delete(ctx, svc); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, svc, func() error {
+		desired := resources.BuildChromiumCDPService(instance)
+		svc.Labels = desired.Labels
+		svc.Spec = desired.Spec
+		return controllerutil.SetControllerReference(instance, svc, r.Scheme)
+	}); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -152,6 +152,14 @@ func ServiceName(instance *openclawv1alpha1.OpenClawInstance) string {
 	return instance.Name
 }
 
+// ChromiumCDPServiceName returns the name of the headless Service used for
+// the Chromium CDP endpoint. A separate headless Service with
+// publishNotReadyAddresses is needed so the CDP URL resolves before the pod
+// is fully Ready (the main container may still be starting).
+func ChromiumCDPServiceName(instance *openclawv1alpha1.OpenClawInstance) string {
+	return instance.Name + "-cdp"
+}
+
 // ServiceAccountName returns the name of the ServiceAccount
 func ServiceAccountName(instance *openclawv1alpha1.OpenClawInstance) string {
 	if instance.Spec.Security.RBAC.ServiceAccountName != "" {

--- a/internal/resources/networkpolicy.go
+++ b/internal/resources/networkpolicy.go
@@ -93,6 +93,13 @@ func networkPolicyIngressPorts(instance *openclawv1alpha1.OpenClawInstance) []ne
 		})
 	}
 
+	if instance.Spec.Chromium.Enabled {
+		ports = append(ports, networkingv1.NetworkPolicyPort{
+			Protocol: Ptr(corev1.ProtocolTCP),
+			Port:     Ptr(intstr.FromInt32(int32(ChromiumPort))),
+		})
+	}
+
 	return ports
 }
 
@@ -210,6 +217,29 @@ func buildEgressRules(instance *openclawv1alpha1.OpenClawInstance) []networkingv
 				{
 					Protocol: Ptr(corev1.ProtocolUDP),
 					Port:     Ptr(intstr.FromInt(41641)),
+				},
+			},
+		})
+	}
+
+	// Allow egress to the Chromium CDP sidecar (port 9222). The main container
+	// reaches the sidecar via a headless Service that resolves to the pod's own
+	// IP. CNIs that strictly enforce NetworkPolicy on hairpin/self traffic
+	// (e.g. Calico) need this rule; Cilium short-circuits self-traffic and
+	// doesn't require it, but it's correct to include for portability.
+	if instance.Spec.Chromium.Enabled {
+		rules = append(rules, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{
+				{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: SelectorLabels(instance),
+					},
+				},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Protocol: Ptr(corev1.ProtocolTCP),
+					Port:     Ptr(intstr.FromInt32(int32(ChromiumPort))),
 				},
 			},
 		})

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -430,30 +430,36 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 
 	sts := BuildStatefulSet(instance, "", nil)
 	containers := sts.Spec.Template.Spec.Containers
+	initContainers := sts.Spec.Template.Spec.InitContainers
 
-	if len(containers) != 3 {
-		t.Fatalf("expected 3 containers (main + gateway-proxy + chromium), got %d", len(containers))
+	if len(containers) != 2 {
+		t.Fatalf("expected 2 containers (main + gateway-proxy), got %d", len(containers))
 	}
 
-	// Find chromium container
+	// Find chromium in init containers (native sidecar)
 	var chromium *corev1.Container
-	for i := range containers {
-		if containers[i].Name == "chromium" {
-			chromium = &containers[i]
+	for i := range initContainers {
+		if initContainers[i].Name == "chromium" {
+			chromium = &initContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 
-	// Main container should have OPENCLAW_CHROMIUM_CDP using service DNS name
+	// Native sidecar: RestartPolicy must be Always
+	if chromium.RestartPolicy == nil || *chromium.RestartPolicy != corev1.ContainerRestartPolicyAlways {
+		t.Errorf("chromium RestartPolicy = %v, want Always (native sidecar)", chromium.RestartPolicy)
+	}
+
+	// Main container should have OPENCLAW_CHROMIUM_CDP using CDP service DNS name
 	mainContainer := containers[0]
 	foundChromiumCDP := false
 	for _, env := range mainContainer.Env {
 		if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 			foundChromiumCDP = true
-			expected := fmt.Sprintf("http://%s.%s.svc:%d", instance.Name, instance.Namespace, ChromiumPort)
+			expected := fmt.Sprintf("http://%s-cdp.%s.svc:%d", instance.Name, instance.Namespace, ChromiumPort)
 			if env.Value != expected {
 				t.Errorf("OPENCLAW_CHROMIUM_CDP = %q, want %q", env.Value, expected)
 			}
@@ -567,16 +573,11 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 		t.Error("chromium-data should be emptyDir when persistence is disabled")
 	}
 
-	// Without persistence, --user-data-dir should NOT be in launch args
-	var launchArgs string
+	// DEFAULT_LAUNCH_ARGS should not exist anymore
 	for _, env := range chromium.Env {
 		if env.Name == "DEFAULT_LAUNCH_ARGS" {
-			launchArgs = env.Value
-			break
+			t.Error("DEFAULT_LAUNCH_ARGS env var should not be set on chromium container")
 		}
-	}
-	if strings.Contains(launchArgs, "--user-data-dir") {
-		t.Error("--user-data-dir should not be set when persistence is disabled")
 	}
 }
 
@@ -591,34 +592,26 @@ func TestBuildStatefulSet_ChromiumExtraArgs(t *testing.T) {
 	sts := BuildStatefulSet(instance, "", nil)
 
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 
-	// ExtraArgs must NOT be set as container Args - that overwrites the image CMD
-	// and causes the first flag to be executed as a binary (issue #209).
+	// ExtraArgs must NOT be set as container Args
 	if len(chromium.Args) != 0 {
-		t.Errorf("expected no container Args (ExtraArgs must use DEFAULT_LAUNCH_ARGS env), got %v", chromium.Args)
+		t.Errorf("expected no container Args, got %v", chromium.Args)
 	}
 
-	// ExtraArgs must be encoded as DEFAULT_LAUNCH_ARGS JSON env var for browserless v2
-	// Default anti-bot-detection flags are prepended, then user ExtraArgs appended
-	var launchArgs string
+	// DEFAULT_LAUNCH_ARGS no longer exists; ExtraArgs are currently not applied (TODO)
 	for _, env := range chromium.Env {
 		if env.Name == "DEFAULT_LAUNCH_ARGS" {
-			launchArgs = env.Value
-			break
+			t.Error("DEFAULT_LAUNCH_ARGS env var should not be set on chromium container")
 		}
-	}
-	const wantLaunchArgs = `["--disable-blink-features=AutomationControlled","--disable-features=AutomationControlled","--no-first-run","--window-size=1920,1080","--user-agent=CustomAgent/1.0"]`
-	if launchArgs != wantLaunchArgs {
-		t.Errorf("DEFAULT_LAUNCH_ARGS = %q, want %q", launchArgs, wantLaunchArgs)
 	}
 }
 
@@ -633,14 +626,14 @@ func TestBuildStatefulSet_ChromiumExtraEnv(t *testing.T) {
 	sts := BuildStatefulSet(instance, "", nil)
 
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 
 	// Operator-managed PORT env must still be present
@@ -677,34 +670,28 @@ func TestBuildStatefulSet_ChromiumExtraEnv(t *testing.T) {
 func TestBuildStatefulSet_ChromiumNoExtraArgs(t *testing.T) {
 	instance := newTestInstance("chromium-no-args")
 	instance.Spec.Chromium.Enabled = true
-	// ExtraArgs not set - DEFAULT_LAUNCH_ARGS should still contain anti-bot defaults
+	// ExtraArgs not set - DEFAULT_LAUNCH_ARGS should not exist
 
 	sts := BuildStatefulSet(instance, "", nil)
 
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 
 	if len(chromium.Args) != 0 {
 		t.Errorf("expected no container Args, got %v", chromium.Args)
 	}
-	var launchArgs string
 	for _, env := range chromium.Env {
 		if env.Name == "DEFAULT_LAUNCH_ARGS" {
-			launchArgs = env.Value
-			break
+			t.Error("DEFAULT_LAUNCH_ARGS env var should not be set on chromium container")
 		}
-	}
-	const wantDefaults = `["--disable-blink-features=AutomationControlled","--disable-features=AutomationControlled","--no-first-run"]`
-	if launchArgs != wantDefaults {
-		t.Errorf("DEFAULT_LAUNCH_ARGS = %q, want %q", launchArgs, wantDefaults)
 	}
 }
 
@@ -1168,14 +1155,14 @@ func TestBuildStatefulSet_ChromiumCustomImage(t *testing.T) {
 
 	sts := BuildStatefulSet(instance, "", nil)
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 	if chromium.Image != "my-registry.io/chromium:v120" {
 		t.Errorf("chromium image = %q, want %q", chromium.Image, "my-registry.io/chromium:v120")
@@ -1193,14 +1180,14 @@ func TestBuildStatefulSet_ChromiumDigest(t *testing.T) {
 
 	sts := BuildStatefulSet(instance, "", nil)
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 	expected := "my-registry.io/chromium@sha256:chromiumhash"
 	if chromium.Image != expected {
@@ -3771,14 +3758,14 @@ func TestBuildStatefulSet_ChromiumCustomResources(t *testing.T) {
 
 	sts := BuildStatefulSet(instance, "", nil)
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 
 	cpuReq := chromium.Resources.Requests[corev1.ResourceCPU]
@@ -4022,18 +4009,25 @@ func TestBuildStatefulSet_InitContainerDefaults(t *testing.T) {
 	}
 }
 
-// TestBuildStatefulSet_ChromiumContainerDefaults verifies the chromium sidecar
+// TestBuildStatefulSet_ChromiumContainerDefaults verifies the chromium native sidecar
 // includes Kubernetes default fields.
 func TestBuildStatefulSet_ChromiumContainerDefaults(t *testing.T) {
 	instance := newTestInstance("chromium-defaults")
 	instance.Spec.Chromium.Enabled = true
 
 	sts := BuildStatefulSet(instance, "", nil)
-	if len(sts.Spec.Template.Spec.Containers) < 2 {
-		t.Fatal("expected chromium sidecar container")
+
+	var chromium *corev1.Container
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
+			break
+		}
+	}
+	if chromium == nil {
+		t.Fatal("chromium init container not found")
 	}
 
-	chromium := sts.Spec.Template.Spec.Containers[1]
 	if chromium.TerminationMessagePath != corev1.TerminationMessagePathDefault {
 		t.Errorf("chromium TerminationMessagePath = %q, want %q", chromium.TerminationMessagePath, corev1.TerminationMessagePathDefault)
 	}
@@ -4061,27 +4055,30 @@ func TestBuildStatefulSet_ChromiumPersistenceEnabled(t *testing.T) {
 		t.Errorf("PVC claim name = %q, want %q", dataVol.PersistentVolumeClaim.ClaimName, "chromium-persist-chromium-data")
 	}
 
-	// --user-data-dir should be in DEFAULT_LAUNCH_ARGS
+	// DATA_DIR env var should be set to /chromium-data when persistence is enabled
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 
-	var launchArgs string
+	foundDataDir := false
 	for _, env := range chromium.Env {
-		if env.Name == "DEFAULT_LAUNCH_ARGS" {
-			launchArgs = env.Value
+		if env.Name == "DATA_DIR" {
+			foundDataDir = true
+			if env.Value != "/chromium-data" {
+				t.Errorf("DATA_DIR = %q, want %q", env.Value, "/chromium-data")
+			}
 			break
 		}
 	}
-	if !strings.Contains(launchArgs, "--user-data-dir=/chromium-data") {
-		t.Errorf("DEFAULT_LAUNCH_ARGS should contain --user-data-dir=/chromium-data, got %q", launchArgs)
+	if !foundDataDir {
+		t.Error("DATA_DIR env var should be set to /chromium-data when persistence is enabled")
 	}
 
 	// Volume mount should exist
@@ -5711,16 +5708,16 @@ func TestBuildStatefulSet_CABundle_WithChromium(t *testing.T) {
 
 	sts := BuildStatefulSet(instance, "", nil)
 
-	// Find chromium container
+	// Find chromium in init containers (native sidecar)
 	var chromium *corev1.Container
-	for i := range sts.Spec.Template.Spec.Containers {
-		if sts.Spec.Template.Spec.Containers[i].Name == "chromium" {
-			chromium = &sts.Spec.Template.Spec.Containers[i]
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+			chromium = &sts.Spec.Template.Spec.InitContainers[i]
 			break
 		}
 	}
 	if chromium == nil {
-		t.Fatal("chromium container not found")
+		t.Fatal("chromium init container not found")
 	}
 
 	// Check mount
@@ -7758,9 +7755,10 @@ func TestBuildStatefulSet_OllamaAndChromiumEnabled(t *testing.T) {
 
 	sts := BuildStatefulSet(instance, "", nil)
 	containers := sts.Spec.Template.Spec.Containers
+	initContainers := sts.Spec.Template.Spec.InitContainers
 
-	if len(containers) != 4 {
-		t.Fatalf("expected 4 containers (main + gateway-proxy + chromium + ollama), got %d", len(containers))
+	if len(containers) != 3 {
+		t.Fatalf("expected 3 containers (main + gateway-proxy + ollama), got %d", len(containers))
 	}
 
 	names := make(map[string]bool)
@@ -7770,11 +7768,17 @@ func TestBuildStatefulSet_OllamaAndChromiumEnabled(t *testing.T) {
 	if !names["openclaw"] {
 		t.Error("main container not found")
 	}
-	if !names["chromium"] {
-		t.Error("chromium container not found")
-	}
 	if !names["ollama"] {
 		t.Error("ollama container not found")
+	}
+
+	// Chromium should be in init containers (native sidecar)
+	initNames := make(map[string]bool)
+	for _, c := range initContainers {
+		initNames[c.Name] = true
+	}
+	if !initNames["chromium"] {
+		t.Error("chromium init container not found")
 	}
 
 	// Both env vars should be present on main container
@@ -7814,7 +7818,7 @@ func TestBuildStatefulSet_OllamaAndChromiumEnabled(t *testing.T) {
 
 	// Init container for model pull
 	foundInitOllama := false
-	for _, ic := range sts.Spec.Template.Spec.InitContainers {
+	for _, ic := range initContainers {
 		if ic.Name == "init-ollama" {
 			foundInitOllama = true
 			break
@@ -9309,6 +9313,54 @@ func TestBuildNetworkPolicy_WebTerminalIngressPort(t *testing.T) {
 	}
 }
 
+func TestBuildNetworkPolicy_ChromiumIngressAndEgress(t *testing.T) {
+	instance := newTestInstance("np-chromium")
+	instance.Spec.Chromium.Enabled = true
+
+	np := BuildNetworkPolicy(instance)
+
+	// Ingress: chromium port (9222) should be in ingress ports
+	if len(np.Spec.Ingress) == 0 {
+		t.Fatal("expected at least one ingress rule")
+	}
+
+	ports := np.Spec.Ingress[0].Ports
+	if len(ports) != 3 {
+		t.Fatalf("expected 3 ingress ports with chromium (gateway, canvas, chromium), got %d", len(ports))
+	}
+
+	foundChromiumIngress := false
+	for _, p := range ports {
+		if p.Port != nil && p.Port.IntValue() == ChromiumPort {
+			foundChromiumIngress = true
+			break
+		}
+	}
+	if !foundChromiumIngress {
+		t.Error("chromium port not found in NetworkPolicy ingress ports")
+	}
+
+	// Egress: should have a rule for chromium CDP (self-traffic on port 9222)
+	foundChromiumEgress := false
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			if p.Port != nil && p.Port.IntValue() == ChromiumPort {
+				foundChromiumEgress = true
+				// Verify it targets the same pod via pod selector
+				if len(rule.To) != 1 {
+					t.Errorf("chromium egress rule should have 1 peer, got %d", len(rule.To))
+				} else if rule.To[0].PodSelector == nil {
+					t.Error("chromium egress rule should use podSelector for self-traffic")
+				}
+				break
+			}
+		}
+	}
+	if !foundChromiumEgress {
+		t.Error("chromium egress rule (port 9222) not found in NetworkPolicy")
+	}
+}
+
 func TestBuildStatefulSet_WebTerminalReadOnlyWithCredential(t *testing.T) {
 	instance := newTestInstance("wt-readonly-cred")
 	instance.Spec.WebTerminal.Enabled = true
@@ -10126,7 +10178,8 @@ func TestBuildStatefulSet_PodLevelRunAsNonRootFalse_Propagation(t *testing.T) {
 	}
 
 	// Chromium should STILL have runAsNonRoot: true (has its own RunAsUser: 999)
-	for _, c := range containers {
+	// Chromium is now a native sidecar in InitContainers
+	for _, c := range initContainers {
 		if c.Name == "chromium" {
 			if c.SecurityContext.RunAsNonRoot == nil || !*c.SecurityContext.RunAsNonRoot {
 				t.Error("chromium: runAsNonRoot should still be true (self-consistent with RunAsUser: 999)")
@@ -10282,19 +10335,24 @@ func TestBuildStatefulSet_FullNonRootFalseScenario(t *testing.T) {
 			if *c.SecurityContext.RunAsUser != 101 {
 				t.Error("gateway-proxy: runAsUser should be 101")
 			}
-		case "chromium":
-			if !*c.SecurityContext.RunAsNonRoot {
-				t.Error("chromium: runAsNonRoot should be true (self-consistent)")
-			}
-			if *c.SecurityContext.RunAsUser != 999 {
-				t.Error("chromium: runAsUser should be 999")
-			}
 		case "ollama":
 			if *c.SecurityContext.RunAsNonRoot {
 				t.Error("ollama: runAsNonRoot should be false (always root)")
 			}
 			if *c.SecurityContext.RunAsUser != 0 {
 				t.Error("ollama: runAsUser should be 0")
+			}
+		}
+	}
+
+	// Chromium is a native sidecar in InitContainers
+	for _, c := range sts.Spec.Template.Spec.InitContainers {
+		if c.Name == "chromium" {
+			if !*c.SecurityContext.RunAsNonRoot {
+				t.Error("chromium: runAsNonRoot should be true (self-consistent)")
+			}
+			if *c.SecurityContext.RunAsUser != 999 {
+				t.Error("chromium: runAsUser should be 999")
 			}
 		}
 	}

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -120,3 +120,36 @@ func buildServicePorts(instance *openclawv1alpha1.OpenClawInstance) []corev1.Ser
 
 	return ports
 }
+
+// BuildChromiumCDPService creates a headless Service for the Chromium CDP
+// endpoint with publishNotReadyAddresses=true. This ensures the CDP URL
+// resolves even before the pod is fully Ready, which is critical because the
+// main container (OpenClaw) checks CDP connectivity during startup — before
+// its own readiness probe has passed. Without this, the main ClusterIP Service
+// has no endpoints and the CDP health check fails permanently.
+func BuildChromiumCDPService(instance *openclawv1alpha1.OpenClawInstance) *corev1.Service {
+	labels := Labels(instance)
+	selectorLabels := SelectorLabels(instance)
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ChromiumCDPServiceName(instance),
+			Namespace: instance.Namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                     corev1.ServiceTypeClusterIP,
+			ClusterIP:                corev1.ClusterIPNone, // headless
+			Selector:                 selectorLabels,
+			PublishNotReadyAddresses: true,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "cdp",
+					Port:       int32(ChromiumPort),
+					TargetPort: intstr.FromInt32(int32(ChromiumPort)),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -205,10 +205,8 @@ func buildContainers(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSe
 		containers = append(containers, buildTailscaleContainer(instance))
 	}
 
-	// Add Chromium sidecar if enabled
-	if instance.Spec.Chromium.Enabled {
-		containers = append(containers, buildChromiumContainer(instance))
-	}
+	// Chromium is now a native sidecar (init container with restartPolicy: Always)
+	// to guarantee it starts before the main container. See buildInitContainers.
 
 	// Add Ollama sidecar if enabled
 	if instance.Spec.Ollama.Enabled {
@@ -372,7 +370,7 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 	}
 
 	if instance.Spec.Chromium.Enabled {
-		// Use the Kubernetes Service DNS name to reach the Chromium sidecar.
+		// Use the headless CDP Service DNS name to reach the Chromium sidecar.
 		// A non-loopback address triggers OpenClaw's remote/attach mode so
 		// the browser control service connects to the existing sidecar
 		// instead of trying to launch a local browser process.
@@ -380,11 +378,15 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 		// (IPv6 addresses need brackets in URLs but Kubernetes env var
 		// interpolation cannot add them conditionally) and is stable
 		// across pod restarts (unlike status.podIP).
-		svcDNS := fmt.Sprintf("%s.%s.svc", ServiceName(instance), instance.Namespace)
+		// The headless CDP Service has publishNotReadyAddresses=true so the
+		// endpoint resolves before the pod is fully Ready, avoiding a race
+		// where OpenClaw checks CDP during startup before the main Service
+		// has endpoints.
+		cdpSvcDNS := fmt.Sprintf("%s.%s.svc", ChromiumCDPServiceName(instance), instance.Namespace)
 		env = append(env,
 			corev1.EnvVar{
 				Name:  "OPENCLAW_CHROMIUM_CDP",
-				Value: fmt.Sprintf("http://%s:%d", svcDNS, ChromiumPort),
+				Value: fmt.Sprintf("http://%s:%d", cdpSvcDNS, ChromiumPort),
 			},
 		)
 	}
@@ -557,6 +559,18 @@ func buildInitContainers(instance *openclawv1alpha1.OpenClawInstance, skillPacks
 	// Ollama model-pulling init container (only if enabled and models are specified)
 	if instance.Spec.Ollama.Enabled && len(instance.Spec.Ollama.Models) > 0 {
 		initContainers = append(initContainers, buildOllamaModelPullInitContainer(instance))
+	}
+
+	// Chromium native sidecar (K8s 1.28+): starts before main containers and
+	// stays running for the pod's lifetime. This guarantees the Chromium CDP
+	// endpoint is ready before OpenClaw boots and performs its one-time CDP
+	// health check. Without this ordering guarantee, OpenClaw may check the
+	// CDP URL before the Service has endpoints and cache "unreachable"
+	// permanently (see #270).
+	if instance.Spec.Chromium.Enabled {
+		chromium := buildChromiumContainer(instance)
+		chromium.RestartPolicy = Ptr(corev1.ContainerRestartPolicyAlways)
+		initContainers = append(initContainers, chromium)
 	}
 
 	// Custom init containers (user-defined, run after operator-managed ones)
@@ -1282,26 +1296,22 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 		})
 	}
 
-	// Build Chrome launch args with anti-bot-detection defaults + user ExtraArgs.
-	// browserless v2 reads DEFAULT_LAUNCH_ARGS env var and forwards the flags
-	// to the Chrome process. Using container Args would override the image CMD
-	// and cause the first flag to be executed as a binary (issue #209).
-	allArgs := []string{
-		"--disable-blink-features=AutomationControlled",
-		"--disable-features=AutomationControlled",
-		"--no-first-run",
-	}
+	// NOTE: DEFAULT_LAUNCH_ARGS was deprecated in browserless v2.0.0 and is
+	// fully ignored. There is no replacement env var — Chrome launch args must
+	// be passed per-request via the `launch` query parameter on the WebSocket
+	// URL (e.g. ws://host:9222?launch={"args":["--no-sandbox"]}).
+	// Anti-bot flags and ExtraArgs are currently NOT applied.
+	// TODO(#270): pass launch args to OpenClaw so it includes them in its
+	// WebSocket connection URL to browserless.
+
 	// When persistence is enabled, direct Chromium to store its profile data
 	// on the persistent volume so cookies, localStorage, and session tokens
-	// survive pod restarts.
+	// survive pod restarts. USER_DATA_DIR is the browserless v2 env var for
+	// the default Chrome user data directory.
 	if instance.Spec.Chromium.Persistence.Enabled {
-		allArgs = append(allArgs, "--user-data-dir=/chromium-data")
-	}
-	allArgs = append(allArgs, instance.Spec.Chromium.ExtraArgs...)
-	if launchArgs, err := json.Marshal(allArgs); err == nil {
 		chromiumEnv = append(chromiumEnv, corev1.EnvVar{
-			Name:  "DEFAULT_LAUNCH_ARGS",
-			Value: string(launchArgs),
+			Name:  "DATA_DIR",
+			Value: "/chromium-data",
 		})
 	}
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1349,15 +1349,15 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				}, statefulSet)
 			}, timeout, interval).Should(Succeed())
 
-			// Verify chromium container exists with correct port
+			// Verify chromium container exists as native sidecar init container with correct port
 			var chromiumContainer *corev1.Container
-			for i := range statefulSet.Spec.Template.Spec.Containers {
-				if statefulSet.Spec.Template.Spec.Containers[i].Name == "chromium" {
-					chromiumContainer = &statefulSet.Spec.Template.Spec.Containers[i]
+			for i := range statefulSet.Spec.Template.Spec.InitContainers {
+				if statefulSet.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+					chromiumContainer = &statefulSet.Spec.Template.Spec.InitContainers[i]
 					break
 				}
 			}
-			Expect(chromiumContainer).NotTo(BeNil(), "chromium sidecar container should exist")
+			Expect(chromiumContainer).NotTo(BeNil(), "chromium sidecar init container should exist")
 			Expect(chromiumContainer.Image).To(Equal("ghcr.io/browserless/chromium:latest"))
 			Expect(chromiumContainer.Ports).To(HaveLen(1))
 			Expect(chromiumContainer.Ports[0].ContainerPort).To(Equal(int32(resources.ChromiumPort)))
@@ -1378,7 +1378,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			mainContainer := statefulSet.Spec.Template.Spec.Containers[0]
 			var foundChromiumCDP bool
 			expectedCDP := fmt.Sprintf("http://%s.%s.svc:%d",
-				resources.ServiceName(instance), instance.Namespace, resources.ChromiumPort)
+				resources.ChromiumCDPServiceName(instance), instance.Namespace, resources.ChromiumPort)
 			for _, env := range mainContainer.Env {
 				if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 					foundChromiumCDP = true
@@ -1494,25 +1494,25 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(dataVol.PersistentVolumeClaim).NotTo(BeNil(), "chromium-data should be a PVC when persistence is enabled")
 			Expect(dataVol.PersistentVolumeClaim.ClaimName).To(Equal(instanceName + "-chromium-data"))
 
-			// Verify chromium container has --user-data-dir in launch args
+			// Verify chromium container has DATA_DIR env var for persistence
 			var chromiumContainer *corev1.Container
-			for i := range statefulSet.Spec.Template.Spec.Containers {
-				if statefulSet.Spec.Template.Spec.Containers[i].Name == "chromium" {
-					chromiumContainer = &statefulSet.Spec.Template.Spec.Containers[i]
+			for i := range statefulSet.Spec.Template.Spec.InitContainers {
+				if statefulSet.Spec.Template.Spec.InitContainers[i].Name == "chromium" {
+					chromiumContainer = &statefulSet.Spec.Template.Spec.InitContainers[i]
 					break
 				}
 			}
-			Expect(chromiumContainer).NotTo(BeNil(), "chromium sidecar container should exist")
+			Expect(chromiumContainer).NotTo(BeNil(), "chromium sidecar init container should exist")
 
-			var launchArgs string
+			var dataDir string
 			for _, env := range chromiumContainer.Env {
-				if env.Name == "DEFAULT_LAUNCH_ARGS" {
-					launchArgs = env.Value
+				if env.Name == "DATA_DIR" {
+					dataDir = env.Value
 					break
 				}
 			}
-			Expect(launchArgs).To(ContainSubstring("--user-data-dir=/chromium-data"),
-				"DEFAULT_LAUNCH_ARGS should contain --user-data-dir=/chromium-data when persistence is enabled")
+			Expect(dataDir).To(Equal("/chromium-data"),
+				"DATA_DIR should be set to /chromium-data when persistence is enabled")
 
 			// Verify chromium container has chromium-data volume mount
 			var foundDataMount bool


### PR DESCRIPTION
## Summary

Fixes the chromium browser integration issues reported in #270:

- **Native sidecar container** (K8s 1.28+): Chromium is now an init container with `restartPolicy: Always`, guaranteeing it starts and is Ready before the main OpenClaw container boots. This eliminates the startup race where OpenClaw checks the CDP URL before the Service has endpoints and permanently caches "unreachable".

- **Headless CDP Service** with `publishNotReadyAddresses: true`: The main ClusterIP Service only routes to Ready pods, but OpenClaw checks CDP during its own startup (before its readiness probe passes). A separate headless Service ensures the CDP endpoint always resolves once chromium is listening.

- **NetworkPolicy: add chromium port 9222** to both ingress and egress rules. The Service exposed port 9222 but the NetworkPolicy never allowed it. This was masked on Cilium clusters (which bypass policy on pod-to-self traffic) but broke on CNIs like Calico that strictly enforce policy on hairpin traffic.

- **Remove deprecated `DEFAULT_LAUNCH_ARGS`**: Ignored since browserless v2.0.0. Anti-bot flags and `ExtraArgs` were silently not being applied. Noted as TODO for future fix via WebSocket `launch` parameter.

### Root cause analysis

The `OPENCLAW_CHROMIUM_CDP` env var uses a Kubernetes Service DNS name (non-loopback, for IPv6 compatibility and remote-mode auto-detection). But the main Service only has endpoints for Ready pods. During startup:

1. Chromium sidecar and OpenClaw boot simultaneously
2. OpenClaw starts faster, checks `http://svc:9222` — Service has zero endpoints (pod not Ready)
3. OpenClaw caches `cdpHttp: false` and never retries
4. Chromium eventually becomes Ready, but OpenClaw has already given up

This was masked on our Cilium cluster (where self-traffic bypasses NetworkPolicy and the timing worked out) but consistently failed for users with slower browserless startup (v2.42.0 takes ~3s for first `/json/version`) or different CNIs.

## Test plan

- [x] All unit tests pass (`go test ./internal/resources/...`)
- [x] All other unit tests pass (registry, skillpacks, webhook)
- [x] E2E test file updated and compiles
- [ ] Deploy to test cluster and verify chromium CDP is reachable
- [ ] Verify on a non-Cilium cluster (Calico) if possible
- [ ] Verify browser tool works in OpenClaw after pod restart

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)