### PR TITLE
fix(chromium): route CDP traffic through proxy instead of bypassing it

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -275,7 +275,7 @@ When enabled, the sidecar:
 - Mounts an emptyDir at `/tmp` for scratch space.
 - When `persistence.enabled` is true, mounts a PVC at `/chromium-data` and passes `--user-data-dir=/chromium-data` to Chrome, persisting cookies, localStorage, IndexedDB, cached credentials, and session tokens across pod restarts.
 
-When Chromium is enabled, the operator also auto-configures browser profiles in the OpenClaw config. Both `"default"` and `"chrome"` profiles are set to point at the sidecar's CDP endpoint (`http://localhost:3000`). This ensures browser tool calls work regardless of which profile name the LLM passes.
+When Chromium is enabled, the operator also auto-configures browser profiles in the OpenClaw config. Both `"default"` and `"chrome"` profiles are set to point at the sidecar's CDP endpoint via the headless CDP Service DNS name. Traffic goes through the chromium-proxy nginx sidecar which injects anti-bot Chrome launch args (and any user `extraArgs`) into every WebSocket connection. This ensures browser tool calls work regardless of which profile name the LLM passes.
 
 ### spec.tailscale
 

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -459,7 +459,7 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 	for _, env := range mainContainer.Env {
 		if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 			foundChromiumCDP = true
-			expected := fmt.Sprintf("http://%s-cdp.%s.svc:%d", instance.Name, instance.Namespace, ChromiumPort)
+			expected := fmt.Sprintf("http://%s-cdp.%s.svc:%d", instance.Name, instance.Namespace, ChromiumProxyPort)
 			if env.Value != expected {
 				t.Errorf("OPENCLAW_CHROMIUM_CDP = %q, want %q", env.Value, expected)
 			}
@@ -11057,8 +11057,8 @@ func TestBuildChromiumCDPService_TargetsProxyPort(t *testing.T) {
 	}
 
 	port := svc.Spec.Ports[0]
-	if port.Port != int32(ChromiumPort) {
-		t.Errorf("service port should be %d (external CDP port), got %d", ChromiumPort, port.Port)
+	if port.Port != int32(ChromiumProxyPort) {
+		t.Errorf("service port should be %d (proxy port, headless Service has no port translation), got %d", ChromiumProxyPort, port.Port)
 	}
 	if port.TargetPort.IntValue() != int(ChromiumProxyPort) {
 		t.Errorf("target port should be %d (proxy), got %d", ChromiumProxyPort, port.TargetPort.IntValue())

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -130,6 +130,12 @@ func buildServicePorts(instance *openclawv1alpha1.OpenClawInstance) []corev1.Ser
 //
 // Traffic is routed to the chromium CDP proxy (ChromiumProxyPort) which
 // injects anti-bot Chrome launch args before forwarding to browserless.
+//
+// IMPORTANT: This is a headless Service (ClusterIP: None), so kube-proxy
+// does NOT translate Port to TargetPort. DNS resolves directly to the pod
+// IP and the client connects on the Port value. Both Port and TargetPort
+// must be ChromiumProxyPort so traffic reaches the proxy, not browserless
+// directly. Using ChromiumPort (9222) here would bypass the proxy entirely.
 func BuildChromiumCDPService(instance *openclawv1alpha1.OpenClawInstance) *corev1.Service {
 	labels := Labels(instance)
 	selectorLabels := SelectorLabels(instance)
@@ -148,7 +154,7 @@ func BuildChromiumCDPService(instance *openclawv1alpha1.OpenClawInstance) *corev
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "cdp",
-					Port:       int32(ChromiumPort),
+					Port:       int32(ChromiumProxyPort),
 					TargetPort: intstr.FromInt32(int32(ChromiumProxyPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -414,14 +414,22 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 	}
 
 	if instance.Spec.Chromium.Enabled {
-		// Use the headless CDP Service DNS name to reach the Chromium sidecar.
+		// Use the headless CDP Service DNS name to reach the Chromium sidecar
+		// via the chromium-proxy nginx sidecar. The proxy intercepts WebSocket
+		// connections and routes them to browserless's /chromium endpoint with
+		// anti-bot launch args (+ user ExtraArgs) via the `launch` query param.
+		//
+		// IMPORTANT: Must use ChromiumProxyPort (9223), not ChromiumPort (9222).
+		// The CDP Service is headless (ClusterIP: None), so kube-proxy does NOT
+		// translate Port to TargetPort. DNS resolves to the pod IP directly and
+		// the client connects on the port in the URL. Using 9222 would bypass
+		// the proxy entirely, hitting browserless directly and skipping all
+		// launch arg injection.
+		//
 		// A non-loopback address triggers OpenClaw's remote/attach mode so
 		// the browser control service connects to the existing sidecar
 		// instead of trying to launch a local browser process.
-		// Using DNS instead of pod IP avoids IPv6 URL formatting issues
-		// (IPv6 addresses need brackets in URLs but Kubernetes env var
-		// interpolation cannot add them conditionally) and is stable
-		// across pod restarts (unlike status.podIP).
+		// Using DNS instead of pod IP avoids IPv6 URL formatting issues.
 		// The headless CDP Service has publishNotReadyAddresses=true so the
 		// endpoint resolves before the pod is fully Ready, avoiding a race
 		// where OpenClaw checks CDP during startup before the main Service
@@ -430,7 +438,7 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 		env = append(env,
 			corev1.EnvVar{
 				Name:  "OPENCLAW_CHROMIUM_CDP",
-				Value: fmt.Sprintf("http://%s:%d", cdpSvcDNS, ChromiumPort),
+				Value: fmt.Sprintf("http://%s:%d", cdpSvcDNS, ChromiumProxyPort),
 			},
 		)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1379,7 +1379,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			mainContainer := statefulSet.Spec.Template.Spec.Containers[0]
 			var foundChromiumCDP bool
 			expectedCDP := fmt.Sprintf("http://%s.%s.svc:%d",
-				resources.ChromiumCDPServiceName(instance), instance.Namespace, resources.ChromiumPort)
+				resources.ChromiumCDPServiceName(instance), instance.Namespace, resources.ChromiumProxyPort)
 			for _, env := range mainContainer.Env {
 				if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 					foundChromiumCDP = true
@@ -1389,7 +1389,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			}
 			Expect(foundChromiumCDP).To(BeTrue(), "OPENCLAW_CHROMIUM_CDP env var should be set")
 
-			// Verify ConfigMap has browser profiles with cdpUrl on port 9222
+			// Verify ConfigMap has browser profiles with cdpUrl via env var
 			configMap := &corev1.ConfigMap{}
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
## Summary
- The headless CDP Service (`ClusterIP: None`) does **not** perform kube-proxy port translation - DNS resolves directly to the pod IP and the client connects on the port in the URL
- `OPENCLAW_CHROMIUM_CDP` used `ChromiumPort` (9222), so all CDP traffic went directly to browserless, completely bypassing the chromium-proxy nginx sidecar on port 9223
- This meant the `rewrite ^ /chromium?launch=...` never fired and `extraArgs` (`--user-agent`, `--window-size`, anti-bot flags) were never injected
- Fix: change both the env var and the headless Service `Port` to use `ChromiumProxyPort` (9223)

Refs #270

## Test plan
- [x] Unit tests pass (`go test ./internal/resources/`)
- [x] Lint passes (`make lint`)
- [ ] CI passes (unit + integration + e2e)
- [ ] Deploy to test cluster and verify `extraArgs` take effect (user-agent, window-size)
- [ ] Verify browser connectivity still works after port change

🤖 Generated with [Claude Code](https://claude.com/claude-code)