### PR TITLE
fix(chromium): swap ports so CDP proxy owns 9222, eliminating headless bypass

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -512,7 +512,7 @@ When `ports` is not set, the Service exposes these default ports:
 |-------------|--------|-------------|---------------------------------|
 | `gateway`   | 18789  | 18790       | OpenClaw WebSocket gateway (via nginx proxy sidecar). |
 | `canvas`    | 18793  | 18794       | OpenClaw Canvas HTTP server (via nginx proxy sidecar). |
-| `chromium`  | 9222   | 9222        | Chrome DevTools Protocol (only if Chromium sidecar is enabled). |
+| `chromium`  | 9222   | 9222        | Chrome DevTools Protocol via nginx CDP proxy (only if Chromium sidecar is enabled). Browserless listens internally on port 9224. |
 
 The gateway and canvas ports route through an nginx reverse proxy sidecar because the gateway process binds to loopback (`127.0.0.1`). The proxy listens on dedicated ports (`0.0.0.0`) and forwards traffic to loopback. This avoids CWE-319 plaintext WebSocket security errors on non-loopback addresses.
 

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -49,16 +49,19 @@ const (
 	// NginxConfigKey is the ConfigMap data key for the nginx stream config
 	NginxConfigKey = "nginx.conf"
 
-	// ChromiumPort is the port the chromium sidecar listens on.
-	// The browserless image defaults to 3000, but we override it to 9222
-	// via the PORT env var to avoid conflicting with the OpenClaw gateway's
-	// built-in browser control service on port 3000.
+	// ChromiumPort is the external CDP port that all clients connect to.
+	// The nginx CDP proxy listens on this port, injecting Chrome launch
+	// args (anti-bot flags) into WebSocket connections before forwarding
+	// to browserless on BrowserlessInternalPort. By owning port 9222
+	// directly, the proxy cannot be bypassed -- even on headless Services
+	// where kube-proxy is not involved and DNS resolves to pod IPs.
 	ChromiumPort = 9222
 
-	// ChromiumProxyPort is the port the nginx CDP proxy listens on.
-	// It sits between OpenClaw and the browserless sidecar, injecting
-	// Chrome launch args (anti-bot flags) into WebSocket connections.
-	ChromiumProxyPort = 9223
+	// BrowserlessInternalPort is the internal port where the browserless
+	// container actually listens. Traffic should always flow through the
+	// CDP proxy on ChromiumPort first. This port is not exposed via
+	// Services and is only reachable within the pod on localhost.
+	BrowserlessInternalPort = 9224
 
 	// ChromiumProxyNginxConfigKey is the ConfigMap data key for the
 	// chromium CDP proxy nginx config

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -656,7 +656,7 @@ http {
         }
     }
 }
-`, ChromiumProxyPort, encoded, ChromiumPort, ChromiumPort)
+`, ChromiumPort, encoded, BrowserlessInternalPort, BrowserlessInternalPort)
 }
 
 // deduplicateArgs merges default and extra Chrome launch args, removing

--- a/internal/resources/networkpolicy.go
+++ b/internal/resources/networkpolicy.go
@@ -106,7 +106,7 @@ func networkPolicyIngressPorts(instance *openclawv1alpha1.OpenClawInstance) []ne
 		},
 			networkingv1.NetworkPolicyPort{
 				Protocol: Ptr(corev1.ProtocolTCP),
-				Port:     Ptr(intstr.FromInt32(int32(ChromiumProxyPort))),
+				Port:     Ptr(intstr.FromInt32(int32(BrowserlessInternalPort))),
 			})
 	}
 
@@ -239,12 +239,12 @@ func buildEgressRules(instance *openclawv1alpha1.OpenClawInstance) []networkingv
 		})
 	}
 
-	// Allow egress to the Chromium CDP proxy and sidecar. The main container
-	// reaches the CDP proxy via a headless Service that resolves to the pod's
-	// own IP. Both the proxy port (9223) and direct port (9222) are allowed
-	// because some CNIs check pre-DNAT ports and others check post-DNAT.
-	// Cilium short-circuits self-traffic and doesn't require this rule, but
-	// it's correct to include for portability (e.g. Calico).
+	// Allow egress to the Chromium CDP proxy and browserless sidecar. The main
+	// container reaches the CDP proxy via a headless Service that resolves to
+	// the pod's own IP. Both the proxy port (9222) and the internal browserless
+	// port (9224) are allowed because some CNIs check pre-DNAT ports and
+	// others check post-DNAT. Cilium short-circuits self-traffic and doesn't
+	// require this rule, but it's correct to include for portability (e.g. Calico).
 	if instance.Spec.Chromium.Enabled {
 		rules = append(rules, networkingv1.NetworkPolicyEgressRule{
 			To: []networkingv1.NetworkPolicyPeer{
@@ -261,7 +261,7 @@ func buildEgressRules(instance *openclawv1alpha1.OpenClawInstance) []networkingv
 				},
 				{
 					Protocol: Ptr(corev1.ProtocolTCP),
-					Port:     Ptr(intstr.FromInt32(int32(ChromiumProxyPort))),
+					Port:     Ptr(intstr.FromInt32(int32(BrowserlessInternalPort))),
 				},
 			},
 		})

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -462,7 +462,7 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 	for _, env := range mainContainer.Env {
 		if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 			foundChromiumCDP = true
-			expected := fmt.Sprintf("http://%s-cdp.%s.svc:%d", instance.Name, instance.Namespace, ChromiumProxyPort)
+			expected := fmt.Sprintf("http://%s-cdp.%s.svc:%d", instance.Name, instance.Namespace, ChromiumPort)
 			if env.Value != expected {
 				t.Errorf("OPENCLAW_CHROMIUM_CDP = %q, want %q", env.Value, expected)
 			}
@@ -478,8 +478,8 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 	for _, env := range chromium.Env {
 		if env.Name == "PORT" {
 			foundPortEnv = true
-			if env.Value != fmt.Sprintf("%d", ChromiumPort) {
-				t.Errorf("chromium PORT env = %q, want %q", env.Value, fmt.Sprintf("%d", ChromiumPort))
+			if env.Value != fmt.Sprintf("%d", BrowserlessInternalPort) {
+				t.Errorf("chromium PORT env = %q, want %q", env.Value, fmt.Sprintf("%d", BrowserlessInternalPort))
 			}
 		}
 		if env.Name == "HOST" {
@@ -505,11 +505,11 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 	if len(chromium.Ports) != 1 {
 		t.Fatalf("chromium container should have 1 port, got %d", len(chromium.Ports))
 	}
-	if chromium.Ports[0].ContainerPort != ChromiumPort {
-		t.Errorf("chromium port = %d, want %d", chromium.Ports[0].ContainerPort, ChromiumPort)
+	if chromium.Ports[0].ContainerPort != BrowserlessInternalPort {
+		t.Errorf("chromium port = %d, want %d", chromium.Ports[0].ContainerPort, BrowserlessInternalPort)
 	}
-	if chromium.Ports[0].Name != "cdp" {
-		t.Errorf("chromium port name = %q, want %q", chromium.Ports[0].Name, "cdp")
+	if chromium.Ports[0].Name != "browserless" {
+		t.Errorf("chromium port name = %q, want %q", chromium.Ports[0].Name, "browserless")
 	}
 
 	// Chromium security context
@@ -9697,29 +9697,29 @@ func TestBuildNetworkPolicy_ChromiumIngressAndEgress(t *testing.T) {
 
 	ports := np.Spec.Ingress[0].Ports
 	if len(ports) != 5 {
-		t.Fatalf("expected 5 ingress ports with chromium (gateway, canvas, chromium, chromium-proxy, metrics), got %d", len(ports))
+		t.Fatalf("expected 5 ingress ports with chromium (gateway, canvas, chromium, browserless, metrics), got %d", len(ports))
 	}
 
 	foundChromiumIngress := false
-	foundChromiumProxyIngress := false
+	foundBrowserlessIngress := false
 	for _, p := range ports {
 		if p.Port != nil && p.Port.IntValue() == ChromiumPort {
 			foundChromiumIngress = true
 		}
-		if p.Port != nil && p.Port.IntValue() == ChromiumProxyPort {
-			foundChromiumProxyIngress = true
+		if p.Port != nil && p.Port.IntValue() == BrowserlessInternalPort {
+			foundBrowserlessIngress = true
 		}
 	}
 	if !foundChromiumIngress {
 		t.Error("chromium port not found in NetworkPolicy ingress ports")
 	}
-	if !foundChromiumProxyIngress {
-		t.Error("chromium proxy port not found in NetworkPolicy ingress ports")
+	if !foundBrowserlessIngress {
+		t.Error("browserless internal port not found in NetworkPolicy ingress ports")
 	}
 
-	// Egress: should have a rule for chromium CDP self-traffic (ports 9222 + 9223)
+	// Egress: should have a rule for chromium CDP self-traffic (ports 9222 + 9224)
 	foundChromiumEgress := false
-	foundChromiumProxyEgress := false
+	foundBrowserlessEgress := false
 	for _, rule := range np.Spec.Egress {
 		for _, p := range rule.Ports {
 			if p.Port != nil && p.Port.IntValue() == ChromiumPort {
@@ -9731,16 +9731,16 @@ func TestBuildNetworkPolicy_ChromiumIngressAndEgress(t *testing.T) {
 					t.Error("chromium egress rule should use podSelector for self-traffic")
 				}
 			}
-			if p.Port != nil && p.Port.IntValue() == ChromiumProxyPort {
-				foundChromiumProxyEgress = true
+			if p.Port != nil && p.Port.IntValue() == BrowserlessInternalPort {
+				foundBrowserlessEgress = true
 			}
 		}
 	}
 	if !foundChromiumEgress {
 		t.Error("chromium egress rule (port 9222) not found in NetworkPolicy")
 	}
-	if !foundChromiumProxyEgress {
-		t.Error("chromium proxy egress rule (port 9223) not found in NetworkPolicy")
+	if !foundBrowserlessEgress {
+		t.Error("browserless internal egress rule (port 9224) not found in NetworkPolicy")
 	}
 }
 
@@ -10912,16 +10912,16 @@ func TestBuildStatefulSet_ChromiumProxySidecar(t *testing.T) {
 	}
 
 	// Should listen on the proxy port
-	if len(proxy.Ports) != 1 || proxy.Ports[0].ContainerPort != ChromiumProxyPort {
-		t.Errorf("expected port %d, got %v", ChromiumProxyPort, proxy.Ports)
+	if len(proxy.Ports) != 1 || proxy.Ports[0].ContainerPort != ChromiumPort {
+		t.Errorf("expected port %d, got %v", ChromiumPort, proxy.Ports)
 	}
 
 	// Should have startup probe on the proxy port
 	if proxy.StartupProbe == nil {
 		t.Fatal("chromium-proxy should have a startup probe")
 	}
-	if proxy.StartupProbe.HTTPGet.Port.IntValue() != int(ChromiumProxyPort) {
-		t.Errorf("startup probe should check port %d, got %d", ChromiumProxyPort, proxy.StartupProbe.HTTPGet.Port.IntValue())
+	if proxy.StartupProbe.HTTPGet.Port.IntValue() != int(ChromiumPort) {
+		t.Errorf("startup probe should check port %d, got %d", ChromiumPort, proxy.StartupProbe.HTTPGet.Port.IntValue())
 	}
 
 	// Should come AFTER the chromium (browserless) sidecar
@@ -10975,13 +10975,13 @@ func TestBuildConfigMap_ChromiumProxyNginxConfig(t *testing.T) {
 	}
 
 	// Should contain the proxy port
-	if !strings.Contains(proxyConfig, fmt.Sprintf("listen 0.0.0.0:%d", ChromiumProxyPort)) {
-		t.Error("proxy config should listen on ChromiumProxyPort")
+	if !strings.Contains(proxyConfig, fmt.Sprintf("listen 0.0.0.0:%d", ChromiumPort)) {
+		t.Error("proxy config should listen on ChromiumPort (9222)")
 	}
 
-	// Should proxy to the chromium port
-	if !strings.Contains(proxyConfig, fmt.Sprintf("proxy_pass http://127.0.0.1:%d", ChromiumPort)) {
-		t.Error("proxy config should forward to ChromiumPort")
+	// Should proxy to the internal browserless port
+	if !strings.Contains(proxyConfig, fmt.Sprintf("proxy_pass http://127.0.0.1:%d", BrowserlessInternalPort)) {
+		t.Error("proxy config should forward to BrowserlessInternalPort (9224)")
 	}
 
 	// Should contain the default anti-bot flags (URL-encoded)
@@ -11060,11 +11060,11 @@ func TestBuildChromiumCDPService_TargetsProxyPort(t *testing.T) {
 	}
 
 	port := svc.Spec.Ports[0]
-	if port.Port != int32(ChromiumProxyPort) {
-		t.Errorf("service port should be %d (proxy port, headless Service has no port translation), got %d", ChromiumProxyPort, port.Port)
+	if port.Port != int32(ChromiumPort) {
+		t.Errorf("service port should be %d (proxy owns this port directly), got %d", ChromiumPort, port.Port)
 	}
-	if port.TargetPort.IntValue() != int(ChromiumProxyPort) {
-		t.Errorf("target port should be %d (proxy), got %d", ChromiumProxyPort, port.TargetPort.IntValue())
+	if port.TargetPort.IntValue() != int(ChromiumPort) {
+		t.Errorf("target port should be %d (proxy), got %d", ChromiumPort, port.TargetPort.IntValue())
 	}
 }
 

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -128,14 +128,11 @@ func buildServicePorts(instance *openclawv1alpha1.OpenClawInstance) []corev1.Ser
 // its own readiness probe has passed. Without this, the main ClusterIP Service
 // has no endpoints and the CDP health check fails permanently.
 //
-// Traffic is routed to the chromium CDP proxy (ChromiumProxyPort) which
-// injects anti-bot Chrome launch args before forwarding to browserless.
-//
-// IMPORTANT: This is a headless Service (ClusterIP: None), so kube-proxy
-// does NOT translate Port to TargetPort. DNS resolves directly to the pod
-// IP and the client connects on the Port value. Both Port and TargetPort
-// must be ChromiumProxyPort so traffic reaches the proxy, not browserless
-// directly. Using ChromiumPort (9222) here would bypass the proxy entirely.
+// Traffic is routed to the chromium CDP proxy on ChromiumPort (9222) which
+// injects anti-bot Chrome launch args before forwarding to browserless on
+// BrowserlessInternalPort (9224). Because the proxy owns port 9222 directly,
+// the headless bypass is eliminated -- DNS resolves to pod IPs, and port
+// 9222 always hits the proxy regardless of whether kube-proxy is involved.
 func BuildChromiumCDPService(instance *openclawv1alpha1.OpenClawInstance) *corev1.Service {
 	labels := Labels(instance)
 	selectorLabels := SelectorLabels(instance)
@@ -154,8 +151,8 @@ func BuildChromiumCDPService(instance *openclawv1alpha1.OpenClawInstance) *corev
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "cdp",
-					Port:       int32(ChromiumProxyPort),
-					TargetPort: intstr.FromInt32(int32(ChromiumProxyPort)),
+					Port:       int32(ChromiumPort),
+					TargetPort: intstr.FromInt32(int32(ChromiumPort)),
 					Protocol:   corev1.ProtocolTCP,
 				},
 			},

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -415,16 +415,10 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 
 	if instance.Spec.Chromium.Enabled {
 		// Use the headless CDP Service DNS name to reach the Chromium sidecar
-		// via the chromium-proxy nginx sidecar. The proxy intercepts WebSocket
-		// connections and routes them to browserless's /chromium endpoint with
-		// anti-bot launch args (+ user ExtraArgs) via the `launch` query param.
-		//
-		// IMPORTANT: Must use ChromiumProxyPort (9223), not ChromiumPort (9222).
-		// The CDP Service is headless (ClusterIP: None), so kube-proxy does NOT
-		// translate Port to TargetPort. DNS resolves to the pod IP directly and
-		// the client connects on the port in the URL. Using 9222 would bypass
-		// the proxy entirely, hitting browserless directly and skipping all
-		// launch arg injection.
+		// via the chromium-proxy nginx sidecar. The proxy owns ChromiumPort
+		// (9222) directly, so connections always hit the proxy first --
+		// regardless of whether the Service is headless (where kube-proxy
+		// doesn't translate Port/TargetPort and DNS resolves to pod IPs).
 		//
 		// A non-loopback address triggers OpenClaw's remote/attach mode so
 		// the browser control service connects to the existing sidecar
@@ -438,7 +432,7 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 		env = append(env,
 			corev1.EnvVar{
 				Name:  "OPENCLAW_CHROMIUM_CDP",
-				Value: fmt.Sprintf("http://%s:%d", cdpSvcDNS, ChromiumProxyPort),
+				Value: fmt.Sprintf("http://%s:%d", cdpSvcDNS, ChromiumPort),
 			},
 		)
 	}
@@ -1338,8 +1332,8 @@ func buildChromiumProxyContainer(instance *openclawv1alpha1.OpenClawInstance) co
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "cdp-proxy",
-				ContainerPort: ChromiumProxyPort,
+				Name:          "cdp",
+				ContainerPort: ChromiumPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
@@ -1383,7 +1377,7 @@ func buildChromiumProxyContainer(instance *openclawv1alpha1.OpenClawInstance) co
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: "/json/version",
-					Port: intstr.FromInt32(ChromiumProxyPort),
+					Port: intstr.FromInt32(ChromiumPort),
 				},
 			},
 			PeriodSeconds:    1,
@@ -1434,7 +1428,7 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 	// HOST=:: enables dual-stack listening so the sidecar is reachable on
 	// both IPv4 (127.0.0.1) and IPv6 (::1) loopback addresses.
 	chromiumEnv := []corev1.EnvVar{
-		{Name: "PORT", Value: fmt.Sprintf("%d", ChromiumPort)},
+		{Name: "PORT", Value: fmt.Sprintf("%d", BrowserlessInternalPort)},
 		{Name: "HOST", Value: "::"},
 	}
 
@@ -1496,8 +1490,8 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "cdp",
-				ContainerPort: ChromiumPort,
+				Name:          "browserless",
+				ContainerPort: BrowserlessInternalPort,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},
@@ -1512,7 +1506,7 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: "/json/version",
-					Port: intstr.FromInt32(ChromiumPort),
+					Port: intstr.FromInt32(BrowserlessInternalPort),
 				},
 			},
 			InitialDelaySeconds: 1,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1313,7 +1313,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})
 
-		It("Should create chromium sidecar on port 9222 to avoid port 3000 conflict", func() {
+		It("Should create chromium sidecar on port 9224 with proxy on port 9222", func() {
 			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
 				Skip("Skipping resource validation in minimal mode")
 			}
@@ -1361,15 +1361,15 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(chromiumContainer).NotTo(BeNil(), "chromium sidecar init container should exist")
 			Expect(chromiumContainer.Image).To(Equal("ghcr.io/browserless/chromium:latest"))
 			Expect(chromiumContainer.Ports).To(HaveLen(1))
-			Expect(chromiumContainer.Ports[0].ContainerPort).To(Equal(int32(resources.ChromiumPort)))
+			Expect(chromiumContainer.Ports[0].ContainerPort).To(Equal(int32(resources.BrowserlessInternalPort)))
 
 			// Verify chromium container has PORT env var to override default (3000)
 			var foundPortEnv bool
 			for _, env := range chromiumContainer.Env {
 				if env.Name == "PORT" {
 					foundPortEnv = true
-					Expect(env.Value).To(Equal(fmt.Sprintf("%d", resources.ChromiumPort)),
-						"PORT env should override browserless default to avoid conflict with OpenClaw browser control service")
+					Expect(env.Value).To(Equal(fmt.Sprintf("%d", resources.BrowserlessInternalPort)),
+						"PORT env should set browserless to internal port so proxy owns port 9222")
 					break
 				}
 			}
@@ -1379,7 +1379,7 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			mainContainer := statefulSet.Spec.Template.Spec.Containers[0]
 			var foundChromiumCDP bool
 			expectedCDP := fmt.Sprintf("http://%s.%s.svc:%d",
-				resources.ChromiumCDPServiceName(instance), instance.Namespace, resources.ChromiumProxyPort)
+				resources.ChromiumCDPServiceName(instance), instance.Namespace, resources.ChromiumPort)
 			for _, env := range mainContainer.Env {
 				if env.Name == "OPENCLAW_CHROMIUM_CDP" {
 					foundChromiumCDP = true


### PR DESCRIPTION
## Summary

- Moves browserless from port 9222 to internal port 9224 (`BrowserlessInternalPort`)
- CDP proxy now listens on port 9222 (`ChromiumPort`) directly, so it cannot be bypassed
- Fixes the headless Service bypass where `ClusterIP: None` caused DNS to resolve to pod IPs, skipping the proxy's `targetPort` mapping entirely
- `spec.chromium.extraArgs` (e.g. `--user-agent`, `--window-size`) and default anti-bot flags now always take effect

**Root cause:** Headless Services don't involve kube-proxy, so `Port`/`TargetPort` translation never happens. DNS resolves to pod IPs and clients connect on the URL port directly. With browserless on 9222 and the proxy on 9223, every connection to port 9222 hit browserless directly, bypassing all launch arg injection.

**Related:** #360 (Playwright/browserless incompatibility is a separate issue -- Playwright discovers Chrome's direct debugging port and bypasses browserless entirely)

Closes #270

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/resources/` -- all chromium-related unit tests pass
- [ ] `make test` -- full unit + integration tests (CI)
- [ ] `make lint` -- golangci-lint (CI)
- [ ] E2E tests verify correct port assignments (CI)
- [ ] No remaining references to `ChromiumProxyPort` constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)