### PR TITLE
fix(autoupdate): scale StatefulSet back up after pre-update backup

### DIFF
--- a/internal/controller/autoupdate.go
+++ b/internal/controller/autoupdate.go
@@ -295,6 +295,26 @@ func (r *OpenClawInstanceReconciler) driveUpdateStateMachine(ctx context.Context
 		return r.abortUpdate(ctx, instance, fmt.Sprintf("failed to patch image tag: %v", err))
 	}
 
+	// Step 4b: Scale StatefulSet back up if it was scaled down for backup.
+	// The backup flow scales to 0 replicas, and the main reconcile loop won't
+	// reach reconcileResources() while pendingVersion is set (early return),
+	// so we must explicitly restore replicas here (#299).
+	if needsBackup && persistenceEnabled {
+		sts := &appsv1.StatefulSet{}
+		stsKey := client.ObjectKey{Name: resources.StatefulSetName(instance), Namespace: instance.Namespace}
+		if getErr := r.Get(ctx, stsKey, sts); getErr == nil {
+			if sts.Spec.Replicas != nil && *sts.Spec.Replicas == 0 {
+				one := int32(1)
+				stsOriginal := sts.DeepCopy()
+				sts.Spec.Replicas = &one
+				if patchErr := r.Patch(ctx, sts, client.MergeFrom(stsOriginal)); patchErr != nil {
+					return r.abortUpdate(ctx, instance, fmt.Sprintf("failed to scale StatefulSet back up: %v", patchErr))
+				}
+				logger.Info("Scaled StatefulSet back up after pre-update backup")
+			}
+		}
+	}
+
 	// Step 5: Enter health check phase (keep PendingVersion set)
 	rollbackEnabled := instance.Spec.AutoUpdate.RollbackOnFailure == nil || *instance.Spec.AutoUpdate.RollbackOnFailure
 	if rollbackEnabled {


### PR DESCRIPTION
## Summary

- When `backupBeforeUpdate: true` with persistence enabled, the pre-update backup flow scales the StatefulSet to 0 replicas. After the backup completes and the image tag is patched, the STS was never scaled back up -- the main reconcile loop early-returns while `pendingVersion` is set (line 179), preventing `reconcileResources()` from restoring replicas.
- The pod stays terminated, health checks never pass, and the update is stuck indefinitely.
- Fix: explicitly scale the STS back to 1 replica between the image patch (step 4) and health check entry (step 5).

## Root cause

The auto-update state machine has an implicit dependency on `reconcileResources()` to restore the StatefulSet replica count after the backup scales it to 0. But the reconcile loop short-circuits at line 179 when `pendingVersion != ""`:

```go
if pendingVersion != "" {
    return r.driveUpdateStateMachine(ctx, instance)
}
```

This means `reconcileResources()` is never called during the health check phase, leaving the STS at 0 replicas.

## Test plan

- [ ] `go vet ./...` passes
- [ ] E2E: deploy instance with `backupBeforeUpdate: true` and persistence, trigger auto-update, verify pod comes back up and update completes

Fixes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)