### PR TITLE
fix(chromium): suppress container permission warnings

### DIFF
--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -205,6 +205,7 @@ var DefaultChromiumLaunchArgs = []string{
 	"--disable-blink-features=AutomationControlled",
 	"--disable-features=AutomationControlled",
 	"--no-first-run",
+	"--disable-oom-score-adj",
 }
 
 // deduplicateArgs merges default and extra Chrome launch args, removing

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -472,6 +472,8 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 	}
 
 	// Chrome runs directly - no PORT/HOST env vars (those were browserless-specific)
+	// HOME=/tmp is set so fontconfig and other tools find a writable home directory.
+	foundHome := false
 	for _, env := range chromium.Env {
 		if env.Name == "PORT" {
 			t.Error("chromium container should not have PORT env var (no longer using browserless)")
@@ -479,6 +481,12 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 		if env.Name == "HOST" {
 			t.Error("chromium container should not have HOST env var (no longer using browserless)")
 		}
+		if env.Name == "HOME" && env.Value == "/tmp" {
+			foundHome = true
+		}
+	}
+	if !foundHome {
+		t.Error("chromium container should have HOME=/tmp env var")
 	}
 
 	// Chromium image defaults
@@ -498,7 +506,7 @@ func TestBuildStatefulSet_WithChromium(t *testing.T) {
 		t.Fatal("chromium container should have Args with Chrome launch flags")
 	}
 	argsStr := strings.Join(chromium.Args, " ")
-	for _, required := range []string{"--no-sandbox", "--disable-gpu", "--no-first-run"} {
+	for _, required := range []string{"--no-sandbox", "--disable-gpu", "--no-first-run", "--disable-oom-score-adj"} {
 		if !strings.Contains(argsStr, required) {
 			t.Errorf("chromium Args missing %q", required)
 		}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1548,7 +1548,12 @@ func buildChromiumContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.
 		},
 	}
 
-	var chromiumEnv []corev1.EnvVar
+	// Set HOME to /tmp (an emptyDir) so fontconfig and other tools that
+	// need a writable home directory work correctly. The default nobody
+	// user (65534) has home /nonexistent which does not exist.
+	chromiumEnv := []corev1.EnvVar{
+		{Name: "HOME", Value: "/tmp"},
+	}
 
 	// Add CA bundle mount if configured. The certificate file is mounted
 	// into the system CA directory so Chrome picks it up automatically.


### PR DESCRIPTION
## Summary
- Add `--disable-oom-score-adj` to default Chrome launch args to suppress `Failed to adjust OOM score` permission errors (we intentionally drop `CAP_SYS_RESOURCE`)
- Set `HOME=/tmp` env var on the chromium container so fontconfig finds a writable cache directory (user 65534/nobody has home `/nonexistent` which does not exist)

Fixes the warnings reported in #396 (comment: https://github.com/openclaw-rocks/openclaw-operator/issues/396#issuecomment-4129690730).

**Note:** The remaining `Failed global descriptor lookup` shared memory error is a known harmless Chrome containerization artifact. We already mount `/dev/shm` as 1Gi tmpfs -- the error relates to file descriptor inheritance between Chrome processes, not `/dev/shm` size. No PVC is needed.

## Test plan
- [x] Unit tests updated and passing (`go test ./internal/resources/`)
- [ ] CI lint + test
- [ ] E2E chromium tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)