### PR TITLE
fix(plugins): set NODE_PATH so OpenClaw discovers installed plugins

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -12548,3 +12548,38 @@ func TestAdditionalWorkspaceCMKey_Roundtrip(t *testing.T) {
 		t.Error("ParseAdditionalWorkspaceCMKey should return false for non-namespaced key")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Plugin NODE_PATH tests (#424)
+// ---------------------------------------------------------------------------
+
+func TestBuildStatefulSet_PluginsNodePath(t *testing.T) {
+	instance := newTestInstance("plugin-env")
+	instance.Spec.Plugins = []string{"@mem0/openclaw-mem0"}
+
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+
+	mainContainer := sts.Spec.Template.Spec.Containers[0]
+	envMap := map[string]string{}
+	for _, ev := range mainContainer.Env {
+		envMap[ev.Name] = ev.Value
+	}
+
+	want := "/home/openclaw/.openclaw/node_modules"
+	if envMap["NODE_PATH"] != want {
+		t.Errorf("NODE_PATH = %q, want %q", envMap["NODE_PATH"], want)
+	}
+}
+
+func TestBuildStatefulSet_NoPluginsNoNodePath(t *testing.T) {
+	instance := newTestInstance("no-plugin-env")
+
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+
+	mainContainer := sts.Spec.Template.Spec.Containers[0]
+	for _, ev := range mainContainer.Env {
+		if ev.Name == "NODE_PATH" {
+			t.Error("NODE_PATH should not be set when no plugins are defined")
+		}
+	}
+}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -482,6 +482,15 @@ func buildMainEnv(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenSecre
 		)
 	}
 
+	// Plugin discovery - set NODE_PATH so Node.js module resolution finds
+	// packages installed by the init-plugins container in the PVC (#424)
+	if len(instance.Spec.Plugins) > 0 {
+		env = append(env, corev1.EnvVar{
+			Name:  "NODE_PATH",
+			Value: "/home/openclaw/.openclaw/node_modules",
+		})
+	}
+
 	// Build custom PATH with optional prefixes for runtime deps, Tailscale CLI,
 	// and npm-installed skill binaries (#335)
 	hasRuntimeDeps := instance.Spec.RuntimeDeps.Pnpm || instance.Spec.RuntimeDeps.Python


### PR DESCRIPTION
## Summary

- Set `NODE_PATH=/home/openclaw/.openclaw/node_modules` on the main container when `spec.plugins` is non-empty
- This allows Node.js module resolution to find packages installed by the `init-plugins` container in the PVC

**Root cause:** Plugins are installed via `npm install` into `~/.openclaw/node_modules/`, but OpenClaw's Node.js runtime resolves modules from its own install directory (e.g. `/usr/local/lib/node_modules/`). Without `NODE_PATH`, the standard resolution algorithm never traverses `~/.openclaw/node_modules/`.

Closes #424

## Test plan

- [x] Unit test: `NODE_PATH` is set when plugins are defined
- [x] Unit test: `NODE_PATH` is absent when no plugins are defined
- [x] Full `internal/resources/` test suite passes
- [ ] E2E: deploy instance with `spec.plugins: ["@mem0/openclaw-mem0"]` and verify `openclaw plugins list` discovers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)