### PR TITLE
fix: chromium proxy nginx temp dirs for read-only rootfs

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -587,6 +587,13 @@ events {
 }
 
 http {
+    # Redirect temp/cache dirs to writable /tmp (rootfs is read-only)
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path /tmp/proxy;
+    fastcgi_temp_path /tmp/fastcgi;
+    uwsgi_temp_path /tmp/uwsgi;
+    scgi_temp_path /tmp/scgi;
+
     map $is_args $launch_sep {
         "?"     "&";
         default "?";


### PR DESCRIPTION
## Summary

- Redirects nginx HTTP temp directories to `/tmp` (emptyDir mount) for the chromium-proxy sidecar
- Fixes CrashLoopBackOff caused by nginx trying to create `/var/cache/nginx/client_temp` on read-only rootfs
- The gateway-proxy doesn't need this because it uses `stream` mode (L4), while the chromium-proxy uses `http` mode (L7) which requires writable cache dirs

**URGENT**: All instances are currently in CrashLoopBackOff due to this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)