### PR TITLE
fix(backup): add --copy-links to rclone to include symlinks

### DIFF
--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -223,7 +223,7 @@ func buildRcloneJob(
 		// S3 -> PVC
 		args = append([]string{"sync", rcloneRemotePath, "/data/", providerFlag, "--s3-endpoint=$(S3_ENDPOINT)"}, authArgs...)
 	}
-	args = append(args, "--transfers=8", "--checkers=16", "-v")
+	args = append(args, "--copy-links", "--transfers=8", "--checkers=16", "-v")
 
 	if creds.Region != "" {
 		args = append(args, "--s3-region=$(S3_REGION)")
@@ -472,7 +472,7 @@ func buildBackupCronJob(
 			` && S3="%s"`+
 			// Step 1: incremental sync to fixed "latest" path
 			` && echo "Step 1: incremental sync to latest"`+
-			` && rclone sync /data/ "${S3}/latest" $R --transfers=8 --checkers=16 -v`+
+			` && rclone sync /data/ "${S3}/latest" $R --copy-links --transfers=8 --checkers=16 -v`+
 			// Step 2: daily snapshot (copy latest to snapshots/YYYY-MM-DD)
 			` && TODAY=$(date -u +%%Y-%%m-%%d)`+
 			` && echo "Step 2: snapshot ${TODAY}"`+

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -157,6 +157,9 @@ var _ = Describe("S3 Helpers", func() {
 				}
 			}
 
+			// Verify --copy-links flag is present (follows symlinks during backup)
+			Expect(container.Args).To(ContainElement("--copy-links"))
+
 			// Verify non-sensitive env vars use plain Value
 			for _, e := range container.Env {
 				if e.Name == "S3_ENDPOINT" {
@@ -188,6 +191,8 @@ var _ = Describe("S3 Helpers", func() {
 			Expect(container.Args[0]).To(Equal("sync"))
 			// For restore, dest is /data/
 			Expect(container.Args[2]).To(Equal("/data/"))
+			// --copy-links is present for restore too (harmless - no symlinks on S3 side)
+			Expect(container.Args).To(ContainElement("--copy-links"))
 
 			vol := job.Spec.Template.Spec.Volumes[0]
 			Expect(vol.PersistentVolumeClaim.ClaimName).To(Equal("myinst-data"))
@@ -468,8 +473,9 @@ var _ = Describe("S3 Helpers", func() {
 			Expect(container.Command[0]).To(Equal("sh"))
 			Expect(container.Command[1]).To(Equal("-c"))
 			cmd := container.Command[2]
-			// Step 1: incremental sync to fixed "latest" path
+			// Step 1: incremental sync to fixed "latest" path (with --copy-links for symlinks)
 			Expect(cmd).To(ContainSubstring("rclone sync /data/"))
+			Expect(cmd).To(ContainSubstring("--copy-links"))
 			Expect(cmd).To(ContainSubstring("/latest"))
 			Expect(cmd).To(ContainSubstring(":s3:test-bucket/backups/cus_123/myinst/periodic"))
 			// Step 2: daily snapshot


### PR DESCRIPTION
## Summary
- Add `--copy-links` flag to rclone `sync` commands so symlinks in the PVC are followed and their target content is backed up to S3
- Fixes both one-time backup/restore jobs (`buildRcloneJob`) and periodic CronJob backups (`buildBackupCronJob`)
- Adds test assertions verifying `--copy-links` is present in backup, restore, and CronJob commands

Closes #398

## Test plan
- [ ] CI passes (unit tests, lint, build)
- [ ] E2E: create instance with `spec.backup.schedule`, verify CronJob rclone command includes `--copy-links`
- [ ] Manual: run rclone backup on a PVC with symlinks, verify no "Can't follow symlink" NOTICE messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)