### PR TITLE
chore: enable minor version bumps for feat: commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
       "release-type": "simple",
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary
- Remove `bump-patch-for-minor-pre-major` from `release-please-config.json`
- This setting was flattening all version bumps to patches while pre-1.0, causing 30+ patch releases without a minor bump despite many `feat:` commits

### Versioning behavior after this change

| Commit type | Before | After |
|-------------|--------|-------|
| `fix:` | patch (0.10.x) | patch (0.10.x) |
| `feat:` | patch (0.10.x) | **minor (0.11.0)** |
| `feat!:` / `BREAKING CHANGE` | minor (0.11.0) | minor (0.11.0) |

## Test plan
- [x] Verified `bump-minor-pre-major` is retained (breaking changes still bump minor, not major, while < 1.0)
- [ ] Next release with a `feat:` commit should produce a minor bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)