### PR TITLE
fix(chromium): route WebSocket to /chromium endpoint for launch args

### DIFF
--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -136,10 +136,11 @@ const (
 	DefaultMetricsPort int32 = 9090
 )
 
-// DefaultChromiumLaunchArgs are anti-bot Chrome flags injected by the
-// chromium CDP proxy into every browserless WebSocket connection.
-// Browserless v2 deprecated DEFAULT_LAUNCH_ARGS (fully ignored since v2.0.0)
-// and only accepts launch args via the `launch` query parameter.
+// DefaultChromiumLaunchArgs are anti-bot Chrome flags injected via the
+// chromium CDP proxy's `launch` query parameter. The proxy routes all
+// WebSocket connections to browserless's /chromium endpoint with these
+// flags (+ user ExtraArgs), ensuring every browser session gets a fresh
+// Chrome launched with the correct args. See chromiumProxyNginxConfig.
 var DefaultChromiumLaunchArgs = []string{
 	"--disable-blink-features=AutomationControlled",
 	"--disable-features=AutomationControlled",

--- a/internal/resources/common_test.go
+++ b/internal/resources/common_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -246,5 +247,81 @@ func TestBuildStatefulSet_WithRegistry(t *testing.T) {
 	}
 	if !strings.HasPrefix(initUvContainer.Image, "my-registry.example.com/") {
 		t.Errorf("init-uv image = %q, want registry prefix", initUvContainer.Image)
+	}
+}
+
+func TestDeduplicateArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		defaults []string
+		extras   []string
+		expected []string
+	}{
+		{
+			name:     "no extras",
+			defaults: []string{"--no-first-run", "--no-sandbox"},
+			extras:   nil,
+			expected: []string{"--no-first-run", "--no-sandbox"},
+		},
+		{
+			name:     "no overlap",
+			defaults: []string{"--no-first-run"},
+			extras:   []string{"--window-size=1920,1080"},
+			expected: []string{"--no-first-run", "--window-size=1920,1080"},
+		},
+		{
+			name:     "exact duplicate removed",
+			defaults: []string{"--no-first-run", "--no-sandbox"},
+			extras:   []string{"--no-first-run"},
+			expected: []string{"--no-first-run", "--no-sandbox"},
+		},
+		{
+			name:     "user value overrides default",
+			defaults: []string{"--user-agent=Default"},
+			extras:   []string{"--user-agent=Custom"},
+			expected: []string{"--user-agent=Custom"},
+		},
+		{
+			name:     "mixed overlap and new",
+			defaults: []string{"--no-first-run", "--disable-blink-features=AutomationControlled"},
+			extras:   []string{"--no-first-run", "--window-size=1920,1080", "--user-agent=Bot/1.0"},
+			expected: []string{"--no-first-run", "--disable-blink-features=AutomationControlled", "--window-size=1920,1080", "--user-agent=Bot/1.0"},
+		},
+		{
+			name:     "both empty",
+			defaults: nil,
+			extras:   nil,
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicateArgs(tt.defaults, tt.extras)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("deduplicateArgs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestArgKey(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"--user-agent=Custom", "--user-agent"},
+		{"--no-sandbox", "--no-sandbox"},
+		{"--window-size=1920,1080", "--window-size"},
+		{"--disable-blink-features=AutomationControlled", "--disable-blink-features"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := argKey(tt.input)
+			if got != tt.expected {
+				t.Errorf("argKey(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
 	}
 }

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -566,14 +566,20 @@ stream {
 
 // chromiumProxyNginxConfig returns the nginx HTTP configuration for the
 // chromium CDP proxy sidecar. It sits between OpenClaw and the browserless
-// sidecar, injecting Chrome launch args (anti-bot flags + user ExtraArgs)
-// into every request via the `launch` query parameter. This is needed
-// because browserless v2 deprecated DEFAULT_LAUNCH_ARGS and only accepts
-// launch args per-request on the WebSocket URL.
+// sidecar, routing WebSocket connections to the /chromium endpoint with
+// Chrome launch args (anti-bot flags + user ExtraArgs) via the `launch`
+// query parameter.
+//
+// Why /chromium specifically: browserless v2 deprecated DEFAULT_LAUNCH_ARGS
+// and only applies the `launch` query parameter on its /chromium WebSocket
+// endpoint (which launches a new Chrome process). Other endpoints like
+// /devtools/browser/<id> connect to already-running Chrome and ignore
+// launch args entirely. By routing all WebSocket upgrades to /chromium,
+// every browser session gets fresh Chrome with the correct flags.
+//
+// HTTP requests (health checks, /json/version) pass through unchanged.
 func chromiumProxyNginxConfig(instance *openclawv1alpha1.OpenClawInstance) string {
-	args := make([]string, 0, len(DefaultChromiumLaunchArgs)+len(instance.Spec.Chromium.ExtraArgs))
-	args = append(args, DefaultChromiumLaunchArgs...)
-	args = append(args, instance.Spec.Chromium.ExtraArgs...)
+	args := deduplicateArgs(DefaultChromiumLaunchArgs, instance.Spec.Chromium.ExtraArgs)
 
 	launchJSON, _ := json.Marshal(map[string]interface{}{"args": args})
 	encoded := url.QueryEscape(string(launchJSON))
@@ -594,30 +600,72 @@ http {
     uwsgi_temp_path /tmp/uwsgi;
     scgi_temp_path /tmp/scgi;
 
-    map $is_args $launch_sep {
-        "?"     "&";
-        default "?";
-    }
-
-    map $http_upgrade $connection_upgrade {
-        default upgrade;
-        ''      close;
-    }
-
     server {
         listen 0.0.0.0:%d;
 
-        location / {
-            proxy_pass http://127.0.0.1:%d$request_uri${launch_sep}launch=%s;
+        # WebSocket connections route to /chromium with launch args.
+        # browserless v2 only applies launch args on the /chromium endpoint
+        # (launches new Chrome), not /devtools/browser/ (existing Chrome).
+        location @chromium_ws {
+            proxy_pass http://127.0.0.1:%d/chromium?launch=%s;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
             proxy_buffering off;
             proxy_read_timeout 86400s;
             proxy_send_timeout 86400s;
         }
+
+        location / {
+            # Route WebSocket upgrades to @chromium_ws via internal redirect.
+            error_page 418 = @chromium_ws;
+            if ($http_upgrade ~* "websocket") {
+                return 418;
+            }
+
+            # HTTP requests pass through to browserless unchanged.
+            proxy_pass http://127.0.0.1:%d;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_buffering off;
+        }
     }
 }
-`, ChromiumProxyPort, ChromiumPort, encoded)
+`, ChromiumProxyPort, ChromiumPort, encoded, ChromiumPort)
+}
+
+// deduplicateArgs merges default and extra Chrome launch args, removing
+// duplicates. When the same flag appears in both lists, the extra (user)
+// value wins. Flags are compared by their key (everything before '=').
+func deduplicateArgs(defaults, extras []string) []string {
+	seen := make(map[string]int) // flag key → index in result
+	result := make([]string, 0, len(defaults)+len(extras))
+
+	for _, arg := range defaults {
+		key := argKey(arg)
+		seen[key] = len(result)
+		result = append(result, arg)
+	}
+	for _, arg := range extras {
+		key := argKey(arg)
+		if idx, ok := seen[key]; ok {
+			result[idx] = arg // user value overrides default
+		} else {
+			seen[key] = len(result)
+			result = append(result, arg)
+		}
+	}
+	return result
+}
+
+// argKey extracts the flag key from a Chrome arg for deduplication.
+// "--user-agent=Foo" → "--user-agent", "--no-sandbox" → "--no-sandbox".
+func argKey(arg string) string {
+	for i, c := range arg {
+		if c == '=' {
+			return arg[:i]
+		}
+	}
+	return arg
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -607,7 +607,8 @@ func TestBuildStatefulSet_ChromiumExtraArgs(t *testing.T) {
 		t.Errorf("expected no container Args, got %v", chromium.Args)
 	}
 
-	// DEFAULT_LAUNCH_ARGS no longer exists; ExtraArgs are currently not applied (TODO)
+	// DEFAULT_LAUNCH_ARGS is deprecated; ExtraArgs are injected via the
+	// chromium-proxy's nginx config (launch query parameter on /chromium endpoint).
 	for _, env := range chromium.Env {
 		if env.Name == "DEFAULT_LAUNCH_ARGS" {
 			t.Error("DEFAULT_LAUNCH_ARGS env var should not be set on chromium container")
@@ -10559,9 +10560,48 @@ func TestBuildConfigMap_ChromiumProxyNginxConfig(t *testing.T) {
 		t.Error("proxy config should contain user ExtraArgs")
 	}
 
-	// Should have WebSocket upgrade headers
+	// Should have WebSocket upgrade headers in @chromium_ws location
 	if !strings.Contains(proxyConfig, "proxy_set_header Upgrade") {
 		t.Error("proxy config should handle WebSocket upgrades")
+	}
+
+	// WebSocket connections should route to /chromium endpoint (not /devtools/)
+	if !strings.Contains(proxyConfig, fmt.Sprintf("proxy_pass http://127.0.0.1:%d/chromium?launch=", ChromiumPort)) {
+		t.Error("proxy config should route WebSocket to /chromium endpoint with launch args")
+	}
+
+	// Should use named location for WebSocket routing
+	if !strings.Contains(proxyConfig, "location @chromium_ws") {
+		t.Error("proxy config should have @chromium_ws named location")
+	}
+
+	// Should redirect WebSocket upgrades via error_page
+	if !strings.Contains(proxyConfig, "error_page 418") {
+		t.Error("proxy config should use error_page 418 for WebSocket routing")
+	}
+}
+
+func TestBuildConfigMap_ChromiumProxyDeduplicatesArgs(t *testing.T) {
+	instance := newTestInstance("cdp-dedup")
+	instance.Spec.Chromium.Enabled = true
+	// Include a flag that's already in DefaultChromiumLaunchArgs
+	instance.Spec.Chromium.ExtraArgs = []string{
+		"--no-first-run",
+		"--window-size=1920,1080",
+	}
+
+	cm := BuildConfigMap(instance, "", nil)
+	proxyConfig := cm.Data[ChromiumProxyNginxConfigKey]
+
+	// --no-first-run should appear only once (deduplicated)
+	count := strings.Count(proxyConfig, "no-first-run")
+	if count != 1 {
+		t.Errorf("--no-first-run should appear once (deduplicated), found %d times", count)
+	}
+
+	// --window-size should be present
+	if !strings.Contains(proxyConfig, "window-size") {
+		t.Error("proxy config should contain --window-size from ExtraArgs")
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1372,8 +1372,9 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 
 	// NOTE: DEFAULT_LAUNCH_ARGS was deprecated in browserless v2.0.0 and is
 	// fully ignored. Chrome launch args are injected by the chromium-proxy
-	// nginx sidecar which appends DefaultChromiumLaunchArgs + ExtraArgs via
-	// the `launch` query parameter on every request to browserless.
+	// nginx sidecar which routes WebSocket connections to the /chromium
+	// endpoint with DefaultChromiumLaunchArgs + ExtraArgs via the `launch`
+	// query parameter. See chromiumProxyNginxConfig in configmap.go.
 
 	// When persistence is enabled, direct Chromium to store its profile data
 	// on the persistent volume so cookies, localStorage, and session tokens


### PR DESCRIPTION
## Summary

- Routes WebSocket connections through the chromium-proxy to browserless's `/chromium` endpoint with `?launch=...` args, instead of appending launch args to all request paths
- Passes HTTP requests (health checks, `/json/version`) through unchanged
- Adds deduplication for Chrome launch args so user `ExtraArgs` that overlap with defaults appear once (user value wins)

## Why

Browserless v2 only applies the `launch` query parameter on its `/chromium` WebSocket endpoint (launches new Chrome with specified args). Other paths like `/devtools/browser/<id>` connect to already-running Chrome and ignore launch args entirely. The previous proxy config appended `?launch=...` to all requests, which meant `ExtraArgs` like `--user-agent` and `--window-size` were silently ignored depending on which path OpenClaw used to connect.

## Changes

| File | What |
|------|------|
| `configmap.go` | Rewrite nginx config: named `@chromium_ws` location for WebSocket, `error_page 418` redirect pattern, HTTP passthrough |
| `configmap.go` | Add `deduplicateArgs` and `argKey` helpers |
| `common.go` | Update `DefaultChromiumLaunchArgs` comment |
| `statefulset.go` | Update comment about launch args injection |
| `common_test.go` | Unit tests for `deduplicateArgs` and `argKey` |
| `resources_test.go` | Updated proxy config test + dedup integration test |

## Test plan

- [x] All existing tests pass (`go test ./internal/resources/`)
- [x] New tests for `deduplicateArgs` (overlap, no overlap, user override, empty)
- [x] New tests for `argKey` (with/without `=`)
- [x] Updated `TestBuildConfigMap_ChromiumProxyNginxConfig` verifies `/chromium` routing, `@chromium_ws` location, `error_page 418`
- [x] New `TestBuildConfigMap_ChromiumProxyDeduplicatesArgs` verifies dedup
- [ ] Manual: deploy and verify `--user-agent` / `--window-size` ExtraArgs take effect

Fixes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)