### PR TITLE
fix(chromium): use rewrite + bare proxy_pass in named location

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -607,7 +607,8 @@ http {
         # browserless v2 only applies launch args on the /chromium endpoint
         # (launches new Chrome), not /devtools/browser/ (existing Chrome).
         location @chromium_ws {
-            proxy_pass http://127.0.0.1:%d/chromium?launch=%s;
+            rewrite ^ /chromium?launch=%s break;
+            proxy_pass http://127.0.0.1:%d;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -632,7 +633,7 @@ http {
         }
     }
 }
-`, ChromiumProxyPort, ChromiumPort, encoded, ChromiumPort)
+`, ChromiumProxyPort, encoded, ChromiumPort, ChromiumPort)
 }
 
 // deduplicateArgs merges default and extra Chrome launch args, removing

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -10623,9 +10623,9 @@ func TestBuildConfigMap_ChromiumProxyNginxConfig(t *testing.T) {
 		t.Error("proxy config should handle WebSocket upgrades")
 	}
 
-	// WebSocket connections should route to /chromium endpoint (not /devtools/)
-	if !strings.Contains(proxyConfig, fmt.Sprintf("proxy_pass http://127.0.0.1:%d/chromium?launch=", ChromiumPort)) {
-		t.Error("proxy config should route WebSocket to /chromium endpoint with launch args")
+	// WebSocket connections should rewrite to /chromium with launch args
+	if !strings.Contains(proxyConfig, "rewrite ^ /chromium?launch=") {
+		t.Error("proxy config should rewrite WebSocket requests to /chromium with launch args")
 	}
 
 	// Should use named location for WebSocket routing


### PR DESCRIPTION
## Summary

Fixes #270. Supersedes #306.

nginx rejects `proxy_pass` with a URI inside named locations (`@chromium_ws`), causing the chromium-proxy sidecar to CrashLoopBackOff:

```
[emerg] "proxy_pass" cannot have URI part in location given by
        [...] named location [...]
```

The fix is a 2-line change based on @mcgilly17's [verified fix](https://github.com/openclaw-rocks/k8s-operator/issues/270#issuecomment-2711937422):

```diff
 location @chromium_ws {
-    proxy_pass http://127.0.0.1:9222/chromium?launch=...;
+    rewrite ^ /chromium?launch=... break;
+    proxy_pass http://127.0.0.1:9222;
     proxy_http_version 1.1;
```

This preserves:
- `/chromium` endpoint routing so browserless applies launch args
- HTTP pass-through for health checks (`/json/version`)
- WebSocket upgrade handling via the existing `error_page 418` redirect

## Test plan

- [x] Unit tests updated and passing (`TestBuildConfigMap_ChromiumProxyNginxConfig`)
- [ ] E2e: deploy with `spec.chromium.enabled: true`, verify proxy starts without CrashLoopBackOff
- [ ] E2e: verify WebSocket connections receive launch args on `/chromium`

🤖 Generated with [Claude Code](https://claude.com/claude-code)