### PR TITLE
chore: add NOTICE file for Apache 2.0 attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+OpenClaw Kubernetes Operator
+Copyright 2026 OpenClaw.rocks
+
+This product includes software developed at OpenClaw.rocks
+(https://openclaw.rocks).


### PR DESCRIPTION
## Summary
- Adds a `NOTICE` file to the repository root with project name, copyright, and URL
- Apache License 2.0 Section 4(d) requires anyone redistributing derivative works to include a readable copy of this file, ensuring attribution is preserved in forks

## Test plan
- [x] Verify NOTICE file contents match Apache 2.0 conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)