### PR TITLE
feat: expose internal scale-to-zero as public spec.suspended API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Every request is validated against the instance's allowlist policy. Protected co
 | **Runtime Deps** | pnpm & Python/uv | Built-in init containers install pnpm (via corepack) or Python 3.12 + uv for MCP servers and skills |
 | **Auto-Update** | OCI registry polling | Opt-in version tracking: checks the registry for new semver releases, backs up first, rolls out, and auto-rolls back if the new version fails health checks |
 | **Scalable** | Auto-scaling | HPA integration with CPU and memory metrics, min/max replica bounds, automatic StatefulSet replica management |
+| **Operational** | Instance suspension | Scale to zero with `spec.suspended: true` - all non-runtime resources remain managed, resume instantly with `false` |
 | **Resilient** | Self-healing lifecycle | PodDisruptionBudgets, health probes, automatic config rollouts via content hashing, 5-minute drift detection |
 | **Backup/Restore** | S3-backed snapshots | Automatic backup to S3-compatible storage on deletion, pre-update, and on a cron schedule; restore into a new instance from any snapshot |
 | **Workspace Seeding** | Initial files & dirs | Pre-populate the workspace with files and directories before the agent starts; reference an external ConfigMap for GitOps workflows |
@@ -1049,6 +1050,27 @@ When auto-scaling is combined with persistent storage:
 - PVCs inherit `size`, `storageClass`, and `accessModes` from `spec.storage.persistence`
 - Retention policy is `Retain` for both scale-down and deletion -- data is preserved
 - If auto-scaling is later disabled, per-replica PVCs become orphaned and must be cleaned up manually
+
+### Instance Suspension
+
+Temporarily scale an instance to zero replicas without deleting it:
+
+```yaml
+spec:
+  suspended: true
+```
+
+When suspended:
+
+- The StatefulSet scales to 0 replicas (pods terminate)
+- All non-runtime resources (Service, ConfigMap, RBAC, NetworkPolicy, PVC) remain fully managed
+- Phase becomes `Suspended`, Ready condition becomes `False`
+- Auto-updates are paused until the instance is resumed
+- `openclaw_instance_ready` metric reports `0`
+
+Resume by setting `spec.suspended: false`. The instance returns to `Running` phase through the normal startup lifecycle.
+
+> **Note:** `spec.suspended` and `spec.availability.autoScaling.enabled` are mutually exclusive. Disable auto-scaling before suspending.
 
 ### Topology Spread Constraints
 

--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -128,6 +128,13 @@ type OpenClawInstanceSpec struct {
 	// +optional
 	Availability AvailabilitySpec `json:"availability,omitempty"`
 
+	// Suspended scales the workload to zero replicas when true.
+	// Non-runtime resources (Service, ConfigMap, RBAC, NetworkPolicy, PVC)
+	// remain fully managed. Set to false to resume normal operation.
+	// +kubebuilder:default=false
+	// +optional
+	Suspended bool `json:"suspended,omitempty"`
+
 	// Backup configures periodic scheduled backups to S3-compatible storage.
 	// Requires the s3-backup-credentials Secret in the operator namespace and persistence enabled.
 	// +optional
@@ -1367,7 +1374,7 @@ type AutoUpdateStatus struct {
 // OpenClawInstanceStatus defines the observed state of OpenClawInstance
 type OpenClawInstanceStatus struct {
 	// Phase represents the current lifecycle phase of the instance
-	// +kubebuilder:validation:Enum=Pending;Provisioning;Running;Degraded;Failed;Terminating;BackingUp;Restoring;Updating
+	// +kubebuilder:validation:Enum=Pending;Provisioning;Running;Degraded;Failed;Terminating;BackingUp;Restoring;Updating;Suspended
 	// +optional
 	Phase string `json:"phase,omitempty"`
 
@@ -1595,4 +1602,5 @@ const (
 	PhaseBackingUp    = "BackingUp"
 	PhaseRestoring    = "Restoring"
 	PhaseUpdating     = "Updating"
+	PhaseSuspended    = "Suspended"
 )

--- a/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
+++ b/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
@@ -9282,6 +9282,13 @@ spec:
                         type: string
                     type: object
                 type: object
+              suspended:
+                default: false
+                description: |-
+                  Suspended scales the workload to zero replicas when true.
+                  Non-runtime resources (Service, ConfigMap, RBAC, NetworkPolicy, PVC)
+                  remain fully managed. Set to false to resume normal operation.
+                type: boolean
               tailscale:
                 description: Tailscale configures Tailscale integration for tailnet
                   access and HTTPS
@@ -9787,6 +9794,7 @@ spec:
                 - BackingUp
                 - Restoring
                 - Updating
+                - Suspended
                 type: string
               restoreJobName:
                 description: RestoreJobName is the name of the active restore Job

--- a/config/crd/bases/openclaw.rocks_openclawinstances.yaml
+++ b/config/crd/bases/openclaw.rocks_openclawinstances.yaml
@@ -9276,6 +9276,13 @@ spec:
                         type: string
                     type: object
                 type: object
+              suspended:
+                default: false
+                description: |-
+                  Suspended scales the workload to zero replicas when true.
+                  Non-runtime resources (Service, ConfigMap, RBAC, NetworkPolicy, PVC)
+                  remain fully managed. Set to false to resume normal operation.
+                type: boolean
               tailscale:
                 description: Tailscale configures Tailscale integration for tailnet
                   access and HTTPS
@@ -9781,6 +9788,7 @@ spec:
                 - BackingUp
                 - Restoring
                 - Updating
+                - Suspended
                 type: string
               restoreJobName:
                 description: RestoreJobName is the name of the active restore Job

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -802,6 +802,21 @@ When enabled, the operator:
 - Adds port 6443 egress to the NetworkPolicy for K8s API access
 - Injects `SELFCONFIG.md` (skill documentation) and `selfconfig.sh` (helper script) into the workspace
 
+### spec.suspended
+
+Scales the workload to zero replicas when `true`. Non-runtime resources (Service, ConfigMap, RBAC, NetworkPolicy, PVC) remain fully managed. Set to `false` to resume normal operation.
+
+| Field       | Type   | Default | Description                                                                  |
+|-------------|--------|---------|------------------------------------------------------------------------------|
+| `suspended` | `bool` | `false` | Scale workload to zero replicas when `true`. Mutually exclusive with `spec.availability.autoScaling.enabled`. |
+
+When suspended:
+- StatefulSet replicas are set to 0
+- `status.phase` becomes `Suspended`
+- `Ready` condition is `False` with reason `Suspended`
+- `StatefulSetReady` condition is `True` once all pods terminate (desired state achieved)
+- Auto-updates are paused and resume when unsuspended
+
 ### spec.availability
 
 High availability and scheduling configuration.

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -169,8 +169,9 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Snapshot status before mutations so we can skip no-op status updates
 	savedStatus := instance.Status.DeepCopy()
 
-	// If an auto-update is in progress, drive the state machine
-	if instance.Status.AutoUpdate.PendingVersion != "" {
+	// If an auto-update is in progress, drive the state machine.
+	// Pause the update state machine while suspended - pending version stays in status and resumes on unsuspend.
+	if instance.Status.AutoUpdate.PendingVersion != "" && !instance.Spec.Suspended {
 		result, err := r.reconcileAutoUpdate(ctx, instance)
 		if err != nil {
 			logger.Error(err, "Auto-update error (non-fatal)")
@@ -215,6 +216,33 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			requeueAfter = 2 * time.Minute
 		}
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
+	}
+
+	// Handle suspended state: override phase and readiness
+	if instance.Spec.Suspended {
+		instance.Status.Phase = openclawv1alpha1.PhaseSuspended
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    openclawv1alpha1.ConditionTypeReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  "Suspended",
+			Message: "Instance is suspended (spec.suspended=true), workload scaled to zero",
+		})
+		if instance.Status.ObservedGeneration != instance.Generation {
+			instance.Status.LastReconcileTime = &metav1.Time{Time: time.Now()}
+		}
+		instance.Status.ObservedGeneration = instance.Generation
+
+		statusChanged := !equality.Semantic.DeepEqual(&instance.Status, savedStatus)
+		if statusChanged {
+			if err := r.Status().Update(ctx, instance); err != nil {
+				logger.Error(err, "Failed to update status")
+				return ctrl.Result{}, err
+			}
+			r.Recorder.Event(instance, corev1.EventTypeNormal, "Suspended", "Instance suspended, workload scaled to zero")
+		}
+		reconcileTotal.WithLabelValues(instance.Name, instance.Namespace, "success").Inc()
+		updatePhaseMetric(instance.Name, instance.Namespace, instance.Status.Phase)
+		return ctrl.Result{RequeueAfter: RequeueAfter}, nil
 	}
 
 	// Determine phase based on condition health
@@ -274,7 +302,7 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 func updatePhaseMetric(name, namespace, currentPhase string) {
-	phases := []string{"Pending", "Provisioning", "Running", "Degraded", "Failed", "Terminating", "BackingUp", "Restoring", "Updating"}
+	phases := []string{"Pending", "Provisioning", "Running", "Degraded", "Failed", "Terminating", "BackingUp", "Restoring", "Updating", "Suspended"}
 	for _, phase := range phases {
 		val := float64(0)
 		if phase == currentPhase {
@@ -1230,7 +1258,7 @@ func (r *OpenClawInstanceReconciler) reconcileStatefulSet(ctx context.Context, i
 		// Preserve current replica count when HPA manages scaling
 		existingReplicas := sts.Spec.Replicas
 		sts.Spec = desired.Spec
-		if resources.IsHPAEnabled(instance) && existingReplicas != nil {
+		if resources.IsHPAEnabled(instance) && !instance.Spec.Suspended && existingReplicas != nil {
 			sts.Spec.Replicas = existingReplicas
 		}
 		// Inject secret hash annotation to trigger rollout on secret rotation
@@ -1247,26 +1275,45 @@ func (r *OpenClawInstanceReconciler) reconcileStatefulSet(ctx context.Context, i
 	instance.Status.ManagedResources.StatefulSet = sts.Name
 
 	// Check StatefulSet status
-	ready := sts.Status.ReadyReplicas > 0
-	status := metav1.ConditionFalse
-	reason := "StatefulSetNotReady"
-	message := "StatefulSet is not ready yet"
-	if ready {
-		status = metav1.ConditionTrue
-		reason = "StatefulSetReady"
-		message = "StatefulSet is ready"
+	var ready bool
+	var stsCondStatus metav1.ConditionStatus
+	var stsCondReason, stsCondMessage string
+
+	if instance.Spec.Suspended {
+		// Suspended: desired=0 replicas. Ready once all pods are terminated.
+		ready = sts.Status.Replicas == 0
+		if ready {
+			stsCondStatus = metav1.ConditionTrue
+			stsCondReason = "StatefulSetSuspended"
+			stsCondMessage = "StatefulSet scaled to zero (instance suspended)"
+		} else {
+			stsCondStatus = metav1.ConditionFalse
+			stsCondReason = "StatefulSetScalingDown"
+			stsCondMessage = "StatefulSet is scaling down for suspension"
+		}
+	} else {
+		ready = sts.Status.ReadyReplicas > 0
+		if ready {
+			stsCondStatus = metav1.ConditionTrue
+			stsCondReason = "StatefulSetReady"
+			stsCondMessage = "StatefulSet is ready"
+		} else {
+			stsCondStatus = metav1.ConditionFalse
+			stsCondReason = "StatefulSetNotReady"
+			stsCondMessage = "StatefulSet is not ready yet"
+		}
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:    openclawv1alpha1.ConditionTypeStatefulSetReady,
-		Status:  status,
-		Reason:  reason,
-		Message: message,
+		Status:  stsCondStatus,
+		Reason:  stsCondReason,
+		Message: stsCondMessage,
 	})
 
-	// Update instance readiness metric
+	// Update instance readiness metric (0 when suspended - instance is not serving traffic)
 	readyVal := float64(0)
-	if ready {
+	if ready && !instance.Spec.Suspended {
 		readyVal = 1
 	}
 	instanceReady.WithLabelValues(instance.Name, instance.Namespace).Set(readyVal)

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -9904,6 +9904,29 @@ func TestStatefulSetReplicas_HPADisabled(t *testing.T) {
 	}
 }
 
+func TestStatefulSetReplicas_Suspended(t *testing.T) {
+	instance := newTestInstance("my-app")
+	instance.Spec.Suspended = true
+
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+	if sts.Spec.Replicas == nil || *sts.Spec.Replicas != 0 {
+		t.Errorf("replicas should be 0 when suspended, got %v", sts.Spec.Replicas)
+	}
+}
+
+func TestStatefulSetReplicas_SuspendedOverridesHPA(t *testing.T) {
+	instance := newTestInstance("my-app")
+	instance.Spec.Suspended = true
+	instance.Spec.Availability.AutoScaling = &openclawv1alpha1.AutoScalingSpec{
+		Enabled: Ptr(true),
+	}
+
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+	if sts.Spec.Replicas == nil || *sts.Spec.Replicas != 0 {
+		t.Errorf("replicas should be 0 when suspended (even with HPA), got %v", sts.Spec.Replicas)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Metrics port tests
 // ---------------------------------------------------------------------------

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -2590,9 +2590,13 @@ func normalizeProbe(p *corev1.Probe) {
 }
 
 // statefulSetReplicas returns the replica count for the StatefulSet.
+// When suspended, replicas is explicitly set to 0.
 // When HPA is enabled, replicas is set to nil so the HPA manages scaling.
 // Otherwise defaults to 1 (single-instance).
 func statefulSetReplicas(instance *openclawv1alpha1.OpenClawInstance) *int32 {
+	if instance.Spec.Suspended {
+		return Ptr(int32(0))
+	}
 	if IsHPAEnabled(instance) {
 		return nil
 	}

--- a/internal/webhook/openclawinstance_webhook.go
+++ b/internal/webhook/openclawinstance_webhook.go
@@ -288,6 +288,11 @@ func (v *OpenClawInstanceValidator) validate(instance *openclawv1alpha1.OpenClaw
 		}
 	}
 
+	// 21. Reject suspended + HPA auto-scaling (mutually exclusive)
+	if instance.Spec.Suspended && resources.IsHPAEnabled(instance) {
+		return nil, fmt.Errorf("spec.suspended and spec.availability.autoScaling.enabled are mutually exclusive: disable auto-scaling before suspending")
+	}
+
 	return warnings, nil
 }
 

--- a/internal/webhook/openclawinstance_webhook_test.go
+++ b/internal/webhook/openclawinstance_webhook_test.go
@@ -1745,3 +1745,54 @@ func TestValidateCreate_AdditionalWorkspaceConfigMapRefEmptyName(t *testing.T) {
 		t.Errorf("expected configMapRef error, got: %v", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Suspended + HPA mutual exclusivity tests
+// ---------------------------------------------------------------------------
+
+func TestValidateCreate_SuspendedWithHPA(t *testing.T) {
+	v := &OpenClawInstanceValidator{}
+	instance := newTestInstance()
+	instance.Spec.Suspended = true
+	instance.Spec.Availability.AutoScaling = &openclawv1alpha1.AutoScalingSpec{
+		Enabled: ptr(true),
+	}
+
+	_, err := v.ValidateCreate(context.Background(), instance)
+	if err == nil {
+		t.Fatal("expected error when suspended and HPA are both enabled")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusivity, got: %s", err.Error())
+	}
+}
+
+func TestValidateCreate_SuspendedWithoutHPA(t *testing.T) {
+	v := &OpenClawInstanceValidator{}
+	instance := newTestInstance()
+	instance.Spec.Suspended = true
+
+	warnings, err := v.ValidateCreate(context.Background(), instance)
+	if err != nil {
+		t.Errorf("suspended without HPA should be valid, got: %v", err)
+	}
+	_ = warnings
+}
+
+func TestValidateUpdate_SuspendedWithHPA(t *testing.T) {
+	v := &OpenClawInstanceValidator{}
+	oldInstance := newTestInstance()
+	newInstance := newTestInstance()
+	newInstance.Spec.Suspended = true
+	newInstance.Spec.Availability.AutoScaling = &openclawv1alpha1.AutoScalingSpec{
+		Enabled: ptr(true),
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldInstance, newInstance)
+	if err == nil {
+		t.Fatal("expected error when suspended and HPA are both enabled on update")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutual exclusivity, got: %s", err.Error())
+	}
+}

--- a/test/e2e/e2e_suspended_test.go
+++ b/test/e2e/e2e_suspended_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	"github.com/openclawrocks/openclaw-operator/internal/resources"
+)
+
+var _ = Describe("Instance Suspension", func() {
+	const (
+		timeout  = time.Second * 120
+		interval = time.Second * 2
+	)
+
+	Context("When creating a suspended instance", func() {
+		var namespace string
+
+		BeforeEach(func() {
+			namespace = "test-suspended-" + time.Now().Format("20060102150405")
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			_ = k8sClient.Delete(ctx, ns)
+		})
+
+		It("Should scale StatefulSet to 0 and set phase to Suspended, then resume on unsuspend", func() {
+			instanceName := "suspended-test"
+
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Suspended: true,
+				},
+			}
+
+			By("Creating a suspended instance")
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			By("Verifying StatefulSet has 0 replicas")
+			Eventually(func() *int32 {
+				sts := &appsv1.StatefulSet{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.StatefulSetName(instance),
+					Namespace: namespace,
+				}, sts)
+				if err != nil {
+					return nil
+				}
+				return sts.Spec.Replicas
+			}, timeout, interval).Should(Equal(resources.Ptr(int32(0))))
+
+			By("Verifying phase is Suspended")
+			Eventually(func() string {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, inst)
+				return inst.Status.Phase
+			}, timeout, interval).Should(Equal(openclawv1alpha1.PhaseSuspended))
+
+			By("Verifying Ready condition is False with reason Suspended")
+			Eventually(func() string {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, inst)
+				cond := meta.FindStatusCondition(inst.Status.Conditions, openclawv1alpha1.ConditionTypeReady)
+				if cond == nil {
+					return ""
+				}
+				return cond.Reason
+			}, timeout, interval).Should(Equal("Suspended"))
+
+			By("Verifying non-runtime resources still exist (Service)")
+			Eventually(func() error {
+				svc := &corev1.Service{}
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.ServiceName(instance),
+					Namespace: namespace,
+				}, svc)
+			}, timeout, interval).Should(Succeed())
+
+			By("Unsuspending the instance")
+			Eventually(func() error {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, inst); err != nil {
+					return err
+				}
+				inst.Spec.Suspended = false
+				return k8sClient.Update(ctx, inst)
+			}, timeout, interval).Should(Succeed())
+
+			By("Verifying StatefulSet scales back to 1 replica")
+			Eventually(func() *int32 {
+				sts := &appsv1.StatefulSet{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.StatefulSetName(instance),
+					Namespace: namespace,
+				}, sts)
+				if err != nil {
+					return nil
+				}
+				return sts.Spec.Replicas
+			}, timeout, interval).Should(Equal(resources.Ptr(int32(1))))
+
+			By("Verifying phase transitions back to Running")
+			Eventually(func() string {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				_ = k8sClient.Get(ctx, types.NamespacedName{Name: instanceName, Namespace: namespace}, inst)
+				return inst.Status.Phase
+			}, timeout, interval).Should(Equal(openclawv1alpha1.PhaseRunning))
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Adds `spec.suspended` boolean field to `OpenClawInstance` so instances can be paused/resumed without deleting the CR.

- `spec.suspended: true` scales the StatefulSet to 0 replicas; all non-runtime resources (Service, ConfigMap, RBAC, NetworkPolicy, PVC) remain managed
- `spec.suspended: false` restores normal replica count and phase transitions back to `Running`
- Phase becomes `Suspended`, `Ready=False` with reason `Suspended`, `StatefulSetReady=True` once pods terminate (prevents false monitoring alerts)
- Auto-updates are paused while suspended and resume on unsuspend
- Webhook rejects `spec.suspended` + `spec.availability.autoScaling.enabled` as mutually exclusive

## Changes

- **CRD types**: `Suspended bool` on spec, `PhaseSuspended` constant, phase enum update
- **Resource builder**: `statefulSetReplicas()` returns 0 when suspended (before HPA check)
- **Controller**: suspended early-return with phase/condition/metric handling, `StatefulSetReady` condition for suspended state, auto-update pause guard
- **Webhook**: mutual exclusivity validation for suspended + HPA
- **Tests**: unit tests for replicas, webhook validation tests, E2E test for full suspend/resume lifecycle
- **Docs**: README feature table + suspension section, API reference

## Test plan

- [x] `make lint` passes
- [x] `make vet` passes
- [x] Unit tests pass (`TestStatefulSetReplicas_Suspended`, `TestStatefulSetReplicas_SuspendedOverridesHPA`)
- [x] Webhook tests pass (`TestValidateCreate_SuspendedWithHPA`, `TestValidateCreate_SuspendedWithoutHPA`, `TestValidateUpdate_SuspendedWithHPA`)
- [ ] E2E test verifies suspend/resume lifecycle on kind cluster (CI)
- [ ] CI pipeline passes (lint, test, security scan, reconcile guard, Helm RBAC sync, build, e2e)

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)