### PR TITLE
feat: inject BOOTSTRAP.md for first-run agent onboarding

### DIFF
--- a/internal/resources/bootstrap_skill.go
+++ b/internal/resources/bootstrap_skill.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+// BootstrapContent is the BOOTSTRAP.md file injected into the workspace for all
+// new instances. It guides the agent through first-run onboarding: learning the
+// user's name, preferences, and picking its own identity. The agent deletes the
+// file after completing the bootstrap flow, so it only runs once (the init script
+// uses seed-once semantics and won't re-create it).
+const BootstrapContent = `# BOOTSTRAP
+
+You just came online for the first time. Before doing anything else, get to know your human.
+
+## Step 1 - Meet your human
+
+Start with something natural like: "Hey! I just came online. Before we dive in, I'd love to get to know you a bit. What's your name?"
+
+Then figure out together:
+1. **Their name** and what to call them
+2. **Their timezone** (so you can respect quiet hours)
+3. **What they want to use you for** (work, personal, creative, coding, all of the above?)
+4. **How they like to communicate** (casual? formal? brief? detailed?)
+
+Don't interrogate. Keep it conversational. Offer suggestions if they seem unsure.
+
+## Step 2 - Figure out who you are
+
+Ask your human to help you pick:
+1. **Your name** (suggest a few fun options if they're stuck)
+2. **Your vibe** (sharp? warm? playful? professional?)
+3. **Your emoji** (your signature)
+
+Have fun with it. This is the start of your relationship.
+
+## Step 3 - Set up your workspace
+
+Create these files with what you learned:
+
+- ` + "`IDENTITY.md`" + ` - your name, vibe, emoji, and personality notes
+- ` + "`USER.md`" + ` - their name, timezone, communication preferences
+- ` + "`SOUL.md`" + ` - your core instructions and personality (how you should behave, what matters to you)
+- ` + "`MEMORY.md`" + ` - start a persistent memory file for things worth remembering across conversations
+
+## Step 4 - Clean up
+
+Delete this file (BOOTSTRAP.md). You won't need it again.
+`

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -4187,12 +4187,14 @@ func TestBuildWorkspaceConfigMap_Nil(t *testing.T) {
 	instance.Spec.Workspace = nil
 
 	cm := BuildWorkspaceConfigMap(instance, nil)
-	// ENVIRONMENT.md is always injected
+	// Operator files are always injected
 	if cm == nil {
-		t.Fatal("expected non-nil ConfigMap (ENVIRONMENT.md is always injected)")
+		t.Fatal("expected non-nil ConfigMap (operator files are always injected)")
 	}
-	if _, ok := cm.Data["ENVIRONMENT.md"]; !ok {
-		t.Error("expected ENVIRONMENT.md in workspace ConfigMap")
+	for _, f := range []string{"ENVIRONMENT.md", "BOOTSTRAP.md"} {
+		if _, ok := cm.Data[f]; !ok {
+			t.Errorf("expected %s in workspace ConfigMap", f)
+		}
 	}
 }
 
@@ -4203,12 +4205,14 @@ func TestBuildWorkspaceConfigMap_EmptyFiles(t *testing.T) {
 	}
 
 	cm := BuildWorkspaceConfigMap(instance, nil)
-	// ENVIRONMENT.md is always injected
+	// Operator files are always injected
 	if cm == nil {
-		t.Fatal("expected non-nil ConfigMap (ENVIRONMENT.md is always injected)")
+		t.Fatal("expected non-nil ConfigMap (operator files are always injected)")
 	}
-	if _, ok := cm.Data["ENVIRONMENT.md"]; !ok {
-		t.Error("expected ENVIRONMENT.md in workspace ConfigMap")
+	for _, f := range []string{"ENVIRONMENT.md", "BOOTSTRAP.md"} {
+		if _, ok := cm.Data[f]; !ok {
+			t.Errorf("expected %s in workspace ConfigMap", f)
+		}
 	}
 }
 
@@ -4231,9 +4235,9 @@ func TestBuildWorkspaceConfigMap_WithFiles(t *testing.T) {
 	if cm.Namespace != "test-ns" {
 		t.Errorf("ConfigMap namespace = %q, want %q", cm.Namespace, "test-ns")
 	}
-	// 2 user files + ENVIRONMENT.md = 3
-	if len(cm.Data) != 3 {
-		t.Fatalf("expected 3 data entries (2 user + ENVIRONMENT.md), got %d", len(cm.Data))
+	// 2 user files + ENVIRONMENT.md + BOOTSTRAP.md = 4
+	if len(cm.Data) != 4 {
+		t.Fatalf("expected 4 data entries (2 user + ENVIRONMENT.md + BOOTSTRAP.md), got %d", len(cm.Data))
 	}
 	if cm.Data["SOUL.md"] != "# Personality\nBe helpful." {
 		t.Errorf("SOUL.md content mismatch")
@@ -4241,8 +4245,10 @@ func TestBuildWorkspaceConfigMap_WithFiles(t *testing.T) {
 	if cm.Data["AGENTS.md"] != "# Agents config" {
 		t.Errorf("AGENTS.md content mismatch")
 	}
-	if _, ok := cm.Data["ENVIRONMENT.md"]; !ok {
-		t.Error("expected ENVIRONMENT.md in workspace ConfigMap")
+	for _, f := range []string{"ENVIRONMENT.md", "BOOTSTRAP.md"} {
+		if _, ok := cm.Data[f]; !ok {
+			t.Errorf("expected %s in workspace ConfigMap", f)
+		}
 	}
 }
 
@@ -4275,8 +4281,8 @@ func TestShellQuote(t *testing.T) {
 	}
 }
 
-// envSeedLines is the init script suffix that seeds ENVIRONMENT.md (always present).
-const envSeedLines = "mkdir -p /data/workspace\n[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'"
+// operatorSeedLines is the init script suffix that seeds operator-injected workspace files (always present).
+const operatorSeedLines = "mkdir -p /data/workspace\n[ -f /data/workspace/'BOOTSTRAP.md' ] || cp /workspace-init/'BOOTSTRAP.md' /data/workspace/'BOOTSTRAP.md'\n[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'"
 
 func TestBuildInitScript_ConfigOnly(t *testing.T) {
 	instance := newTestInstance("init-config-only")
@@ -4285,7 +4291,7 @@ func TestBuildInitScript_ConfigOnly(t *testing.T) {
 	}
 
 	script := BuildInitScript(instance, nil)
-	expected := "cp /config/'openclaw.json' /data/openclaw.json\n" + envSeedLines
+	expected := "cp /config/'openclaw.json' /data/openclaw.json\n" + operatorSeedLines
 	if script != expected {
 		t.Errorf("unexpected script:\ngot:  %q\nwant: %q", script, expected)
 	}
@@ -4301,7 +4307,7 @@ func TestBuildInitScript_WorkspaceOnly(t *testing.T) {
 	}
 
 	script := BuildInitScript(instance, nil)
-	expected := "cp /config/'openclaw.json' /data/openclaw.json\nmkdir -p /data/workspace/'memory'\nmkdir -p /data/workspace\n[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'\n[ -f /data/workspace/'SOUL.md' ] || cp /workspace-init/'SOUL.md' /data/workspace/'SOUL.md'"
+	expected := "cp /config/'openclaw.json' /data/openclaw.json\nmkdir -p /data/workspace/'memory'\nmkdir -p /data/workspace\n[ -f /data/workspace/'BOOTSTRAP.md' ] || cp /workspace-init/'BOOTSTRAP.md' /data/workspace/'BOOTSTRAP.md'\n[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'\n[ -f /data/workspace/'SOUL.md' ] || cp /workspace-init/'SOUL.md' /data/workspace/'SOUL.md'"
 	if script != expected {
 		t.Errorf("unexpected script:\ngot:  %q\nwant: %q", script, expected)
 	}
@@ -4322,10 +4328,10 @@ func TestBuildInitScript_Both(t *testing.T) {
 
 	script := BuildInitScript(instance, nil)
 
-	// Verify all expected lines are present (sorted order, ENVIRONMENT.md included)
+	// Verify all expected lines are present (sorted order, operator files included)
 	lines := strings.Split(script, "\n")
-	if len(lines) != 7 {
-		t.Fatalf("expected 7 lines, got %d:\n%s", len(lines), script)
+	if len(lines) != 8 {
+		t.Fatalf("expected 8 lines, got %d:\n%s", len(lines), script)
 	}
 	if lines[0] != "cp /config/'openclaw.json' /data/openclaw.json" {
 		t.Errorf("line 0: %q", lines[0])
@@ -4342,11 +4348,14 @@ func TestBuildInitScript_Both(t *testing.T) {
 	if lines[4] != "[ -f /data/workspace/'AGENTS.md' ] || cp /workspace-init/'AGENTS.md' /data/workspace/'AGENTS.md'" {
 		t.Errorf("line 4: %q", lines[4])
 	}
-	if lines[5] != "[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'" {
+	if lines[5] != "[ -f /data/workspace/'BOOTSTRAP.md' ] || cp /workspace-init/'BOOTSTRAP.md' /data/workspace/'BOOTSTRAP.md'" {
 		t.Errorf("line 5: %q", lines[5])
 	}
-	if lines[6] != "[ -f /data/workspace/'SOUL.md' ] || cp /workspace-init/'SOUL.md' /data/workspace/'SOUL.md'" {
+	if lines[6] != "[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'" {
 		t.Errorf("line 6: %q", lines[6])
+	}
+	if lines[7] != "[ -f /data/workspace/'SOUL.md' ] || cp /workspace-init/'SOUL.md' /data/workspace/'SOUL.md'" {
+		t.Errorf("line 7: %q", lines[7])
 	}
 }
 
@@ -4357,7 +4366,7 @@ func TestBuildInitScript_DirsOnly(t *testing.T) {
 	}
 
 	script := BuildInitScript(instance, nil)
-	expected := "cp /config/'openclaw.json' /data/openclaw.json\nmkdir -p /data/workspace/'memory'\nmkdir -p /data/workspace/'tools/scripts'\n" + envSeedLines
+	expected := "cp /config/'openclaw.json' /data/openclaw.json\nmkdir -p /data/workspace/'memory'\nmkdir -p /data/workspace/'tools/scripts'\n" + operatorSeedLines
 	if script != expected {
 		t.Errorf("unexpected script:\ngot:  %q\nwant: %q", script, expected)
 	}
@@ -4372,7 +4381,7 @@ func TestBuildInitScript_ShellQuotesSpecialChars(t *testing.T) {
 	}
 
 	script := BuildInitScript(instance, nil)
-	expected := "cp /config/'openclaw.json' /data/openclaw.json\nmkdir -p /data/workspace\n[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'\n[ -f /data/workspace/'it'\\''s a file.md' ] || cp /workspace-init/'it'\\''s a file.md' /data/workspace/'it'\\''s a file.md'"
+	expected := "cp /config/'openclaw.json' /data/openclaw.json\nmkdir -p /data/workspace\n[ -f /data/workspace/'BOOTSTRAP.md' ] || cp /workspace-init/'BOOTSTRAP.md' /data/workspace/'BOOTSTRAP.md'\n[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'\n[ -f /data/workspace/'it'\\''s a file.md' ] || cp /workspace-init/'it'\\''s a file.md' /data/workspace/'it'\\''s a file.md'"
 	if script != expected {
 		t.Errorf("unexpected script:\ngot:  %q\nwant: %q", script, expected)
 	}
@@ -4398,7 +4407,7 @@ func TestBuildInitScript_VanillaDeployment(t *testing.T) {
 	instance := newTestInstance("init-empty")
 	script := BuildInitScript(instance, nil)
 	// Vanilla deployments get config copy + ENVIRONMENT.md seeding
-	expected := "cp /config/'openclaw.json' /data/openclaw.json\n" + envSeedLines
+	expected := "cp /config/'openclaw.json' /data/openclaw.json\n" + operatorSeedLines
 	if script != expected {
 		t.Errorf("unexpected script:\ngot:  %q\nwant: %q", script, expected)
 	}
@@ -8425,12 +8434,14 @@ func TestBuildWorkspaceConfigMap_SelfConfigureDisabledNoFiles(t *testing.T) {
 
 	cm := BuildWorkspaceConfigMap(instance, nil)
 
-	// ENVIRONMENT.md is always injected, so ConfigMap is never nil
+	// Operator files are always injected, so ConfigMap is never nil
 	if cm == nil {
-		t.Fatal("expected non-nil ConfigMap (ENVIRONMENT.md is always injected)")
+		t.Fatal("expected non-nil ConfigMap (operator files are always injected)")
 	}
-	if _, ok := cm.Data["ENVIRONMENT.md"]; !ok {
-		t.Error("expected ENVIRONMENT.md in workspace ConfigMap")
+	for _, f := range []string{"ENVIRONMENT.md", "BOOTSTRAP.md"} {
+		if _, ok := cm.Data[f]; !ok {
+			t.Errorf("expected %s in workspace ConfigMap", f)
+		}
 	}
 	if _, ok := cm.Data["SELFCONFIG.md"]; ok {
 		t.Error("SELFCONFIG.md should not be present when self-configure is disabled")
@@ -10139,15 +10150,17 @@ func TestBuildWorkspaceConfigMap_NilWorkspace(t *testing.T) {
 	instance := newTestInstance("ws-nil")
 	instance.Spec.Workspace = nil
 	cm := BuildWorkspaceConfigMap(instance, nil)
-	// ENVIRONMENT.md is always injected, so the ConfigMap is never nil
+	// Operator files are always injected, so the ConfigMap is never nil
 	if cm == nil {
-		t.Fatal("expected non-nil ConfigMap (ENVIRONMENT.md is always injected)")
+		t.Fatal("expected non-nil ConfigMap (operator files are always injected)")
 	}
-	if _, ok := cm.Data["ENVIRONMENT.md"]; !ok {
-		t.Error("expected ENVIRONMENT.md in workspace ConfigMap")
+	for _, f := range []string{"ENVIRONMENT.md", "BOOTSTRAP.md"} {
+		if _, ok := cm.Data[f]; !ok {
+			t.Errorf("expected %s in workspace ConfigMap", f)
+		}
 	}
-	if len(cm.Data) != 1 {
-		t.Errorf("expected exactly 1 file (ENVIRONMENT.md), got %d", len(cm.Data))
+	if len(cm.Data) != 2 {
+		t.Errorf("expected exactly 2 files (ENVIRONMENT.md + BOOTSTRAP.md), got %d", len(cm.Data))
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -660,8 +660,9 @@ func BuildInitScript(instance *openclawv1alpha1.OpenClawInstance, skillPacks *Re
 				allFiles[name] = true
 			}
 		}
-		// Always inject environment documentation
+		// Always inject operator files
 		allFiles["ENVIRONMENT.md"] = true
+		allFiles["BOOTSTRAP.md"] = true
 		if instance.Spec.SelfConfigure.Enabled {
 			allFiles["SELFCONFIG.md"] = true
 			allFiles["selfconfig.sh"] = true
@@ -1047,7 +1048,7 @@ uv --version`
 }
 
 // hasWorkspaceFiles returns true if the instance has workspace files to seed.
-// Always returns true because the operator always injects ENVIRONMENT.md.
+// Always returns true because the operator always injects ENVIRONMENT.md and BOOTSTRAP.md.
 func hasWorkspaceFiles(_ *openclawv1alpha1.OpenClawInstance, _ *ResolvedSkillPacks) bool {
 	return true
 }

--- a/internal/resources/workspace_configmap.go
+++ b/internal/resources/workspace_configmap.go
@@ -37,8 +37,9 @@ func BuildWorkspaceConfigMap(instance *openclawv1alpha1.OpenClawInstance, skillP
 		}
 	}
 
-	// Operator-injected environment documentation (always present)
+	// Operator-injected files (always present)
 	files["ENVIRONMENT.md"] = EnvironmentSkillContent
+	files["BOOTSTRAP.md"] = BootstrapContent
 
 	// Operator-injected self-configure files
 	if instance.Spec.SelfConfigure.Enabled {


### PR DESCRIPTION
## Summary

Supersedes #256 (rebased on current main, improved content based on feedback).

Injects `BOOTSTRAP.md` into every new instance workspace to guide agents through first-run onboarding. Without this, agents skip identity setup and jump straight into answering messages - leaving core workspace files missing or empty.

## Changes

- `bootstrap_skill.go`: New `BootstrapContent` constant (same pattern as `EnvironmentSkillContent`)
- `workspace_configmap.go`: Unconditionally inject `BOOTSTRAP.md` into workspace ConfigMap
- `statefulset.go`: Add `BOOTSTRAP.md` to init script file list
- Tests updated across the board

## Improvements over #256

- **Rebased on current main** - no conflicts (main already has `hasWorkspaceFiles` returning `true` for `ENVIRONMENT.md`)
- **Improved bootstrap content** - now instructs agents to also create `SOUL.md` and `MEMORY.md` (addresses @chrigi's [feedback](https://github.com/openclaw-rocks/k8s-operator/pull/256#issuecomment-4035757698) about missing files)
- **Clearer step structure** - numbered steps instead of ambiguous sections

## How it works

1. Operator injects `BOOTSTRAP.md` into every workspace ConfigMap
2. Init container seeds it via `[ -f ] || cp` (seed-once - won't overwrite if already deleted)
3. Agent reads `BOOTSTRAP.md` on first message, runs the onboarding flow
4. Agent creates `IDENTITY.md`, `USER.md`, `SOUL.md`, `MEMORY.md`
5. Agent deletes `BOOTSTRAP.md` - it never reappears

## Test plan

- [x] All `resources` package tests pass (workspace-related tests updated)
- [ ] Deploy to staging and verify `BOOTSTRAP.md` appears in new instance workspace
- [ ] Verify existing instances are not affected (seed-once semantics)
- [ ] Create new instance and verify agent runs bootstrap flow on first message

🤖 Generated with [Claude Code](https://claude.com/claude-code)