### PR TITLE
fix(web-terminal): pass -W flag when ReadOnly is false

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -9045,6 +9045,10 @@ func TestBuildStatefulSet_WebTerminalEnabled(t *testing.T) {
 	if !strings.Contains(wt.Command[2], "exec ttyd") {
 		t.Errorf("web-terminal command should contain 'exec ttyd', got %q", wt.Command[2])
 	}
+	// Default (ReadOnly: false) should include -W flag for writable mode
+	if !strings.Contains(wt.Command[2], "-W") {
+		t.Errorf("web-terminal command should contain '-W' for writable mode by default, got %q", wt.Command[2])
+	}
 
 	// No credential env vars by default
 	if len(wt.Env) != 0 {
@@ -9152,6 +9156,10 @@ func TestBuildStatefulSet_WebTerminalReadOnly(t *testing.T) {
 	// Command should include -R flag
 	if !strings.Contains(wt.Command[2], "-R") {
 		t.Errorf("web-terminal command should contain '-R' for read-only, got %q", wt.Command[2])
+	}
+	// Should NOT include -W flag
+	if strings.Contains(wt.Command[2], "-W") {
+		t.Errorf("web-terminal command should NOT contain '-W' in read-only mode, got %q", wt.Command[2])
 	}
 
 	// Data mount should be read-only

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1515,6 +1515,10 @@ func buildWebTerminalContainer(instance *openclawv1alpha1.OpenClawInstance) core
 	var flags []string
 	if instance.Spec.WebTerminal.ReadOnly {
 		flags = append(flags, "-R")
+	} else {
+		// ttyd defaults to read-only when --writable/-W is not passed.
+		// Explicitly pass -W so that ReadOnly: false results in an interactive terminal.
+		flags = append(flags, "-W")
 	}
 	if instance.Spec.WebTerminal.Credential != nil {
 		flags = append(flags, `-c "${TTYD_USERNAME}:${TTYD_PASSWORD}"`)


### PR DESCRIPTION
## Problem

ttyd defaults to read-only mode when neither -R nor -W is passed. The current buildWebTerminalContainer code only passes -R when ReadOnly is true, but omits -W when ReadOnly is false (which is the CRD default).

This means every web terminal instance starts in read-only mode regardless of the readOnly field value. Users see the following warning in ttyd container logs even with readOnly: false explicitly set:

    W: The --writable option is not set, will start in readonly mode

## Root Cause

In internal/resources/statefulset.go, buildWebTerminalContainer() only adds the -R flag for read-only mode but never adds -W for writable mode. Since ttyd defaults to read-only when --writable is not passed, all terminals end up read-only.

## Fix

Explicitly pass -W (--writable) when ReadOnly is false, so the terminal is interactive as expected.

## Testing

- Updated TestBuildStatefulSet_WebTerminalEnabled to verify -W flag is present by default
- Updated TestBuildStatefulSet_WebTerminalReadOnly to verify -W is NOT present in read-only mode
- All 9 existing web terminal tests pass
