### PR TITLE
feat: add Service and ServiceMonitor for operator metrics

### DIFF
--- a/charts/openclaw-operator/templates/metrics-rbac.yaml
+++ b/charts/openclaw-operator/templates/metrics-rbac.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "openclaw-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "openclaw-operator.labels" . | nindent 4 }}
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+{{- end }}

--- a/charts/openclaw-operator/templates/metrics-service.yaml
+++ b/charts/openclaw-operator/templates/metrics-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openclaw-operator.fullname" . }}-metrics
+  labels:
+    {{- include "openclaw-operator.labels" . | nindent 4 }}
+    control-plane: controller-manager
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "openclaw-operator.selectorLabels" . | nindent 4 }}
+    control-plane: controller-manager
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+{{- end }}

--- a/charts/openclaw-operator/templates/metrics-servicemonitor.yaml
+++ b/charts/openclaw-operator/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openclaw-operator.fullname" . }}
+  labels:
+    {{- include "openclaw-operator.labels" . | nindent 4 }}
+    control-plane: controller-manager
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "openclaw-operator.selectorLabels" . | nindent 6 }}
+      control-plane: controller-manager
+  endpoints:
+    - port: metrics
+      path: /metrics
+      {{- if .Values.metrics.secure }}
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+{{- end }}

--- a/charts/openclaw-operator/values.yaml
+++ b/charts/openclaw-operator/values.yaml
@@ -86,6 +86,16 @@ metrics:
   enabled: true
   bindAddress: ":8443"
   secure: true
+  # Service for operator metrics endpoint
+  service:
+    port: 8443
+    annotations: {}
+  # ServiceMonitor for Prometheus Operator scraping
+  serviceMonitor:
+    enabled: false
+    interval: ""
+    scrapeTimeout: ""
+    labels: {}
 
 # Webhook configuration (optional)
 webhook:


### PR DESCRIPTION
## Summary

- Adds a `Service` exposing the operator's metrics endpoint (port 8443) so Prometheus can discover it
- Adds an optional `ServiceMonitor` for Prometheus Operator-based scraping with proper HTTPS + bearer token auth
- Adds a `metrics-reader` `ClusterRole` granting `/metrics` access (users bind this to their Prometheus SA)

All gated behind existing `metrics.enabled` and new `metrics.serviceMonitor.enabled` values.

Closes #348

## New values

```yaml
metrics:
  service:
    port: 8443
    annotations: {}
  serviceMonitor:
    enabled: false    # opt-in (requires prometheus-operator CRDs)
    interval: ""
    scrapeTimeout: ""
    labels: {}
```

## Test plan

- [ ] `helm template` renders Service when `metrics.enabled=true` (default)
- [ ] `helm template` renders no metrics resources when `metrics.enabled=false`
- [ ] `helm template --set metrics.serviceMonitor.enabled=true` renders ServiceMonitor with HTTPS + bearerTokenFile
- [ ] `helm template --set metrics.serviceMonitor.enabled=true --set metrics.secure=false` renders ServiceMonitor without TLS config
- [ ] Deploy to kind cluster and verify Prometheus discovers the operator target

🤖 Generated with [Claude Code](https://claude.com/claude-code)