### PR TITLE
fix(chromium): use run.sh entrypoint to fix CDP on Chrome M136+

### DIFF
--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -49,9 +49,10 @@ const (
 	// NginxConfigKey is the ConfigMap data key for the nginx stream config
 	NginxConfigKey = "nginx.conf"
 
-	// ChromiumPort is the CDP port that Chromium listens on directly.
-	// Chrome is started with --remote-debugging-port=9222 so all CDP
-	// clients (OpenClaw, health probes) connect here without any proxy.
+	// ChromiumPort is the CDP port that Chromium listens on.
+	// The image entrypoint (run.sh) starts Chrome with
+	// --remote-debugging-port=9222 so all CDP clients (OpenClaw,
+	// health probes) connect here.
 	ChromiumPort = 9222
 
 	// DefaultChromiumImage is the default image for the Chromium sidecar.
@@ -168,14 +169,12 @@ const (
 	OTelCollectorConfigKey = "otel-collector.yaml"
 )
 
-// DefaultChromiumLaunchArgs are Chrome flags passed directly as container
-// args when starting Chromium. These include anti-bot flags and the
-// required --remote-debugging-port/--remote-debugging-address for CDP.
+// DefaultChromiumLaunchArgs are additional Chrome flags passed as container
+// args to run.sh. The image entrypoint (run.sh) handles CDP connectivity
+// (--remote-debugging-port/--remote-debugging-address) internally.
 // User ExtraArgs are appended via deduplicateArgs.
 var DefaultChromiumLaunchArgs = []string{
 	"--no-sandbox",
-	"--remote-debugging-port=9222",
-	"--remote-debugging-address=0.0.0.0",
 	"--disable-gpu",
 	"--disable-software-rasterizer",
 	"--disable-blink-features=AutomationControlled",

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -492,7 +492,7 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 		t.Fatal("chromium container should have Args with Chrome launch flags")
 	}
 	argsStr := strings.Join(chromium.Args, " ")
-	for _, required := range []string{"--remote-debugging-port=9222", "--remote-debugging-address=0.0.0.0", "--no-sandbox"} {
+	for _, required := range []string{"--no-sandbox", "--disable-gpu", "--no-first-run"} {
 		if !strings.Contains(argsStr, required) {
 			t.Errorf("chromium Args missing %q", required)
 		}
@@ -610,8 +610,8 @@ func TestBuildStatefulSet_ChromiumExtraArgs(t *testing.T) {
 		}
 	}
 	// Default args should also be present
-	if !strings.Contains(argsStr, "--remote-debugging-port=9222") {
-		t.Error("chromium Args missing --remote-debugging-port=9222")
+	if !strings.Contains(argsStr, "--no-sandbox") {
+		t.Error("chromium Args missing --no-sandbox")
 	}
 }
 
@@ -678,8 +678,8 @@ func TestBuildStatefulSet_ChromiumNoExtraArgs(t *testing.T) {
 		t.Fatal("chromium container should have default Args")
 	}
 	argsStr := strings.Join(chromium.Args, " ")
-	if !strings.Contains(argsStr, "--remote-debugging-port=9222") {
-		t.Error("chromium Args missing --remote-debugging-port=9222")
+	if !strings.Contains(argsStr, "--no-sandbox") {
+		t.Error("chromium Args missing --no-sandbox")
 	}
 }
 
@@ -11524,7 +11524,7 @@ func TestBuildStatefulSet_NoChromiumProxy(t *testing.T) {
 	sts := BuildStatefulSet(instance, "", nil)
 	for _, c := range sts.Spec.Template.Spec.InitContainers {
 		if c.Name == "chromium-proxy" {
-			t.Error("chromium-proxy should not exist - Chrome runs directly without browserless")
+			t.Error("chromium-proxy should not exist - Chrome runs via run.sh")
 		}
 	}
 }
@@ -11552,8 +11552,8 @@ func TestChromiumArgs_Deduplication(t *testing.T) {
 	}
 
 	// Default args should be present
-	if !strings.Contains(argsStr, "--remote-debugging-port=9222") {
-		t.Error("args should contain --remote-debugging-port=9222")
+	if !strings.Contains(argsStr, "--no-sandbox") {
+		t.Error("args should contain --no-sandbox")
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -626,10 +626,10 @@ func buildInitContainers(instance *openclawv1alpha1.OpenClawInstance, skillPacks
 	// CDP URL before the Service has endpoints and cache "unreachable"
 	// permanently (see #270).
 	//
-	// Chrome runs directly with --remote-debugging-port=9222 (no browserless
-	// proxy layer). This avoids session lifecycle issues where browserless
-	// kills Chrome when the WebSocket client disconnects between tool calls
-	// (see #360).
+	// Chrome runs via run.sh which handles --remote-debugging-port=9222
+	// internally (no browserless proxy layer). This avoids session lifecycle
+	// issues where browserless kills Chrome when the WebSocket client
+	// disconnects between tool calls (see #360).
 	if instance.Spec.Chromium.Enabled {
 		chromium := buildChromiumContainer(instance)
 		chromium.RestartPolicy = Ptr(corev1.ContainerRestartPolicyAlways)
@@ -1428,11 +1428,11 @@ func buildGatewayProxyContainer(instance *openclawv1alpha1.OpenClawInstance) cor
 }
 
 // buildChromiumContainer creates the Chromium sidecar container.
-// Chrome runs directly with --remote-debugging-port=9222 (no browserless
-// proxy layer). This avoids session lifecycle issues where browserless
-// kills Chrome when the WebSocket client disconnects between tool calls
-// (see #360). Launch args (anti-bot flags + user ExtraArgs) are passed
-// as container args instead of being injected via an nginx proxy.
+// Chrome runs via run.sh which handles --remote-debugging-port=9222
+// internally (no browserless proxy layer). This avoids session lifecycle
+// issues where browserless kills Chrome when the WebSocket client
+// disconnects between tool calls (see #360). Additional launch args
+// (anti-bot flags + user ExtraArgs) are passed as container args to run.sh.
 func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Container {
 	repo := instance.Spec.Chromium.Image.Repository
 	if repo == "" {
@@ -1489,18 +1489,10 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 	// Append user-supplied extra env vars
 	chromiumEnv = append(chromiumEnv, instance.Spec.Chromium.ExtraEnv...)
 
-	// Override Command for the default image to bypass its run.sh entrypoint
-	// (which adds a socat proxy layer). Custom images use their own entrypoint.
-	var command []string
-	if repo == DefaultChromiumImage {
-		command = []string{"/headless-shell/headless-shell"}
-	}
-
 	return corev1.Container{
 		Name:                     "chromium",
 		Image:                    image,
 		ImagePullPolicy:          corev1.PullIfNotPresent,
-		Command:                  command,
 		Args:                     ChromiumArgs(instance),
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1512,16 +1512,15 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(chromiumContainer.Ports).To(HaveLen(1))
 			Expect(chromiumContainer.Ports[0].ContainerPort).To(Equal(int32(resources.ChromiumPort)))
 
-			// Chrome runs directly - Args should contain CDP flags
+			// Chrome runs via run.sh - Args should contain launch flags
 			Expect(chromiumContainer.Args).NotTo(BeEmpty(), "chromium should have Args with launch flags")
 			argsStr := strings.Join(chromiumContainer.Args, " ")
-			Expect(argsStr).To(ContainSubstring("--remote-debugging-port=9222"))
 			Expect(argsStr).To(ContainSubstring("--no-sandbox"))
 
 			// No chromium-proxy container should exist
 			for _, c := range statefulSet.Spec.Template.Spec.InitContainers {
 				Expect(c.Name).NotTo(Equal("chromium-proxy"),
-					"chromium-proxy should not exist - Chrome runs directly")
+					"chromium-proxy should not exist - Chrome runs via run.sh")
 			}
 
 			// Verify main container has OPENCLAW_CHROMIUM_CDP using service DNS name


### PR DESCRIPTION
## Summary

- Remove the `Command` override that bypassed the `chromedp/headless-shell` image's `run.sh` entrypoint, which contains a socat workaround essential for Chrome M136+ (where `--remote-debugging-address=0.0.0.0` is silently forced to `127.0.0.1`)
- Remove `--remote-debugging-port` and `--remote-debugging-address` from `DefaultChromiumLaunchArgs` since `run.sh` manages them internally
- Update unit and e2e tests to reflect the change

Fixes #386

## Test plan

- [ ] Unit tests pass (`go test ./internal/resources/`)
- [ ] Lint passes (`make lint`)
- [ ] E2E: deploy with default chromium settings, verify startup probe passes and CDP is reachable on port 9222
- [ ] E2E: verify custom chromium image still works (no `Command` override applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)