### PR TITLE
fix: remove env token injection in trusted-proxy mode

### DIFF
--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -595,6 +595,36 @@ func (r *OpenClawInstanceReconciler) reconcileNetworkPolicy(ctx context.Context,
 	return nil
 }
 
+// isGatewayAuthTrustedProxy checks whether the instance's config (inline or
+// external ConfigMap) sets gateway.auth.mode to "trusted-proxy". This mode is
+// mutually exclusive with token-based auth, so the operator must not inject
+// gateway token env vars or config keys when it is active.
+func (r *OpenClawInstanceReconciler) isGatewayAuthTrustedProxy(ctx context.Context, instance *openclawv1alpha1.OpenClawInstance) bool {
+	if instance.Spec.Config.ConfigMapRef != nil {
+		ref := instance.Spec.Config.ConfigMapRef
+		externalCM := &corev1.ConfigMap{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Namespace: instance.Namespace,
+			Name:      ref.Name,
+		}, externalCM); err != nil {
+			return false
+		}
+		key := ref.Key
+		if key == "" {
+			key = "openclaw.json"
+		}
+		data, ok := externalCM.Data[key]
+		if !ok {
+			return false
+		}
+		return resources.IsGatewayAuthTrustedProxy([]byte(data))
+	}
+	if instance.Spec.Config.Raw != nil {
+		return resources.IsGatewayAuthTrustedProxy(instance.Spec.Config.Raw.Raw)
+	}
+	return false
+}
+
 // reconcileGatewayTokenSecret ensures a gateway token Secret exists for the instance.
 // If spec.gateway.existingSecret is set, the operator uses that Secret instead of
 // auto-generating one. Otherwise, a random 32-byte hex token is generated and stored.
@@ -1210,9 +1240,11 @@ func (r *OpenClawInstanceReconciler) reconcileStatefulSet(ctx context.Context, i
 		})
 	}
 
-	// Compute gateway token secret name once for both VCT-change detection and CreateOrUpdate
+	// Compute gateway token secret name once for both VCT-change detection and CreateOrUpdate.
+	// trusted-proxy mode is mutually exclusive with token auth - skip injecting the
+	// OPENCLAW_GATEWAY_TOKEN env var when trusted-proxy is configured.
 	var gwSecretName string
-	if gatewayToken != "" {
+	if gatewayToken != "" && !r.isGatewayAuthTrustedProxy(ctx, instance) {
 		if instance.Spec.Gateway.ExistingSecret != "" {
 			gwSecretName = instance.Spec.Gateway.ExistingSecret
 		} else {

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -177,6 +177,25 @@ func enrichConfigWithGatewayAuth(configJSON []byte, token string) ([]byte, error
 	return json.Marshal(config)
 }
 
+// IsGatewayAuthTrustedProxy returns true if the given config JSON sets
+// gateway.auth.mode to "trusted-proxy".
+func IsGatewayAuthTrustedProxy(configJSON []byte) bool {
+	var config map[string]interface{}
+	if err := json.Unmarshal(configJSON, &config); err != nil {
+		return false
+	}
+	gw, _ := config["gateway"].(map[string]interface{})
+	if gw == nil {
+		return false
+	}
+	auth, _ := gw["auth"].(map[string]interface{})
+	if auth == nil {
+		return false
+	}
+	mode, _ := auth["mode"].(string)
+	return mode == "trusted-proxy"
+}
+
 // enrichConfigWithOTelMetrics injects diagnostics.otel config into the config
 // JSON so OpenClaw pushes metrics to the OTel Collector sidecar via OTLP.
 // The collector then exposes these metrics as a Prometheus scrape endpoint.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -6313,6 +6313,31 @@ func TestEnrichConfigWithGatewayAuth_PreservesOtherAuthFields(t *testing.T) {
 	}
 }
 
+func TestIsGatewayAuthTrustedProxy(t *testing.T) {
+	tests := []struct {
+		name   string
+		config string
+		want   bool
+	}{
+		{"trusted-proxy mode", `{"gateway":{"auth":{"mode":"trusted-proxy"}}}`, true},
+		{"token mode", `{"gateway":{"auth":{"mode":"token"}}}`, false},
+		{"no mode set", `{"gateway":{"auth":{}}}`, false},
+		{"no auth key", `{"gateway":{}}`, false},
+		{"no gateway key", `{}`, false},
+		{"empty config", ``, false},
+		{"invalid JSON", `not-json`, false},
+		{"trusted-proxy with extra fields", `{"gateway":{"auth":{"mode":"trusted-proxy","allowTailscale":true}}}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsGatewayAuthTrustedProxy([]byte(tt.config))
+			if got != tt.want {
+				t.Errorf("IsGatewayAuthTrustedProxy(%s) = %v, want %v", tt.config, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildConfigMap_WithGatewayToken(t *testing.T) {
 	instance := newTestInstance("gw-test")
 	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
@@ -6550,6 +6575,28 @@ func TestBuildStatefulSet_NoGatewayTokenSecretName(t *testing.T) {
 	for _, env := range main.Env {
 		if env.Name == "OPENCLAW_GATEWAY_TOKEN" {
 			t.Error("OPENCLAW_GATEWAY_TOKEN should not be present when no secret name is provided")
+		}
+	}
+}
+
+// TestBuildStatefulSet_TrustedProxy_NoGatewayTokenEnv verifies that when the
+// controller detects trusted-proxy mode and passes an empty gwSecretName,
+// the OPENCLAW_GATEWAY_TOKEN env var is not injected into the StatefulSet.
+func TestBuildStatefulSet_TrustedProxy_NoGatewayTokenEnv(t *testing.T) {
+	instance := newTestInstance("trusted-proxy-sts")
+	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{"gateway":{"auth":{"mode":"trusted-proxy"}}}`),
+		},
+	}
+
+	// In trusted-proxy mode, the controller passes empty gwSecretName
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+
+	main := sts.Spec.Template.Spec.Containers[0]
+	for _, env := range main.Env {
+		if env.Name == "OPENCLAW_GATEWAY_TOKEN" {
+			t.Error("OPENCLAW_GATEWAY_TOKEN must not be present in trusted-proxy mode")
 		}
 	}
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -2394,6 +2394,21 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			Expect(auth).NotTo(HaveKey("token"),
 				"gateway.auth.token must not be set in trusted-proxy mode")
 
+			// OPENCLAW_GATEWAY_TOKEN env var must NOT be present on the StatefulSet
+			sts := &appsv1.StatefulSet{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.StatefulSetName(instance),
+					Namespace: namespace,
+				}, sts)
+			}, timeout, interval).Should(Succeed())
+
+			mainContainer := sts.Spec.Template.Spec.Containers[0]
+			for _, env := range mainContainer.Env {
+				Expect(env.Name).NotTo(Equal("OPENCLAW_GATEWAY_TOKEN"),
+					"OPENCLAW_GATEWAY_TOKEN env var must not be set in trusted-proxy mode")
+			}
+
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
Follow-up to https://github.com/openclaw-rocks/openclaw-operator/pull/428. Unfortunately, I had missed that the operator also injects the gateway token as an environment variable into the StatefulSet which OpenClaw also denies with an error.

This time, I actually understood how to run the pipeline and build a test image myself, so hopefully the pipeline will be green on the first attempt and at least for my OpenClaw configuration, I can confirm that it starts up successfully with the image I built.