### PR TITLE
fix: add missing --s3-region flag to periodic backup CronJob

### DIFF
--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -400,6 +400,9 @@ func rcloneCronJobEnv(creds *s3Credentials, credentialSecretName string) []corev
 			},
 		)
 	}
+	if creds.Region != "" {
+		env = append(env, corev1.EnvVar{Name: "S3_REGION", Value: creds.Region})
+	}
 	return env
 }
 
@@ -458,6 +461,9 @@ func buildBackupCronJob(
 	basePath := fmt.Sprintf("backups/%s/%s/periodic", tenantID, instance.Name)
 	remote := fmt.Sprintf(":s3:%s/%s", creds.Bucket, basePath)
 	s3Flags := fmt.Sprintf(`--s3-provider=%s --s3-endpoint="${S3_ENDPOINT}" %s`, creds.Provider, authFlags)
+	if creds.Region != "" {
+		s3Flags += ` --s3-region="${S3_REGION}"`
+	}
 
 	// CUTOFF uses epoch arithmetic (busybox-compatible, since the rclone image is Alpine-based)
 	rcloneCmd := fmt.Sprintf(

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -612,5 +612,67 @@ var _ = Describe("S3 Helpers", func() {
 			podSpec := cronJob.Spec.JobTemplate.Spec.Template.Spec
 			Expect(podSpec.ServiceAccountName).To(BeEmpty())
 		})
+
+		It("Should include --s3-region flag in rclone command and S3_REGION env var when Region is set", func() {
+			creds.Region = "us-west-2"
+			cronJob := buildBackupCronJob(instance, creds, "myinst-s3-credentials")
+			container := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+			// Verify --s3-region flag is present in the shell command
+			Expect(container.Command[2]).To(ContainSubstring(`--s3-region="${S3_REGION}"`))
+
+			// Verify S3_REGION env var is present as plain Value (not sensitive)
+			var regionEnv *corev1.EnvVar
+			for i, e := range container.Env {
+				if e.Name == "S3_REGION" {
+					regionEnv = &container.Env[i]
+					break
+				}
+			}
+			Expect(regionEnv).NotTo(BeNil())
+			Expect(regionEnv.Value).To(Equal("us-west-2"))
+			Expect(regionEnv.ValueFrom).To(BeNil())
+		})
+
+		It("Should not include --s3-region flag or S3_REGION env var when Region is empty", func() {
+			cronJob := buildBackupCronJob(instance, creds, "myinst-s3-credentials")
+			container := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+			// Verify --s3-region flag is NOT present in the shell command
+			Expect(container.Command[2]).NotTo(ContainSubstring("--s3-region"))
+
+			// Verify S3_REGION env var is NOT present
+			var envNames []string
+			for _, e := range container.Env {
+				envNames = append(envNames, e.Name)
+			}
+			Expect(envNames).NotTo(ContainElement("S3_REGION"))
+		})
+
+		It("Should include --s3-region with env-auth mode when Region is set", func() {
+			envAuthCreds := &s3Credentials{
+				Bucket:   "test-bucket",
+				Endpoint: "https://s3.us-west-2.amazonaws.com",
+				Provider: "AWS",
+				Region:   "us-west-2",
+				EnvAuth:  true,
+			}
+			cronJob := buildBackupCronJob(instance, envAuthCreds, "")
+			container := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+
+			// Verify --s3-region flag is present in the shell command
+			Expect(container.Command[2]).To(ContainSubstring(`--s3-region="${S3_REGION}"`))
+
+			// Verify S3_REGION env var is present
+			var regionEnv *corev1.EnvVar
+			for i, e := range container.Env {
+				if e.Name == "S3_REGION" {
+					regionEnv = &container.Env[i]
+					break
+				}
+			}
+			Expect(regionEnv).NotTo(BeNil())
+			Expect(regionEnv.Value).To(Equal("us-west-2"))
+		})
 	})
 })

--- a/test/e2e/e2e_backup_cronjob_test.go
+++ b/test/e2e/e2e_backup_cronjob_test.go
@@ -369,6 +369,94 @@ var _ = Describe("Periodic Backup CronJob", func() {
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})
 
+		It("Should include --s3-region flag and S3_REGION env var when S3_REGION is set in credentials Secret", func() {
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			// Recreate the s3-backup-credentials Secret with S3_REGION
+			operatorNS := os.Getenv("OPERATOR_NAMESPACE")
+			if operatorNS == "" {
+				operatorNS = "openclaw-operator-system"
+			}
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "s3-backup-credentials",
+					Namespace: operatorNS,
+				},
+			}
+			_ = k8sClient.Delete(ctx, existingSecret)
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "s3-backup-credentials",
+					Namespace: operatorNS,
+				}, existingSecret)
+				return apierrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			regionSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "s3-backup-credentials",
+					Namespace: operatorNS,
+				},
+				StringData: map[string]string{
+					"S3_BUCKET":            "test-bucket",
+					"S3_ACCESS_KEY_ID":     "test-key",
+					"S3_SECRET_ACCESS_KEY": "test-secret",
+					"S3_ENDPOINT":          "https://s3.us-west-2.amazonaws.com",
+					"S3_REGION":            "us-west-2",
+				},
+			}
+			Expect(k8sClient.Create(ctx, regionSecret)).Should(Succeed())
+
+			instanceName := "backup-cron-region"
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Backup: openclawv1alpha1.BackupSpec{
+						Schedule: "0 7 * * *",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Verify CronJob is created with --s3-region in the rclone command
+			cronJob := &batchv1.CronJob{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instanceName + "-backup-periodic",
+					Namespace: namespace,
+				}, cronJob)
+			}, timeout, interval).Should(Succeed())
+
+			container := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
+			Expect(container.Command[2]).To(ContainSubstring("--s3-region"))
+
+			// Verify S3_REGION env var is present
+			var regionEnv *corev1.EnvVar
+			for i, e := range container.Env {
+				if e.Name == "S3_REGION" {
+					regionEnv = &container.Env[i]
+					break
+				}
+			}
+			Expect(regionEnv).NotTo(BeNil())
+			Expect(regionEnv.Value).To(Equal("us-west-2"))
+
+			// Clean up
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+
 		It("Should propagate nodeSelector and tolerations to CronJob pod template", func() {
 			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
 				Skip("Skipping resource validation in minimal mode")


### PR DESCRIPTION
## Summary
- Adds `--s3-region` flag to the rclone shell command in `buildBackupCronJob()` when `creds.Region != ""`
- Adds `S3_REGION` env var to `rcloneCronJobEnv()` when region is set
- The pre-delete/pre-update backup Jobs (`buildRcloneJob()`) already handled this correctly -- only the periodic CronJob code path was affected

Closes #351

## Test plan
- [x] Unit tests: added 3 new test cases in `s3_test.go` covering region with static creds, no region, and region with env-auth
- [x] E2E test: added test verifying CronJob gets `--s3-region` flag and `S3_REGION` env var when `S3_REGION` is set in the credentials Secret
- [x] `go vet ./...` passes
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)