### PR TITLE
fix(chromium): return static /json/version to prevent Playwright bypass

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -600,7 +600,12 @@ stream {
 // launch args entirely. By routing all WebSocket upgrades to /chromium,
 // every browser session gets fresh Chrome with the correct flags.
 //
-// HTTP requests (health checks, /json/version) pass through unchanged.
+// The /json/version endpoint returns a static response with
+// webSocketDebuggerUrl pointing back to the proxy (ws://127.0.0.1:9222).
+// This prevents Playwright's connectOverCDP() from discovering Chrome's
+// random direct debugging port and bypassing the proxy -- which would
+// cause browserless to kill Chrome (0 clients) and break the session.
+// Other HTTP requests (health checks, /json/list) pass through unchanged.
 func chromiumProxyNginxConfig(instance *openclawv1alpha1.OpenClawInstance) string {
 	args := deduplicateArgs(DefaultChromiumLaunchArgs, instance.Spec.Chromium.ExtraArgs)
 
@@ -624,14 +629,22 @@ http {
     scgi_temp_path /tmp/scgi;
 
     server {
-        listen 0.0.0.0:%d;
+        listen 0.0.0.0:%[1]d;
+
+        # Return a static /json/version so Playwright's connectOverCDP()
+        # reconnects through this proxy instead of discovering Chrome's
+        # random direct debugging port and bypassing browserless.
+        location = /json/version {
+            default_type application/json;
+            return 200 '{"webSocketDebuggerUrl":"ws://127.0.0.1:%[1]d"}';
+        }
 
         # WebSocket connections route to /chromium with launch args.
         # browserless v2 only applies launch args on the /chromium endpoint
         # (launches new Chrome), not /devtools/browser/ (existing Chrome).
         location @chromium_ws {
-            rewrite ^ /chromium?launch=%s break;
-            proxy_pass http://127.0.0.1:%d;
+            rewrite ^ /chromium?launch=%[2]s break;
+            proxy_pass http://127.0.0.1:%[3]d;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -649,14 +662,14 @@ http {
             }
 
             # HTTP requests pass through to browserless unchanged.
-            proxy_pass http://127.0.0.1:%d;
+            proxy_pass http://127.0.0.1:%[3]d;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_buffering off;
         }
     }
 }
-`, ChromiumPort, encoded, BrowserlessInternalPort, BrowserlessInternalPort)
+`, ChromiumPort, encoded, BrowserlessInternalPort)
 }
 
 // deduplicateArgs merges default and extra Chrome launch args, removing

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -11042,6 +11042,44 @@ func TestBuildConfigMap_ChromiumProxyNginxConfig(t *testing.T) {
 	if !strings.Contains(proxyConfig, "error_page 418") {
 		t.Error("proxy config should use error_page 418 for WebSocket routing")
 	}
+
+	// Should have static /json/version response to prevent Playwright bypass
+	if !strings.Contains(proxyConfig, "location = /json/version") {
+		t.Error("proxy config should have exact-match /json/version location")
+	}
+	expectedWsURL := fmt.Sprintf(`"webSocketDebuggerUrl":"ws://127.0.0.1:%d"`, ChromiumPort)
+	if !strings.Contains(proxyConfig, expectedWsURL) {
+		t.Errorf("proxy config should return static webSocketDebuggerUrl pointing to proxy port, want %s", expectedWsURL)
+	}
+}
+
+func TestBuildConfigMap_ChromiumProxyJsonVersionRewrite(t *testing.T) {
+	instance := newTestInstance("cdp-json-version")
+	instance.Spec.Chromium.Enabled = true
+
+	cm := BuildConfigMap(instance, "", nil)
+	proxyConfig := cm.Data[ChromiumProxyNginxConfigKey]
+
+	// The static /json/version must point to the proxy port (ChromiumPort)
+	// so Playwright's connectOverCDP() reconnects through the proxy instead
+	// of discovering Chrome's random direct debugging port.
+	expectedWsURL := fmt.Sprintf(`ws://127.0.0.1:%d`, ChromiumPort)
+	if !strings.Contains(proxyConfig, expectedWsURL) {
+		t.Errorf("static /json/version should contain %s", expectedWsURL)
+	}
+
+	// Must use exact-match location to take priority over the prefix location /
+	if !strings.Contains(proxyConfig, "location = /json/version") {
+		t.Error("/json/version should use exact-match location (= prefix)")
+	}
+
+	// Must return 200 with application/json content type
+	if !strings.Contains(proxyConfig, "return 200") {
+		t.Error("/json/version should return 200")
+	}
+	if !strings.Contains(proxyConfig, "default_type application/json") {
+		t.Error("/json/version should set content type to application/json")
+	}
 }
 
 func TestBuildConfigMap_ChromiumProxyDeduplicatesArgs(t *testing.T) {

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1372,8 +1372,10 @@ func buildChromiumProxyContainer(instance *openclawv1alpha1.OpenClawInstance) co
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},
 		},
-		// Startup probe verifies the proxy can reach browserless via /json/version.
-		// This gates the next init container / regular containers from starting.
+		// Startup probe verifies the proxy is up via /json/version (static response).
+		// Browserless health is already guaranteed by its own startup probe on
+		// BrowserlessInternalPort (native sidecar ordering). This gates the next
+		// init container / regular containers from starting.
 		StartupProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1486,6 +1486,15 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			}
 			Expect(foundChromiumPort).To(BeTrue(), "Service should have chromium port")
 
+			// Verify chromium proxy nginx config has /json/version rewrite
+			proxyConfig, hasProxyConfig := configMap.Data[resources.ChromiumProxyNginxConfigKey]
+			Expect(hasProxyConfig).To(BeTrue(), "ConfigMap should contain chromium proxy nginx config")
+			Expect(proxyConfig).To(ContainSubstring("location = /json/version"),
+				"proxy config should have static /json/version to prevent Playwright bypass")
+			Expect(proxyConfig).To(ContainSubstring(
+				fmt.Sprintf(`"webSocketDebuggerUrl":"ws://127.0.0.1:%d"`, resources.ChromiumPort)),
+				"static /json/version should point webSocketDebuggerUrl to proxy port")
+
 			// Clean up
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})


### PR DESCRIPTION
## Summary

- Adds an exact-match `location = /json/version` block to the CDP proxy nginx config that returns a static response with `webSocketDebuggerUrl` pointing to `ws://127.0.0.1:9222` (the proxy itself)
- Prevents Playwright's `connectOverCDP()` from discovering Chrome's random direct debugging port and bypassing browserless
- Fixes "tab not found" errors caused by browserless killing Chrome after Playwright switches to the direct port (0 clients)

**Root cause:** `connectOverCDP()` fetches `/json/version`, reads `webSocketDebuggerUrl` (e.g. `ws://127.0.0.1:39395/devtools/browser/...`), and connects directly to Chrome's random port. Browserless sees 0 active clients and kills Chrome after ~5 seconds.

**Fix:** The proxy returns a static `/json/version` response pointing back to itself. Playwright reconnects through the proxy, which routes to `/chromium?launch=...` with anti-bot flags, and browserless manages the Chrome lifecycle properly.

Closes #360

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/resources/` -- all tests pass including new `TestBuildConfigMap_ChromiumProxyJsonVersionRewrite`
- [ ] `make test` -- full unit + integration tests (CI)
- [ ] `make lint` -- golangci-lint (CI)
- [ ] E2E tests verify `/json/version` rewrite in ConfigMap (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)