### PR TITLE
fix: preserve user-set gateway auth mode in config enrichment

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -133,9 +133,10 @@ func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseCo
 	}
 }
 
-// enrichConfigWithGatewayAuth injects gateway.auth.mode=token and
-// gateway.auth.token into the config JSON. If the user has already set
-// gateway.auth.token, the config is returned unchanged (user override wins).
+// enrichConfigWithGatewayAuth injects the gateway token into the config JSON
+// for internal loopback authentication (cron, sessions_spawn). If the user has
+// not set gateway.auth.mode, it also injects mode=token. If the user has already
+// set gateway.auth.token, the config is returned unchanged (user override wins).
 func enrichConfigWithGatewayAuth(configJSON []byte, token string) ([]byte, error) {
 	var config map[string]interface{}
 	if err := json.Unmarshal(configJSON, &config); err != nil {
@@ -152,12 +153,18 @@ func enrichConfigWithGatewayAuth(configJSON []byte, token string) ([]byte, error
 		auth = make(map[string]interface{})
 	}
 
-	// If the user already set a token, don't override
+	// If the user already set a token, don't override anything
 	if existingToken, ok := auth["token"].(string); ok && existingToken != "" {
 		return configJSON, nil
 	}
 
-	auth["mode"] = "token" //nolint:goconst // OpenClaw auth mode, not k8s Secret key
+	// Only set mode to "token" if the user hasn't chosen a mode already.
+	// This preserves user-configured modes like "trusted-proxy" while still
+	// injecting the operator token for internal loopback connections (e.g.
+	// openclaw cron, sessions_spawn).
+	if _, hasMode := auth["mode"]; !hasMode {
+		auth["mode"] = "token" //nolint:goconst // OpenClaw auth mode, not k8s Secret key
+	}
 	auth["token"] = token
 	gw["auth"] = auth
 	config["gateway"] = gw

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2196,6 +2196,40 @@ func TestBuildConfigMapFromBytes_EnrichesExternalConfig(t *testing.T) {
 	}
 }
 
+func TestBuildConfigMapFromBytes_PreservesTrustedProxyMode(t *testing.T) {
+	instance := newTestInstance("trusted-proxy")
+	externalConfig := []byte(`{"gateway":{"auth":{"mode":"trusted-proxy"}},"mcpServers":{"test":{"url":"http://localhost"}}}`)
+
+	cm := BuildConfigMapFromBytes(instance, externalConfig, "my-gateway-token", nil)
+
+	content := cm.Data["openclaw.json"]
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	// User config should be preserved
+	if _, ok := parsed["mcpServers"]; !ok {
+		t.Error("mcpServers should be preserved from external config")
+	}
+
+	// Gateway auth mode should be preserved, token should be injected
+	gw, ok := parsed["gateway"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway key after enrichment")
+	}
+	auth, ok := gw["auth"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway.auth key after enrichment")
+	}
+	if auth["mode"] != "trusted-proxy" {
+		t.Errorf("gateway.auth.mode = %v, want %q (user's mode should be preserved)", auth["mode"], "trusted-proxy")
+	}
+	if auth["token"] != "my-gateway-token" {
+		t.Errorf("gateway.auth.token = %v, want %q (token should still be injected)", auth["token"], "my-gateway-token")
+	}
+}
+
 func TestBuildConfigMapFromBytes_PreservesUserConfig(t *testing.T) {
 	instance := newTestInstance("from-bytes-preserve")
 	externalConfig := []byte(`{
@@ -6216,6 +6250,76 @@ func TestEnrichConfigWithGatewayAuth_InvalidJSON(t *testing.T) {
 	// Should return unchanged
 	if !bytes.Equal(result, configJSON) {
 		t.Errorf("expected unchanged result for invalid JSON, got %s", string(result))
+	}
+}
+
+func TestEnrichConfigWithGatewayAuth_PreservesUserMode(t *testing.T) {
+	configJSON := []byte(`{"gateway":{"auth":{"mode":"trusted-proxy"}}}`)
+	token := "operator-generated-token"
+
+	result, err := enrichConfigWithGatewayAuth(configJSON, token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	gw := parsed["gateway"].(map[string]interface{})
+	auth := gw["auth"].(map[string]interface{})
+
+	// User's mode should be preserved
+	if auth["mode"] != "trusted-proxy" {
+		t.Errorf("gateway.auth.mode = %v, want %q (user's mode should be preserved)", auth["mode"], "trusted-proxy")
+	}
+	// Operator's token should still be injected for internal loopback auth
+	if auth["token"] != token {
+		t.Errorf("gateway.auth.token = %v, want %q (token should be injected for internal auth)", auth["token"], token)
+	}
+}
+
+func TestEnrichConfigWithGatewayAuth_PreservesUserModeAndToken(t *testing.T) {
+	configJSON := []byte(`{"gateway":{"auth":{"mode":"trusted-proxy","token":"user-custom-token"}}}`)
+	token := "operator-generated-token"
+
+	result, err := enrichConfigWithGatewayAuth(configJSON, token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be completely unchanged because user set their own token
+	if !bytes.Equal(result, configJSON) {
+		t.Errorf("config should be unchanged when user sets both mode and token\ngot:  %s\nwant: %s", string(result), string(configJSON))
+	}
+}
+
+func TestEnrichConfigWithGatewayAuth_PreservesOtherAuthFields(t *testing.T) {
+	configJSON := []byte(`{"gateway":{"auth":{"mode":"trusted-proxy","allowTailscale":true}}}`)
+	token := "operator-token"
+
+	result, err := enrichConfigWithGatewayAuth(configJSON, token)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+
+	gw := parsed["gateway"].(map[string]interface{})
+	auth := gw["auth"].(map[string]interface{})
+
+	if auth["mode"] != "trusted-proxy" {
+		t.Errorf("gateway.auth.mode = %v, want %q", auth["mode"], "trusted-proxy")
+	}
+	if auth["allowTailscale"] != true {
+		t.Errorf("gateway.auth.allowTailscale = %v, want true", auth["allowTailscale"])
+	}
+	if auth["token"] != token {
+		t.Errorf("gateway.auth.token = %v, want %q", auth["token"], token)
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -2325,6 +2325,77 @@ var _ = Describe("OpenClawInstance Controller", func() {
 
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})
+
+		It("Should preserve trusted-proxy auth mode while injecting token", func() {
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instanceName := "cmref-trusted-proxy"
+
+			// Create external ConfigMap with trusted-proxy auth mode
+			externalCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "trusted-proxy-config",
+					Namespace: namespace,
+				},
+				Data: map[string]string{
+					"openclaw.json": `{"gateway":{"auth":{"mode":"trusted-proxy"}}}`,
+				},
+			}
+			Expect(k8sClient.Create(ctx, externalCM)).Should(Succeed())
+
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Config: openclawv1alpha1.ConfigSpec{
+						ConfigMapRef: &openclawv1alpha1.ConfigMapKeySelector{
+							Name: "trusted-proxy-config",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Verify operator-managed ConfigMap preserves the auth mode
+			cm := &corev1.ConfigMap{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.ConfigMapName(instance),
+					Namespace: namespace,
+				}, cm)
+			}, timeout, interval).Should(Succeed())
+
+			configContent, ok := cm.Data["openclaw.json"]
+			Expect(ok).To(BeTrue(), "operator-managed ConfigMap should have openclaw.json key")
+
+			var parsed map[string]interface{}
+			Expect(json.Unmarshal([]byte(configContent), &parsed)).To(Succeed())
+
+			gw, ok := parsed["gateway"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "config should have gateway key")
+			auth, ok := gw["auth"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "gateway should have auth key")
+
+			// Mode should be preserved as trusted-proxy (not overwritten to token)
+			Expect(auth["mode"]).To(Equal("trusted-proxy"),
+				"gateway.auth.mode should be preserved as trusted-proxy")
+			// Token should still be injected for internal loopback auth
+			Expect(auth["token"]).NotTo(BeEmpty(),
+				"gateway.auth.token should be set for internal loopback connections")
+
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
 	})
 
 	Context("When creating an instance with auto-scaling enabled", func() {


### PR DESCRIPTION
## Summary
- Fix `enrichConfigWithGatewayAuth()` to check `auth.mode` before overwriting -- previously it only checked `auth.token`, silently replacing user-configured modes like `trusted-proxy` with `token`
- Always inject the gateway token into config (regardless of auth mode) so internal loopback connections (`openclaw cron`, `sessions_spawn`) can authenticate
- Add unit tests, integration test, and E2E test for auth mode preservation

Closes #381
Closes #401

## Test plan
- [x] `TestEnrichConfigWithGatewayAuth_PreservesUserMode` -- trusted-proxy mode preserved, token injected
- [x] `TestEnrichConfigWithGatewayAuth_PreservesUserModeAndToken` -- both user values preserved unchanged
- [x] `TestEnrichConfigWithGatewayAuth_PreservesOtherAuthFields` -- sibling fields (allowTailscale) survive
- [x] `TestBuildConfigMapFromBytes_PreservesTrustedProxyMode` -- full enrichment pipeline
- [x] All existing gateway auth tests still pass (no regressions)
- [ ] E2E: "Should preserve trusted-proxy auth mode while injecting token"

🤖 Generated with [Claude Code](https://claude.com/claude-code)