### PR TITLE
docs: add Control UI auth, merge mode caveats, and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ The operator automatically generates a gateway token Secret for each instance an
 - If you set `gateway.auth.token` in your config or `OPENCLAW_GATEWAY_TOKEN` in `spec.env`, your value takes precedence
 - To bring your own token Secret, set `spec.gateway.existingSecret` - the operator will use it instead of auto-generating one (the Secret must have a key named `token`)
 - The operator automatically sets `gateway.controlUi.dangerouslyDisableDeviceAuth: true` - device pairing is incompatible with Kubernetes (users cannot approve pairing from inside a container, connections are always proxied, and mDNS is unavailable)
+- **Do not set `gateway.mode: local`** in your config - this mode is for desktop installs and enforces device identity checks that cannot work behind a reverse proxy in Kubernetes
+- When connecting to the Control UI through an Ingress, pass the gateway token in the URL fragment: `https://openclaw.example.com/#token=<your-token>`
 - Since v2026.2.24, OpenClaw restricts `gateway.allowedOrigins` to same-origin by default - if accessing via a non-default hostname (e.g. Ingress), set `gateway.allowedOrigins: ["*"]` in your config
 
 ### Control UI allowed origins
@@ -405,6 +407,8 @@ spec:
           model:
             primary: "anthropic/claude-sonnet-4-20250514"
 ```
+
+**Caveat:** In merge mode, removing a key from the CR does not remove it from the PVC config - the old value persists because deep-merge only adds or updates keys. If you need to remove stale config keys (e.g., after removing `gateway.mode: local`), temporarily switch to `mergeMode: replace`, apply, wait for the pod to restart, then switch back to `merge`.
 
 ### Skill installation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -44,7 +44,7 @@ Configuration for the OpenClaw application (`openclaw.json`).
 |----------------|-----------------------|---------------|----------------------------------------------------------------------------|
 | `configMapRef` | `ConfigMapKeySelector`| --            | Reference to an external ConfigMap. If set, `raw` is ignored.              |
 | `raw`          | `RawConfig`           | --            | Inline JSON configuration. The operator creates a managed ConfigMap.       |
-| `mergeMode`    | `string`              | `overwrite`   | How config is applied to the PVC. `overwrite` replaces on every restart. `merge` deep-merges with existing PVC config, preserving runtime changes. |
+| `mergeMode`    | `string`              | `overwrite`   | How config is applied to the PVC. `overwrite` replaces on every restart. `merge` deep-merges with existing PVC config, preserving runtime changes. **Caveat:** in merge mode, removing a key from the CR does not delete it from the PVC - temporarily use `replace` to wipe stale keys. |
 | `format`       | `string`              | `json`        | Config file format. `json` (standard JSON) or `json5` (JSON5 with comments/trailing commas). JSON5 requires `configMapRef` - inline `raw` must be valid JSON. JSON5 is converted to standard JSON by the init container using npx json5. |
 
 **ConfigMapKeySelector:**
@@ -763,7 +763,9 @@ When `existingSecret` is not set, the operator automatically generates a random 
 
 **Auto-injected settings:**
 
-The operator always injects `gateway.controlUi.dangerouslyDisableDeviceAuth: true` into the config JSON. Device pairing (introduced in OpenClaw v2026.3.2) is fundamentally incompatible with Kubernetes because users cannot approve pairing from inside a container, connections always come through the nginx proxy sidecar (non-local), and mDNS is unavailable. If you explicitly set `gateway.controlUi.dangerouslyDisableDeviceAuth` in your config, your value takes precedence.
+The operator always injects `gateway.controlUi.dangerouslyDisableDeviceAuth: true` into the config JSON. Device pairing (introduced in OpenClaw v2026.3.2) is fundamentally incompatible with Kubernetes because users cannot approve pairing from inside a container, connections always come through the nginx proxy sidecar (non-local), and mDNS is unavailable. If you explicitly set `gateway.controlUi.dangerouslyDisableDeviceAuth` in your config, your value takes precedence. **Do not set `gateway.mode: local`** - this desktop-only mode enforces device identity checks that cannot work behind a reverse proxy.
+
+When accessing the Control UI through an Ingress, authenticate by appending the gateway token to the URL fragment: `https://openclaw.example.com/#token=<your-token>`.
 
 The operator auto-injects `gateway.controlUi.allowedOrigins` into the config JSON with:
 - **Localhost** (always): `http://localhost:18789`, `http://127.0.0.1:18789`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -365,6 +365,36 @@ kubectl describe pvc my-assistant-data -n openclaw
 
 6. **WebSocket connectivity**: The operator automatically adds WebSocket-related nginx annotations. If using a different Ingress controller, you may need to add controller-specific annotations for WebSocket support.
 
+### Control UI Shows "device identity required"
+
+**Symptoms**: Connecting to the Control UI through an Ingress fails with `code=1008 reason=device identity required` in the OpenClaw logs.
+
+**Possible causes and solutions**:
+
+1. **`gateway.mode: local` is set in the config**: This mode enforces browser-based device identity verification, which is incompatible with Kubernetes. Remove `gateway.mode` from your CR's `spec.config.raw` - the operator defaults to server mode which is correct for K8s.
+
+2. **Stale config from merge mode**: If you previously had `gateway.mode: local` in your config and are using `mergeMode: merge`, the old key persists on the PVC even after removing it from the CR. Temporarily set `mergeMode: replace` to wipe stale keys:
+   ```yaml
+   spec:
+     config:
+       mergeMode: replace  # temporarily set, then switch back to merge
+   ```
+
+3. **Upstream OpenClaw bug**: Even with `dangerouslyDisableDeviceAuth: true` (which the operator injects automatically), some OpenClaw versions still enforce device identity. **Workaround**: Pass the gateway token directly in the URL fragment:
+   ```
+   https://openclaw.example.com/#token=<your-gateway-token>
+   ```
+   You can find the token in the auto-generated Secret:
+   ```bash
+   kubectl get secret <instance>-gateway-token -n <namespace> -o jsonpath='{.data.token}' | base64 -d
+   ```
+
+### Gateway Proxy "Connection Refused" on Startup
+
+**Symptoms**: The gateway-proxy (nginx) container logs show `connect() failed (111: Connection refused)` immediately after pod startup.
+
+**This is expected and harmless.** The nginx proxy sidecar starts before the OpenClaw gateway is fully listening. The connection refused errors resolve within a few seconds once the gateway binds to its port. No action is needed - subsequent connections will succeed.
+
 ### Chromium Sidecar Issues
 
 **Symptoms**: The Chromium sidecar is not starting, crashing, or browser automation fails.


### PR DESCRIPTION
## Summary
Documentation improvements based on user feedback in #297:

- **Control UI `#token=` URL format**: Document that users behind a reverse proxy authenticate via `https://host/#token=<token>` in the URL fragment
- **`gateway.mode: local` warning**: Explicitly warn against using this desktop-only mode in Kubernetes
- **Merge mode caveat**: Document that removing a key from the CR does not remove it from the PVC config in merge mode, and how to fix stale keys
- **Troubleshooting: "device identity required"**: New entry covering causes (stale `gateway.mode: local`, upstream OpenClaw bug) and the `#token=` workaround
- **Troubleshooting: gateway-proxy "Connection refused"**: Note that nginx connection refused on startup is expected and harmless

### Files changed
- `README.md` - Gateway auth section + merge mode section
- `docs/api-reference.md` - `mergeMode` field + auto-injected settings
- `docs/troubleshooting.md` - Two new entries

Closes #297

## Test plan
- [x] Verified all three files are consistent
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)