### PR TITLE
fix: increase main container startup probe timeout to 300s

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -653,10 +653,10 @@ Health probe configuration for the main OpenClaw container. All probes use HTTP 
 | Field                 | Type     | Default | Description                                           |
 |-----------------------|----------|---------|-------------------------------------------------------|
 | `enabled`             | `*bool`  | `true`  | Enable the startup probe.                             |
-| `initialDelaySeconds` | `*int32` | `0`     | Seconds to wait before the first check.               |
+| `initialDelaySeconds` | `*int32` | `5`     | Seconds to wait before the first check.               |
 | `periodSeconds`       | `*int32` | `5`     | Seconds between checks.                              |
 | `timeoutSeconds`      | `*int32` | `3`     | Seconds before the check times out.                  |
-| `failureThreshold`    | `*int32` | `30`    | Consecutive failures before killing the container. Allows up to 150s startup. |
+| `failureThreshold`    | `*int32` | `60`    | Consecutive failures before killing the container. Allows up to 300s startup. |
 
 ### spec.observability
 

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -403,8 +403,11 @@ func TestBuildStatefulSet_Defaults(t *testing.T) {
 	}
 
 	// Startup probe defaults
-	if main.StartupProbe.FailureThreshold != 30 {
-		t.Errorf("startup probe failureThreshold = %d, want 30", main.StartupProbe.FailureThreshold)
+	if main.StartupProbe.InitialDelaySeconds != 5 {
+		t.Errorf("startup probe initialDelaySeconds = %d, want 5", main.StartupProbe.InitialDelaySeconds)
+	}
+	if main.StartupProbe.FailureThreshold != 60 {
+		t.Errorf("startup probe failureThreshold = %d, want 60", main.StartupProbe.FailureThreshold)
 	}
 
 	// Data volume mount

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -2175,11 +2175,11 @@ func buildStartupProbe(instance *openclawv1alpha1.OpenClawInstance) *corev1.Prob
 
 	probe := &corev1.Probe{
 		ProbeHandler:        buildHTTPProbeHandler("/healthz"),
-		InitialDelaySeconds: 0,
+		InitialDelaySeconds: 5,
 		PeriodSeconds:       5,
 		TimeoutSeconds:      3,
 		SuccessThreshold:    1,
-		FailureThreshold:    30, // 30 * 5s = 150s startup time
+		FailureThreshold:    60, // 60 * 5s = 300s startup time
 	}
 
 	if spec != nil {


### PR DESCRIPTION
## Summary
- Increases the main container startup probe budget from 150s to 300s (`failureThreshold` 30 -> 60)
- Adds a 5s `initialDelaySeconds` to avoid probing before the container has started listening
- Updates unit tests and API reference docs to match new defaults

Closes #344

## Test plan
- [x] Unit tests pass (`go test ./internal/resources/`)
- [x] Lint passes (`make lint`)
- [ ] CI passes (unit + integration + e2e)
- [ ] Deploy to a test cluster and verify startup probe events are reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)