### PR TITLE
fix: handle merge commits in release tag creation step

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -28,12 +28,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
-          # Detect if the current push merged a release-please PR
+          # Detect if the current push merged a release-please PR.
+          # Check both the commit message (squash merge) and the merged
+          # PR title (merge commit) to handle all merge strategies.
           COMMIT_MSG=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}" \
             --jq '.commit.message' | head -1)
 
+          VERSION=""
           if [[ "$COMMIT_MSG" =~ ^chore\(main\):\ release\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="${BASH_REMATCH[1]}"
+          elif [[ "$COMMIT_MSG" =~ ^Merge\ pull\ request\ \#([0-9]+) ]]; then
+            # Merge commit - check the PR title instead
+            PR_NUM="${BASH_REMATCH[1]}"
+            PR_TITLE=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUM}" --jq '.title')
+            if [[ "$PR_TITLE" =~ ^chore\(main\):\ release\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+              VERSION="${BASH_REMATCH[1]}"
+            fi
+          fi
+
+          if [[ -n "$VERSION" ]]; then
             TAG="v${VERSION}"
 
             # Only create if tag doesn't already exist


### PR DESCRIPTION
## Summary
- The "Create release tag" step in `release-please.yaml` only matched squash merge commit messages (`chore(main): release X.Y.Z`)
- When PR #284 (release 0.10.30) was merged with a merge commit, the message was `Merge pull request #284 from ...` which didn't match the regex, so the `v0.10.30` tag was never created
- This caused the next release-please PR (#290) to include the entire project history in the changelog
- Now the step also extracts the PR number from merge commits and checks the PR title as a fallback

## Test plan
- [x] Verified the regex matches both `chore(main): release X.Y.Z` (squash) and `Merge pull request #N` (merge commit) formats
- [ ] Merge a future release-please PR with a merge commit and verify the tag is created

Fixes the root cause of the bloated changelog in #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)