### PR TITLE
fix(controller): normalize UpdateStrategy.RollingUpdate to stop continuous reconcile loop

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -11123,6 +11123,25 @@ func TestNormalizeStatefulSet_NoSpuriousDiff(t *testing.T) {
 	}
 }
 
+func TestNormalizeStatefulSet_UpdateStrategyRollingUpdate(t *testing.T) {
+	// Regression test: K8s API server defaults UpdateStrategy.RollingUpdate to &{}
+	// when Type == RollingUpdate and RollingUpdate == nil. Without normalizing this,
+	// CreateOrUpdate detects a diff on every reconcile (nil vs &{}), issues an
+	// unnecessary Update, and triggers a continuous reconcile loop via the StatefulSet watch.
+	instance := newTestInstance("norm-update-strategy")
+	sts := BuildStatefulSet(instance, "", nil)
+
+	if sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+		t.Fatal("expected RollingUpdate strategy type from builder")
+	}
+
+	NormalizeStatefulSet(sts)
+
+	if sts.Spec.UpdateStrategy.RollingUpdate == nil {
+		t.Error("NormalizeStatefulSet should set UpdateStrategy.RollingUpdate to &{} to match K8s API server defaulting")
+	}
+}
+
 func TestNormalizeStatefulSet_ProbeDefaults(t *testing.T) {
 	instance := newTestInstance("norm-probe")
 	sts := BuildStatefulSet(instance, "", nil)

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -2388,6 +2388,15 @@ func NormalizeStatefulSet(sts *appsv1.StatefulSet) {
 		normalizeContainer(&spec.Containers[i])
 	}
 
+	// K8s defaults UpdateStrategy.RollingUpdate to &{} when Type == RollingUpdate.
+	// Without this, CreateOrUpdate sees nil vs &{} on every reconcile, issues an
+	// unnecessary Update, increments the StatefulSet resourceVersion, fires a watch
+	// event, and causes a continuous reconcile loop.
+	// Mirrors: k8s.io/kubernetes/pkg/apis/apps/v1/defaults.go SetDefaults_StatefulSetSpec
+	if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate == nil {
+		sts.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{}
+	}
+
 	// K8s defaults VolumeMode to Filesystem on VolumeClaimTemplates
 	filesystemMode := corev1.PersistentVolumeFilesystem
 	for i := range sts.Spec.VolumeClaimTemplates {


### PR DESCRIPTION
## Summary

`NormalizeStatefulSet` was missing one Kubernetes API server default, causing the operator to issue an unnecessary `Update` on every reconcile cycle. This created a continuous reconcile loop for every managed instance.

## Root Cause

When a StatefulSet is created with `UpdateStrategy: {Type: RollingUpdate}` and no `RollingUpdate` field, the Kubernetes API server applies this default (from `pkg/apis/apps/v1/defaults.go`):

```go
if obj.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType && obj.UpdateStrategy.RollingUpdate == nil {
    obj.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{}
}
```

The operator's `NormalizeStatefulSet` function pre-sets other API server defaults to avoid spurious diffs, but this one was missing. The result on every reconcile:

1. Builder produces `UpdateStrategy.RollingUpdate = nil`
2. `controllerutil.CreateOrUpdate` fetches the existing StatefulSet from the API server, which has `RollingUpdate = &{}`
3. The mutate function sets `sts.Spec = desired.Spec`, making `RollingUpdate` nil again
4. `equality.Semantic.DeepEqual` sees `nil` vs `&{}` -- not equal -- and issues an `Update`
5. The API server accepts the update, re-applies the default, and increments `resourceVersion`
6. The `Owns(&appsv1.StatefulSet{})` watch fires and re-queues the reconciler
7. Repeat forever

## Observed Symptom

Multiple reconcile cycles completing back-to-back within the same second for every instance:

```
2026-03-23T15:13:12Z    INFO    Reconciling OpenClawInstance    {"controller": "openclawinstance", ..., "name": "openclaw-bkapusta", "reconcileID": "12816017-2793-440e-9291-6998780b77da"}
2026-03-23T15:13:12Z    INFO    Reconciliation completed successfully    {"controller": "openclawinstance", ..., "name": "openclaw-bkapusta", "reconcileID": "12816017-2793-440e-9291-6998780b77da"}
2026-03-23T15:13:12Z    INFO    Reconciling OpenClawInstance    {"controller": "openclawinstance", ..., "name": "openclaw-bkapusta", "reconcileID": "270b4c36-4503-469e-aad4-b3704e32e4e6"}
2026-03-23T15:13:12Z    INFO    Reconciliation completed successfully    {"controller": "openclawinstance", ..., "name": "openclaw-bkapusta", "reconcileID": "270b4c36-4503-469e-aad4-b3704e32e4e6"}
2026-03-23T15:13:12Z    INFO    Reconciling OpenClawInstance    {"controller": "openclawinstance", ..., "name": "openclaw-bkapusta", "reconcileID": "97c5b20c-36d7-4f39-b0de-8ed933d49a05"}
2026-03-23T15:13:12Z    INFO    Reconciliation completed successfully    {"controller": "openclawinstance", ..., "name": "openclaw-bkapusta", "reconcileID": "97c5b20c-36d7-4f39-b0de-8ed933d49a05"}
```

The `RequeueAfter` is 5 minutes, so a timer cannot explain sub-second cycling. This is a watch-event-driven loop.

## Fix

Add the missing normalization to `NormalizeStatefulSet`:

```go
// K8s defaults UpdateStrategy.RollingUpdate to &{} when Type == RollingUpdate.
if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate == nil {
    sts.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{}
}
```

## Why the existing test didn't catch this

`TestNormalizeStatefulSet_NoSpuriousDiff` simulates the round-trip using JSON marshal/unmarshal, which does not apply Kubernetes admission defaulting. The test correctly verified idempotency of the builder+normalizer, but missed the gap between the normalized desired spec and what the API server actually stores.

A targeted regression test (`TestNormalizeStatefulSet_UpdateStrategyRollingUpdate`) is included.

## Test plan

- [x] `go test ./internal/resources/ -run TestNormalizeStatefulSet` passes
- [x] `go vet ./...` clean
- [x] `make fmt` clean
- [ ] CI unit + integration tests
- [ ] Deploy to a cluster and verify reconcile rate drops to the 5-minute `RequeueAfter` interval