### PR TITLE
docs: document restoreFrom for clone/migrate workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,8 @@ spec:
 
 The operator runs a restore job to populate the PVC before starting the StatefulSet, then clears `restoreFrom` automatically. Backup paths follow the format `backups/<tenantId>/<instanceName>/<timestamp>`.
 
+**Clone / migrate an instance:** `restoreFrom` works on both existing and brand-new instances. To clone an instance across namespaces, create a new `OpenClawInstance` with `spec.restoreFrom` pointing to the source's backup path - the operator creates the PVC, runs the restore Job, then starts the StatefulSet. The new instance gets a fresh gateway token; the source is unaffected. The restore Job uses `spec.backup.serviceAccountName` when set, so workload identity (IRSA/Pod Identity) works for cross-namespace clones. For ArgoCD users, add `spec.restoreFrom` to `ignoreDifferences` since the operator auto-clears it after restore.
+
 For full details see the [Backup and Restore section](docs/api-reference.md#backup-and-restore) in the API reference.
 
 ### What the operator manages automatically

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -774,9 +774,9 @@ spec:
 
 | Field         | Type     | Default | Description                                                                                       |
 |---------------|----------|---------|---------------------------------------------------------------------------------------------------|
-| `restoreFrom` | `string` | --      | S3 path to restore data from (e.g., `backups/{tenantId}/{instanceId}/{timestamp}`). When set, the operator restores PVC data from this path before creating the StatefulSet. Cleared automatically after successful restore. Requires the `s3-backup-credentials` Secret to be present in the operator namespace. |
+| `restoreFrom` | `string` | --      | S3 path to restore data from (e.g., `backups/{tenantId}/{instanceId}/{timestamp}`). When set, the operator restores PVC data from this path before creating the StatefulSet. Works on both existing and new instances (enabling clone/migrate workflows). Cleared automatically after successful restore. Requires the `s3-backup-credentials` Secret to be present in the operator namespace. |
 
-See [Backup and Restore](#backup-and-restore) for full setup instructions.
+See [Backup and Restore](#backup-and-restore) for full setup instructions, including [clone/migrate workflows](#clone--migrate-an-instance).
 
 ### spec.runtimeDeps
 
@@ -1046,6 +1046,54 @@ spec:
 ```
 
 To find available backups, list the S3 bucket directly (e.g., `aws s3 ls s3://my-openclaw-backups/backups/`). The `status.lastBackupPath` field on any existing instance shows its last backup path.
+
+**Restore behavior:**
+
+- The restore Job runs **before** the StatefulSet is created (reconcile order: PVC -> restore Job -> StatefulSet)
+- `spec.restoreFrom` is cleared automatically after a successful restore and the original path is recorded in `status.restoredFrom`
+- The restore Job uses `spec.backup.serviceAccountName` when set, so workload identity (IRSA/Pod Identity) works for restores
+- If the restore Job fails, the operator sets `RestoreComplete=False` and retries. Delete the failed Job to trigger a fresh attempt
+
+### Clone / migrate an instance
+
+`spec.restoreFrom` works on **new instances** (with empty PVCs), not just existing ones. This enables cloning and cross-namespace migration workflows.
+
+**Example - clone instance A from namespace X to namespace Y:**
+
+```yaml
+# 1. Check the source instance's last backup path:
+#    kubectl get openclawinstance my-agent -n ns-x -o jsonpath='{.status.lastBackupPath}'
+#    -> backups/tenant-x/my-agent/2026-03-15T02:00:00Z
+
+# 2. Create a new instance in the target namespace with restoreFrom:
+apiVersion: openclaw.rocks/v1alpha1
+kind: OpenClawInstance
+metadata:
+  name: my-agent-clone
+  namespace: ns-y
+spec:
+  image:
+    repository: ghcr.io/openclaw/openclaw
+    tag: latest
+  restoreFrom: "backups/tenant-x/my-agent/2026-03-15T02:00:00Z"
+  backup:
+    serviceAccountName: "openclaw-backup"  # if using workload identity
+```
+
+The operator creates the PVC, runs the restore Job (rclone sync from S3 to the new PVC), then starts the StatefulSet with the restored data. The new instance gets a fresh gateway token - the source instance is unaffected.
+
+**ArgoCD integration:** The operator auto-clears `spec.restoreFrom` after a successful restore. To prevent ArgoCD from detecting this as drift, add it to `ignoreDifferences`:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  ignoreDifferences:
+    - group: openclaw.rocks
+      kind: OpenClawInstance
+      jsonPointers:
+        - /spec/restoreFrom
+```
 
 ### Periodic / scheduled backups
 


### PR DESCRIPTION
## Summary
- Adds a "Clone / migrate an instance" section to the API reference with a worked example for cross-namespace cloning
- Documents restore Job behavior: reconcile ordering, auto-clear of `spec.restoreFrom`, `status.restoredFrom`, SA inheritance, and retry mechanism
- Adds ArgoCD `ignoreDifferences` example for the auto-cleared `restoreFrom` field
- Updates the `spec.restoreFrom` field table to mention clone/migrate support
- Adds a clone/migrate summary paragraph to the README backup section

Closes #352

## Test plan
- [x] Docs-only change -- no code modifications
- [x] Verified anchor links resolve correctly (`#clone--migrate-an-instance`)
- [x] Cross-referenced from `spec.restoreFrom` table and README

🤖 Generated with [Claude Code](https://claude.com/claude-code)