### PR TITLE
feat(init-skills): propagate spec.env and spec.envFrom to skills init container

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -5011,6 +5011,56 @@ func TestBuildStatefulSet_WithNpmSkill_InitSkillsScript(t *testing.T) {
 	}
 }
 
+func TestBuildStatefulSet_WithSkills_EnvAndEnvFromPropagated(t *testing.T) {
+	instance := newTestInstance("skills-env")
+	instance.Spec.Skills = []string{"@anthropic/mcp-server-fetch"}
+	instance.Spec.Env = []corev1.EnvVar{
+		{Name: "CLAWHUB_TOKEN", Value: "secret-token"},
+	}
+	instance.Spec.EnvFrom = []corev1.EnvFromSource{
+		{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "vault-secrets"},
+			},
+		},
+	}
+
+	sts := BuildStatefulSet(instance, "", nil)
+
+	var skillsContainer *corev1.Container
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "init-skills" {
+			skillsContainer = &sts.Spec.Template.Spec.InitContainers[i]
+			break
+		}
+	}
+	if skillsContainer == nil {
+		t.Fatal("init-skills container not found")
+	}
+
+	// Hardcoded env vars should come first (take precedence)
+	names := envNames(skillsContainer.Env)
+	if len(names) < 4 {
+		t.Fatalf("expected at least 4 env vars, got %d: %v", len(names), names)
+	}
+	if names[0] != "HOME" || names[1] != "NPM_CONFIG_CACHE" || names[2] != "NPM_CONFIG_IGNORE_SCRIPTS" {
+		t.Errorf("hardcoded env vars should come first, got %v", names[:3])
+	}
+
+	// User-defined env var should be appended after hardcoded ones
+	if names[len(names)-1] != "CLAWHUB_TOKEN" {
+		t.Errorf("user-defined CLAWHUB_TOKEN should be last, got %v", names)
+	}
+
+	// EnvFrom should be propagated
+	if len(skillsContainer.EnvFrom) != 1 {
+		t.Fatalf("expected 1 envFrom source, got %d", len(skillsContainer.EnvFrom))
+	}
+	if skillsContainer.EnvFrom[0].SecretRef.Name != "vault-secrets" {
+		t.Errorf("envFrom secretRef = %q, want vault-secrets", skillsContainer.EnvFrom[0].SecretRef.Name)
+	}
+}
+
 func TestBuildStatefulSet_WithSkills_SkillsTmpVolume(t *testing.T) {
 	instance := newTestInstance("skills-vol")
 	instance.Spec.Skills = []string{"some-skill"}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -805,12 +805,19 @@ func buildSkillsInitContainer(instance *openclawv1alpha1.OpenClawInstance) *core
 		})
 	}
 
+	// Append user-supplied env vars after hardcoded defaults so that
+	// credentials like CLAWHUB_TOKEN are available during skill installation.
+	// Hardcoded vars (HOME, NPM_CONFIG_CACHE, NPM_CONFIG_IGNORE_SCRIPTS)
+	// take precedence because they appear first.
+	env = append(env, instance.Spec.Env...)
+
 	return &corev1.Container{
 		Name:                     "init-skills",
 		Image:                    GetImage(instance),
 		Command:                  []string{"sh", "-c", script},
 		ImagePullPolicy:          getPullPolicy(instance),
 		Env:                      env,
+		EnvFrom:                  instance.Spec.EnvFrom,
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
## Summary

- Appends `instance.Spec.Env` to the init-skills container env vars after hardcoded defaults (`HOME`, `NPM_CONFIG_CACHE`, `NPM_CONFIG_IGNORE_SCRIPTS`), so user-supplied credentials like `CLAWHUB_TOKEN` are available during skill installation
- Passes through `instance.Spec.EnvFrom` to the init-skills container, enabling Secret/ConfigMap references (e.g. Vault via VSO) to work the same way they do on the main container

This addresses Part 1 of #307. Part 2 (install resilience with retry/skip) is left for a follow-up discussion and PR as it involves CRD changes.

## Test plan

- [x] New unit test `TestBuildStatefulSet_WithSkills_EnvAndEnvFromPropagated` verifies:
  - Hardcoded env vars come first (take precedence)
  - User-defined env vars are appended after
  - `EnvFrom` sources are propagated
- [x] All existing skills init container tests pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)