### PR TITLE
fix: drop read-only PVC mount in backup CronJob to fix fsGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ spec:
     serviceAccountName: ""   # Optional: IRSA/Pod Identity SA for backup Jobs
 ```
 
-The operator creates a Kubernetes CronJob that runs rclone to sync PVC data to S3. The CronJob mounts the PVC read-only (hot backup - no downtime) and uses pod affinity to co-locate on the same node as the StatefulSet pod (required for RWO PVCs). Backups use an incremental sync strategy: data is synced to a fixed `latest` path (only changed files uploaded), a daily snapshot is taken, and snapshots older than `retentionDays` are automatically pruned.
+The operator creates a Kubernetes CronJob that runs rclone to sync PVC data to S3. The CronJob uses pod affinity to co-locate on the same node as the StatefulSet pod (required for RWO PVCs). Backups use an incremental sync strategy: data is synced to a fixed `latest` path (only changed files uploaded), a daily snapshot is taken, and snapshots older than `retentionDays` are automatically pruned.
 
 **Restoring from backup:**
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -746,7 +746,7 @@ Configures periodic scheduled backups to S3-compatible storage. Requires the `s3
 | `serviceAccountName` | `string` | --      | ServiceAccount to use for backup and restore Jobs. Set this to an IRSA-annotated or Pod Identity-enabled ServiceAccount so Jobs authenticate via the AWS credential chain instead of static credentials. Applies to all backup Jobs (pre-delete, pre-update, periodic, and restore). |
 | `retentionDays`      | `*int32` | `7`     | Number of days to keep daily snapshots in S3. Snapshots older than this are pruned after each successful backup. Minimum: `1`, Maximum: `365`. |
 
-The CronJob mounts the PVC read-only (hot backup - no downtime) and uses pod affinity to schedule on the same node as the StatefulSet pod (required for RWO PVCs).
+The CronJob mounts the PVC (hot backup - no downtime) and uses pod affinity to schedule on the same node as the StatefulSet pod (required for RWO PVCs).
 
 Periodic backups use an incremental sync strategy to minimize S3 transactions and storage costs:
 
@@ -1111,7 +1111,7 @@ spec:
 
 The operator creates a Kubernetes CronJob (`<instance>-backup-periodic`) that:
 
-- Mounts the PVC **read-only** (hot backup - no downtime or StatefulSet scale-down)
+- Mounts the PVC with **fsGroup** matching the StatefulSet (hot backup - no downtime or StatefulSet scale-down)
 - Uses **pod affinity** to co-locate on the same node as the StatefulSet pod (required for RWO PVCs)
 - Stores each run under a unique timestamped path: `backups/<tenantId>/<instanceName>/periodic/<YYYYMMDDTHHMMSSz>`
 - Uses `ConcurrencyPolicy: Forbid` to prevent overlapping backup runs

--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -524,6 +524,12 @@ func buildBackupCronJob(
 							ServiceAccountName:            instance.Spec.Backup.ServiceAccountName,
 							NodeSelector:                  instance.Spec.Availability.NodeSelector,
 							Tolerations:                   instance.Spec.Availability.Tolerations,
+							// Match the StatefulSet pod security context. The PVC must
+							// NOT be mounted read-only so that Kubernetes can apply
+							// fsGroup ownership (chown to GID 1000) on mount. Without
+							// this, the PVC root stays root:root and rclone (UID 1000)
+							// gets "permission denied". rclone sync from /data/ is
+							// inherently read-only (source path, not destination).
 							SecurityContext: &corev1.PodSecurityContext{
 								RunAsUser:  int64Ptr(1000),
 								RunAsGroup: int64Ptr(1000),
@@ -557,7 +563,6 @@ func buildBackupCronJob(
 										{
 											Name:      "data",
 											MountPath: "/data",
-											ReadOnly:  true,
 										},
 									},
 									TerminationMessagePath:   "/dev/termination-log",
@@ -570,7 +575,6 @@ func buildBackupCronJob(
 									VolumeSource: corev1.VolumeSource{
 										PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 											ClaimName: pvcName,
-											ReadOnly:  true,
 										},
 									},
 								},

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -437,15 +437,15 @@ var _ = Describe("S3 Helpers", func() {
 			Expect(*cronJob.Spec.FailedJobsHistoryLimit).To(Equal(int32(2)))
 		})
 
-		It("Should mount PVC read-only", func() {
+		It("Should mount PVC read-write so fsGroup can apply ownership", func() {
 			cronJob := buildBackupCronJob(instance, creds, "myinst-s3-credentials")
 			container := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0]
 			Expect(container.VolumeMounts).To(HaveLen(1))
-			Expect(container.VolumeMounts[0].ReadOnly).To(BeTrue())
+			Expect(container.VolumeMounts[0].ReadOnly).To(BeFalse())
 			Expect(container.VolumeMounts[0].MountPath).To(Equal("/data"))
 
 			vol := cronJob.Spec.JobTemplate.Spec.Template.Spec.Volumes[0]
-			Expect(vol.PersistentVolumeClaim.ReadOnly).To(BeTrue())
+			Expect(vol.PersistentVolumeClaim.ReadOnly).To(BeFalse())
 		})
 
 		It("Should set pod affinity for co-location with StatefulSet pod", func() {


### PR DESCRIPTION
The backup CronJob mounted the PVC with readOnly: true, which prevents Kubernetes from applying fsGroup ownership changes on mount. The PVC root stays root:root and rclone (UID 1000) gets "permission denied".

Fix: remove readOnly from both the VolumeMount and PVC source. The fsGroup: 1000 then works correctly (Kubernetes chowns to GID 1000 on mount). rclone sync uses /data/ as the source path so it only reads - no write risk even without the read-only flag.