### PR TITLE
fix: inject diagnostics.metrics config into OpenClaw when metrics enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,8 @@ The operator follows a **secure-by-default** philosophy. Every instance ships wi
 | `openclaw_autoupdate_applied_total` | Counter | Successful auto-updates applied |
 | `openclaw_autoupdate_rollbacks_total` | Counter | Auto-update rollbacks triggered |
 
+When `metrics.enabled: true` (the default), the operator automatically injects `diagnostics.metrics` config into the OpenClaw application so it serves a Prometheus `/metrics` endpoint on the configured port (default 9090). No manual OpenClaw configuration is needed.
+
 ### ServiceMonitor
 
 ```yaml

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -666,8 +666,8 @@ Metrics and logging configuration.
 
 | Field                       | Type                | Default | Description                                   |
 |-----------------------------|---------------------|---------|-----------------------------------------------|
-| `enabled`                   | `*bool`             | `true`  | Enable the metrics endpoint on the managed instance. |
-| `port`                      | `*int32`            | `9090`  | Metrics port.                                 |
+| `enabled`                   | `*bool`             | `true`  | Enable the metrics endpoint on the managed instance. When enabled, the operator injects `diagnostics.metrics.enabled=true` and `diagnostics.metrics.port` into the OpenClaw config so the application serves a Prometheus scrape endpoint on the configured port. |
+| `port`                      | `*int32`            | `9090`  | Metrics port. Injected into the OpenClaw config as `diagnostics.metrics.port`. |
 | `serviceMonitor.enabled`    | `*bool`             | `false` | Create a Prometheus `ServiceMonitor`.         |
 | `serviceMonitor.interval`   | `string`            | `30s`   | Prometheus scrape interval.                   |
 | `serviceMonitor.labels`     | `map[string]string` | --      | Labels to add to the ServiceMonitor (for Prometheus selector matching). |

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -46,8 +46,8 @@ func BuildConfigMap(instance *openclawv1alpha1.OpenClawInstance, gatewayToken st
 // BuildConfigMapFromBytes creates a ConfigMap for the OpenClawInstance using
 // the provided base config bytes. This allows the controller to pass config
 // from any source (inline raw, external ConfigMap, or empty default).
-// The enrichment pipeline (gateway auth, device auth, tailscale, browser,
-// gateway bind, skill packs) always runs on the provided bytes.
+// The enrichment pipeline (metrics, gateway auth, device auth, tailscale,
+// browser, gateway bind, skill packs) always runs on the provided bytes.
 func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseConfig []byte, gatewayToken string, skillPacks *ResolvedSkillPacks) *corev1.ConfigMap {
 	labels := Labels(instance)
 
@@ -56,7 +56,12 @@ func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseCo
 		configBytes = []byte("{}")
 	}
 
-	// Enrichment pipeline: gateway auth -> device auth -> tailscale -> browser -> gateway bind -> trusted proxies -> control UI origins -> skill packs
+	// Enrichment pipeline: metrics -> gateway auth -> device auth -> tailscale -> browser -> gateway bind -> trusted proxies -> control UI origins -> skill packs
+	if IsMetricsEnabled(instance) {
+		if enriched, err := enrichConfigWithMetrics(configBytes, instance); err == nil {
+			configBytes = enriched
+		}
+	}
 	if gatewayToken != "" {
 		if enriched, err := enrichConfigWithGatewayAuth(configBytes, gatewayToken); err == nil {
 			configBytes = enriched
@@ -153,6 +158,38 @@ func enrichConfigWithGatewayAuth(configJSON []byte, token string) ([]byte, error
 	auth["token"] = token
 	gw["auth"] = auth
 	config["gateway"] = gw
+
+	return json.Marshal(config)
+}
+
+// enrichConfigWithMetrics injects diagnostics.metrics.enabled=true and
+// diagnostics.metrics.port into the config JSON so OpenClaw starts a
+// Prometheus scrape endpoint on the configured metrics port. Without this
+// injection, the operator creates the container port, Service port, and
+// ServiceMonitor but nothing inside the container actually binds to the port.
+// If the user has already set diagnostics.metrics, the config is returned
+// unchanged (user override wins).
+func enrichConfigWithMetrics(configJSON []byte, instance *openclawv1alpha1.OpenClawInstance) ([]byte, error) {
+	var config map[string]interface{}
+	if err := json.Unmarshal(configJSON, &config); err != nil {
+		return configJSON, nil // not a JSON object, return unchanged
+	}
+
+	diag, _ := config["diagnostics"].(map[string]interface{})
+	if diag == nil {
+		diag = make(map[string]interface{})
+	}
+
+	// If the user already set diagnostics.metrics, don't override
+	if _, ok := diag["metrics"]; ok {
+		return configJSON, nil
+	}
+
+	diag["metrics"] = map[string]interface{}{
+		"enabled": true,
+		"port":    float64(MetricsPort(instance)),
+	}
+	config["diagnostics"] = diag
 
 	return json.Marshal(config)
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2269,6 +2269,172 @@ func TestBuildConfigMapFromBytes_JSON5Passthrough(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// enrichConfigWithMetrics tests
+// ---------------------------------------------------------------------------
+
+func TestEnrichConfigWithMetrics(t *testing.T) {
+	input := []byte(`{}`)
+	instance := newTestInstance("metrics-test")
+	out, err := enrichConfigWithMetrics(input, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	diag, ok := cfg["diagnostics"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected diagnostics key")
+	}
+	metrics, ok := diag["metrics"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected diagnostics.metrics key")
+	}
+	if metrics["enabled"] != true {
+		t.Errorf("diagnostics.metrics.enabled = %v, want true", metrics["enabled"])
+	}
+	if metrics["port"] != float64(DefaultMetricsPort) {
+		t.Errorf("diagnostics.metrics.port = %v, want %v", metrics["port"], DefaultMetricsPort)
+	}
+}
+
+func TestEnrichConfigWithMetrics_CustomPort(t *testing.T) {
+	input := []byte(`{}`)
+	instance := newTestInstance("metrics-custom-port")
+	customPort := int32(9191)
+	instance.Spec.Observability.Metrics.Port = &customPort
+	out, err := enrichConfigWithMetrics(input, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	diag := cfg["diagnostics"].(map[string]interface{})
+	metrics := diag["metrics"].(map[string]interface{})
+	if metrics["port"] != float64(9191) {
+		t.Errorf("diagnostics.metrics.port = %v, want 9191", metrics["port"])
+	}
+}
+
+func TestEnrichConfigWithMetrics_PreservesUserOverride(t *testing.T) {
+	input := []byte(`{"diagnostics":{"metrics":{"enabled":true,"port":8080,"path":"/custom"}}}`)
+	instance := newTestInstance("metrics-user-override")
+	out, err := enrichConfigWithMetrics(input, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	diag := cfg["diagnostics"].(map[string]interface{})
+	metrics := diag["metrics"].(map[string]interface{})
+	// User's custom path should be preserved (not overwritten)
+	if metrics["path"] != "/custom" {
+		t.Errorf("user-set diagnostics.metrics.path = %v, want /custom", metrics["path"])
+	}
+	if metrics["port"] != float64(8080) {
+		t.Errorf("user-set diagnostics.metrics.port = %v, want 8080", metrics["port"])
+	}
+}
+
+func TestEnrichConfigWithMetrics_PreservesOtherDiagnosticsFields(t *testing.T) {
+	input := []byte(`{"diagnostics":{"otel":{"endpoint":"http://collector:4317"}}}`)
+	instance := newTestInstance("metrics-other-fields")
+	out, err := enrichConfigWithMetrics(input, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	diag := cfg["diagnostics"].(map[string]interface{})
+	// OTEL config should be preserved
+	otel, ok := diag["otel"].(map[string]interface{})
+	if !ok {
+		t.Fatal("diagnostics.otel should be preserved")
+	}
+	if otel["endpoint"] != "http://collector:4317" {
+		t.Errorf("diagnostics.otel.endpoint = %v, want http://collector:4317", otel["endpoint"])
+	}
+	// Metrics should also be injected
+	metrics, ok := diag["metrics"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected diagnostics.metrics key")
+	}
+	if metrics["enabled"] != true {
+		t.Errorf("diagnostics.metrics.enabled = %v, want true", metrics["enabled"])
+	}
+}
+
+func TestEnrichConfigWithMetrics_InvalidJSON(t *testing.T) {
+	input := []byte(`not-json`)
+	instance := newTestInstance("metrics-invalid")
+	out, err := enrichConfigWithMetrics(input, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(out, input) {
+		t.Error("invalid JSON should be returned unchanged")
+	}
+}
+
+func TestBuildConfigMap_MetricsInjected(t *testing.T) {
+	instance := newTestInstance("cm-metrics")
+	cm := BuildConfigMap(instance, "", nil)
+
+	content := cm.Data["openclaw.json"]
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	diag, ok := parsed["diagnostics"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected diagnostics key in default config (metrics enabled by default)")
+	}
+	metrics, ok := diag["metrics"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected diagnostics.metrics key")
+	}
+	if metrics["enabled"] != true {
+		t.Errorf("diagnostics.metrics.enabled = %v, want true", metrics["enabled"])
+	}
+	if metrics["port"] != float64(DefaultMetricsPort) {
+		t.Errorf("diagnostics.metrics.port = %v, want %v", metrics["port"], float64(DefaultMetricsPort))
+	}
+}
+
+func TestBuildConfigMap_MetricsDisabled_NoDiagnosticsInjected(t *testing.T) {
+	instance := newTestInstance("cm-metrics-disabled")
+	disabled := false
+	instance.Spec.Observability.Metrics.Enabled = &disabled
+	cm := BuildConfigMap(instance, "", nil)
+
+	content := cm.Data["openclaw.json"]
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	if _, ok := parsed["diagnostics"]; ok {
+		t.Error("diagnostics should not be injected when metrics.enabled=false")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // enrichConfigWithGatewayBind tests
 // ---------------------------------------------------------------------------
 

--- a/test/e2e/e2e_observability_test.go
+++ b/test/e2e/e2e_observability_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"encoding/json"
 	"os"
 	"time"
 
@@ -330,6 +331,29 @@ var _ = Describe("Observability - Deep Insights", func() {
 				}
 			}
 			Expect(foundMetricsContainerPort).To(BeTrue(), "main container should have a metrics port")
+
+			// Verify ConfigMap has diagnostics.metrics config injected
+			cm := &corev1.ConfigMap{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.ConfigMapName(instance),
+					Namespace: namespace,
+				}, cm)
+			}, timeout, interval).Should(Succeed())
+
+			configContent, ok := cm.Data["openclaw.json"]
+			Expect(ok).To(BeTrue(), "ConfigMap should have openclaw.json key")
+
+			var parsed map[string]interface{}
+			Expect(json.Unmarshal([]byte(configContent), &parsed)).To(Succeed())
+
+			diag, ok := parsed["diagnostics"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "config should have diagnostics key")
+			metrics, ok := diag["metrics"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "diagnostics should have metrics key")
+			Expect(metrics["enabled"]).To(Equal(true), "diagnostics.metrics.enabled should be true")
+			Expect(metrics["port"]).To(Equal(float64(resources.DefaultMetricsPort)),
+				"diagnostics.metrics.port should match the default metrics port")
 
 			// Verify ServiceMonitor targets metrics port
 			sm := &unstructured.Unstructured{}


### PR DESCRIPTION
## Summary
- The operator created the Kubernetes plumbing for metrics (container port, Service port, ServiceMonitor) but never injected config into the OpenClaw application to actually serve a Prometheus endpoint on that port, causing `TargetDown` alerts
- Adds `enrichConfigWithMetrics()` to the config enrichment pipeline that injects `diagnostics.metrics.enabled=true` and `diagnostics.metrics.port` into `openclaw.json` when `spec.observability.metrics.enabled` is true (the default)
- User-set `diagnostics.metrics` config is preserved (user override wins)

## Test plan
- [x] Unit tests for `enrichConfigWithMetrics` (default port, custom port, user override, other diagnostics fields preserved, invalid JSON)
- [x] Integration tests: `TestBuildConfigMap_MetricsInjected`, `TestBuildConfigMap_MetricsDisabled_NoDiagnosticsInjected`
- [x] E2E test: verifies ConfigMap contains `diagnostics.metrics` config alongside existing Service/StatefulSet/ServiceMonitor checks
- [x] `go vet ./...` passes
- [x] `make lint` passes

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)