### PR TITLE
SelfConfig SSA improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,15 @@ spec:
 
 The operator validates the request, applies it to the parent `OpenClawInstance`, and sets the request's status to `Applied`, `Denied`, or `Failed`. Terminal requests are auto-deleted after 1 hour.
 
+#### GitOps Coexistence
+
+SelfConfig uses Kubernetes Server-Side Apply (SSA) with the field manager name `openclaw-selfconfig`. This enables safe coexistence with GitOps controllers (FluxCD, ArgoCD, etc.) that manage the same `OpenClawInstance` resource:
+
+- **Per-item ownership** -- Skills (set items), env vars (map items by name), and workspace files (map fields) are tracked individually. A SelfConfig can add or remove only the items it owns without conflicting with items managed by other controllers.
+- **Atomic ownership** -- The `config.raw` field is owned atomically. If a GitOps controller also manages `config.raw`, `ForceOwnership` transfers ownership to the SelfConfig field manager on apply.
+- **Removal safety** -- When a SelfConfig attempts to remove an item owned by another field manager, the operator emits a `Warning` / `SelfConfigSkippedRemoval` event identifying the owning manager and includes the warning in the status message.
+- **Non-SSA users are unaffected** -- If you do not use `selfConfigure`, no SSA field managers are created and existing workflows remain unchanged.
+
 See the [API reference](docs/api-reference.md) for the full `OpenClawSelfConfig` CRD spec and `spec.selfConfigure` fields.
 
 ### Persistent storage

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -181,7 +181,7 @@ configMapGenerator:
 
 | Field    | Type       | Default | Description                                                                                       |
 |----------|------------|---------|---------------------------------------------------------------------------------------------------|
-| `skills` | `[]string` | --      | Skills to install. Three formats supported: ClawHub identifiers (e.g., `mcp-server-fetch`), npm packages with `npm:` prefix (e.g., `npm:@openclaw/matrix`), and GitHub-hosted skill packs with `pack:` prefix (e.g., `pack:openclaw-rocks/skills/image-gen`). ClawHub installs are idempotent - already-installed skills are skipped gracefully, making restarts safe with persistent storage. npm lifecycle scripts are disabled for security. Max 20 items. |
+| `skills` | `[]string` | --      | Skills to install. Three formats supported: ClawHub identifiers (e.g., `mcp-server-fetch`), npm packages with `npm:` prefix (e.g., `npm:@openclaw/matrix`), and GitHub-hosted skill packs with `pack:` prefix (e.g., `pack:openclaw-rocks/skills/image-gen`). ClawHub installs are idempotent - already-installed skills are skipped gracefully, making restarts safe with persistent storage. npm lifecycle scripts are disabled for security. Max 20 items. SSA list type: `set` -- each skill is individually tracked for field ownership. |
 
 ```yaml
 spec:
@@ -228,7 +228,7 @@ spec:
 
 | Field | Type           | Default | Description                                         |
 |-------|----------------|---------|-----------------------------------------------------|
-| `env` | `[]EnvVar`     | --      | Individual environment variables to set.             |
+| `env` | `[]EnvVar`     | --      | Individual environment variables to set. SSA list type: `map` (key: `name`) -- each env var is individually tracked for field ownership. |
 
 Standard Kubernetes `EnvVar`. Example:
 
@@ -1349,6 +1349,17 @@ An `OpenClawSelfConfig` represents a request from an agent to modify its own `Op
 4. Status transitions to `Applied` (success) or `Failed` (error)
 5. An owner reference is set to the parent instance for garbage collection
 6. Terminal requests are auto-deleted after 1 hour
+
+### Server-Side Apply and Field Ownership
+
+The SelfConfig controller uses Kubernetes Server-Side Apply (SSA) with the field manager name `openclaw-selfconfig`. This enables fine-grained field ownership tracking:
+
+- **Skills** (`+listType=set`): Each skill name is individually owned. Multiple field managers can each own different skills on the same instance.
+- **Env vars** (`+listType=map`, key: `name`): Each env var is individually owned by the field manager that last set it.
+- **Workspace files** (map fields): Each file entry under `initialFiles` is individually owned.
+- **Config raw**: Owned atomically as a single field.
+
+When a SelfConfig request attempts to remove an item owned by another field manager, the removal is skipped and the operator emits a `Warning` / `SelfConfigSkippedRemoval` event identifying the owning manager. The status message includes details about any skipped removals.
 
 ### Protected Resources
 

--- a/internal/controller/openclawselfconfig_controller.go
+++ b/internal/controller/openclawselfconfig_controller.go
@@ -124,23 +124,20 @@ func (r *OpenClawSelfConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 			fmt.Sprintf("failed to build apply spec: %v", err))
 	}
 
-	// Check managed fields for removal attempts on unowned items
+	// Check managed fields for removal attempts on unowned items.
+	// These checks are purely informational - SSA naturally prevents removing
+	// items not owned by our field manager. The apply spec still includes the
+	// removals, but SSA will simply not remove items owned by other managers.
+	// We emit warnings so users understand why certain removals had no effect.
 	managedFields := instance.GetManagedFields()
 	var warnings []string
 
 	if len(sc.Spec.RemoveSkills) > 0 {
 		ownedSkills := extractOwnedSkills(managedFields)
 		for _, s := range sc.Spec.RemoveSkills {
-			if ownedSkills != nil && ownedSkills[s] {
-				continue // owned by us, will be removed by the apply
-			}
-			manager := findSkillFieldManager(managedFields, s)
-			if manager != "" {
-				msg := fmt.Sprintf("cannot remove skill %q: managed by field manager %q", s, manager)
-				warnings = append(warnings, msg)
-				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
-			} else {
-				msg := fmt.Sprintf("cannot remove skill %q: not managed by %s", s, SelfConfigFieldManager)
+			if msg := checkRemovalOwnership(s, "skill", ownedSkills, func(name string) string {
+				return findSkillFieldManager(managedFields, name)
+			}); msg != "" {
 				warnings = append(warnings, msg)
 				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
 			}
@@ -150,16 +147,9 @@ func (r *OpenClawSelfConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if len(sc.Spec.RemoveEnvVars) > 0 {
 		ownedEnv := extractOwnedEnvVars(managedFields)
 		for _, name := range sc.Spec.RemoveEnvVars {
-			if ownedEnv != nil && ownedEnv[name] {
-				continue
-			}
-			manager := findEnvVarFieldManager(managedFields, name)
-			if manager != "" {
-				msg := fmt.Sprintf("cannot remove env var %q: managed by field manager %q", name, manager)
-				warnings = append(warnings, msg)
-				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
-			} else {
-				msg := fmt.Sprintf("cannot remove env var %q: not managed by %s", name, SelfConfigFieldManager)
+			if msg := checkRemovalOwnership(name, "env var", ownedEnv, func(name string) string {
+				return findEnvVarFieldManager(managedFields, name)
+			}); msg != "" {
 				warnings = append(warnings, msg)
 				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
 			}
@@ -169,16 +159,9 @@ func (r *OpenClawSelfConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if len(sc.Spec.RemoveWorkspaceFiles) > 0 {
 		ownedFiles := extractOwnedWorkspaceFiles(managedFields)
 		for _, name := range sc.Spec.RemoveWorkspaceFiles {
-			if ownedFiles != nil && ownedFiles[name] {
-				continue
-			}
-			manager := findWorkspaceFileFieldManager(managedFields, name)
-			if manager != "" {
-				msg := fmt.Sprintf("cannot remove workspace file %q: managed by field manager %q", name, manager)
-				warnings = append(warnings, msg)
-				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
-			} else {
-				msg := fmt.Sprintf("cannot remove workspace file %q: not managed by %s", name, SelfConfigFieldManager)
+			if msg := checkRemovalOwnership(name, "workspace file", ownedFiles, func(name string) string {
+				return findWorkspaceFileFieldManager(managedFields, name)
+			}); msg != "" {
 				warnings = append(warnings, msg)
 				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
 			}

--- a/internal/controller/openclawselfconfig_controller.go
+++ b/internal/controller/openclawselfconfig_controller.go
@@ -19,10 +19,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -122,10 +124,72 @@ func (r *OpenClawSelfConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 			fmt.Sprintf("failed to build apply spec: %v", err))
 	}
 
+	// Check managed fields for removal attempts on unowned items
+	managedFields := instance.GetManagedFields()
+	var warnings []string
+
+	if len(sc.Spec.RemoveSkills) > 0 {
+		ownedSkills := extractOwnedSkills(managedFields)
+		for _, s := range sc.Spec.RemoveSkills {
+			if ownedSkills != nil && ownedSkills[s] {
+				continue // owned by us, will be removed by the apply
+			}
+			manager := findSkillFieldManager(managedFields, s)
+			if manager != "" {
+				msg := fmt.Sprintf("cannot remove skill %q: managed by field manager %q", s, manager)
+				warnings = append(warnings, msg)
+				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
+			} else {
+				msg := fmt.Sprintf("cannot remove skill %q: not managed by %s", s, SelfConfigFieldManager)
+				warnings = append(warnings, msg)
+				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
+			}
+		}
+	}
+
+	if len(sc.Spec.RemoveEnvVars) > 0 {
+		ownedEnv := extractOwnedEnvVars(managedFields)
+		for _, name := range sc.Spec.RemoveEnvVars {
+			if ownedEnv != nil && ownedEnv[name] {
+				continue
+			}
+			manager := findEnvVarFieldManager(managedFields, name)
+			if manager != "" {
+				msg := fmt.Sprintf("cannot remove env var %q: managed by field manager %q", name, manager)
+				warnings = append(warnings, msg)
+				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
+			} else {
+				msg := fmt.Sprintf("cannot remove env var %q: not managed by %s", name, SelfConfigFieldManager)
+				warnings = append(warnings, msg)
+				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
+			}
+		}
+	}
+
+	if len(sc.Spec.RemoveWorkspaceFiles) > 0 {
+		ownedFiles := extractOwnedWorkspaceFiles(managedFields)
+		for _, name := range sc.Spec.RemoveWorkspaceFiles {
+			if ownedFiles != nil && ownedFiles[name] {
+				continue
+			}
+			manager := findWorkspaceFileFieldManager(managedFields, name)
+			if manager != "" {
+				msg := fmt.Sprintf("cannot remove workspace file %q: managed by field manager %q", name, manager)
+				warnings = append(warnings, msg)
+				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
+			} else {
+				msg := fmt.Sprintf("cannot remove workspace file %q: not managed by %s", name, SelfConfigFieldManager)
+				warnings = append(warnings, msg)
+				r.Recorder.Event(instance, "Warning", "SelfConfigSkippedRemoval", msg)
+			}
+		}
+	}
+
 	// Apply changes using Server-Side Apply with dedicated field manager.
-	// This allows coexistence with GitOps controllers (FluxCD, ArgoCD) by
-	// tracking field ownership at the API server level.
-	applyObj := &openclawv1alpha1.OpenClawInstance{
+	// Use unstructured to preserve empty slices/maps in the JSON payload,
+	// which typed objects with omitempty would drop. This ensures the field
+	// manager correctly releases ownership when all items are removed.
+	typedObj := &openclawv1alpha1.OpenClawInstance{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: openclawv1alpha1.GroupVersion.String(),
 			Kind:       "OpenClawInstance",
@@ -136,6 +200,15 @@ func (r *OpenClawSelfConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 		},
 		Spec: *applySpec,
 	}
+
+	rawMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(typedObj)
+	if err != nil {
+		logger.Error(err, "failed to convert apply spec to unstructured")
+		return r.setTerminalStatus(ctx, sc, openclawv1alpha1.SelfConfigPhaseFailed,
+			fmt.Sprintf("failed to convert apply spec: %v", err))
+	}
+
+	applyObj := &unstructured.Unstructured{Object: rawMap}
 
 	applyErr := r.Patch(ctx, applyObj,
 		client.Apply,
@@ -164,7 +237,13 @@ func (r *OpenClawSelfConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 	r.Recorder.Event(instance, "Normal", "SelfConfigApplied",
 		fmt.Sprintf("self-config request %q applied", sc.Name))
 
-	return r.setTerminalStatus(ctx, sc, openclawv1alpha1.SelfConfigPhaseApplied, "changes applied successfully")
+	// Build status message including any warnings about skipped removals
+	statusMsg := "changes applied successfully"
+	if len(warnings) > 0 {
+		statusMsg = fmt.Sprintf("changes applied with warnings: %s", strings.Join(warnings, "; "))
+	}
+
+	return r.setTerminalStatus(ctx, sc, openclawv1alpha1.SelfConfigPhaseApplied, statusMsg)
 }
 
 // setTerminalStatus updates the SelfConfig status to a terminal phase.

--- a/internal/controller/selfconfig_apply.go
+++ b/internal/controller/selfconfig_apply.go
@@ -98,7 +98,7 @@ func buildSkillsApply(current []string, sc *openclawv1alpha1.OpenClawSelfConfig)
 	}
 
 	seen := make(map[string]bool, len(current)+len(sc.Spec.AddSkills))
-	var result []string
+	result := make([]string, 0, len(current)+len(sc.Spec.AddSkills))
 	for _, s := range current {
 		if removeSet[s] {
 			continue
@@ -220,7 +220,7 @@ func buildEnvApply(current []corev1.EnvVar, sc *openclawv1alpha1.OpenClawSelfCon
 	}
 
 	seen := make(map[string]bool, len(current)+len(sc.Spec.AddEnvVars))
-	var result []corev1.EnvVar
+	result := make([]corev1.EnvVar, 0, len(current)+len(sc.Spec.AddEnvVars))
 	for _, ev := range current {
 		if removeSet[ev.Name] {
 			continue
@@ -242,6 +242,19 @@ func buildEnvApply(current []corev1.EnvVar, sc *openclawv1alpha1.OpenClawSelfCon
 	}
 
 	return result, nil
+}
+
+// checkRemovalOwnership checks whether a named item is owned by the SelfConfig
+// field manager. Returns a warning message if the item is not owned (and thus
+// SSA will not remove it), or empty string if the removal is valid.
+func checkRemovalOwnership(name, kind string, owned map[string]bool, findManager func(string) string) string {
+	if owned != nil && owned[name] {
+		return ""
+	}
+	if manager := findManager(name); manager != "" {
+		return fmt.Sprintf("cannot remove %s %q: managed by field manager %q", kind, name, manager)
+	}
+	return fmt.Sprintf("cannot remove %s %q: not managed by %s", kind, name, SelfConfigFieldManager)
 }
 
 // buildApplySpec constructs the partial OpenClawInstanceSpec for an SSA apply

--- a/internal/controller/selfconfig_apply_test.go
+++ b/internal/controller/selfconfig_apply_test.go
@@ -472,6 +472,42 @@ func TestDeepMerge(t *testing.T) {
 	}
 }
 
+func TestBuildSkillsApply_RemoveAll_NonNilSlice(t *testing.T) {
+	sc := newTestSelfConfig()
+	sc.Spec.RemoveSkills = []string{"skill-a", "skill-b"}
+
+	result := buildSkillsApply([]string{"skill-a", "skill-b"}, sc)
+
+	if result == nil {
+		t.Fatal("expected non-nil empty slice, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %v", result)
+	}
+}
+
+func TestBuildEnvApply_RemoveAll_NonNilSlice(t *testing.T) {
+	current := []corev1.EnvVar{
+		{Name: "VAR_A", Value: "a"},
+		{Name: "VAR_B", Value: "b"},
+	}
+
+	sc := newTestSelfConfig()
+	sc.Spec.RemoveEnvVars = []string{"VAR_A", "VAR_B"}
+
+	result, err := buildEnvApply(current, sc)
+	if err != nil {
+		t.Fatalf("buildEnvApply failed: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil empty slice, got nil")
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty slice, got %v", result)
+	}
+}
+
 func TestBuildApplySpec_AllActions(t *testing.T) {
 	instance := newTestInstance()
 	instance.Spec.Skills = []string{"existing-skill"}

--- a/internal/controller/selfconfig_managed_fields.go
+++ b/internal/controller/selfconfig_managed_fields.go
@@ -66,11 +66,15 @@ func navigateFields(fields managedFieldsSet, path ...string) managedFieldsSet {
 	return current
 }
 
-// findFieldManagerByKey searches all managed field entries for one that owns
-// the given key at the specified field path. Returns the field manager name
-// or empty string if not found.
+// findFieldManagerByKey searches all Apply-type managed field entries for one
+// that owns the given key at the specified field path. Returns the field manager
+// name or empty string if not found. Only Apply entries are checked to avoid
+// matching Update entries from the same manager.
 func findFieldManagerByKey(managedFields []metav1.ManagedFieldsEntry, key string, path ...string) string {
 	for _, entry := range managedFields {
+		if entry.Operation != metav1.ManagedFieldsOperationApply {
+			continue
+		}
 		if entry.FieldsV1 == nil {
 			continue
 		}
@@ -164,6 +168,9 @@ func findSkillFieldManager(managedFields []metav1.ManagedFieldsEntry, skill stri
 }
 
 // findEnvVarFieldManager returns the field manager that owns a given env var.
+// The key is constructed via string concatenation without JSON-escaping because
+// Kubernetes env var names are restricted to [A-Za-z_][A-Za-z0-9_]* and cannot
+// contain characters that would need escaping.
 func findEnvVarFieldManager(managedFields []metav1.ManagedFieldsEntry, name string) string {
 	key := `k:{"name":"` + name + `"}`
 	return findFieldManagerByKey(managedFields, key, "f:spec", "f:env")

--- a/internal/controller/selfconfig_managed_fields.go
+++ b/internal/controller/selfconfig_managed_fields.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// managedFieldsSet is a recursive map structure representing SSA managed fields.
+// Keys are field paths like "f:spec", "f:skills", "v:skill-name", "k:{\"name\":\"VAR\"}".
+type managedFieldsSet map[string]interface{}
+
+// findSelfConfigFields returns the managed fields set for the SelfConfig field manager,
+// or nil if the field manager is not found.
+func findSelfConfigFields(managedFields []metav1.ManagedFieldsEntry) managedFieldsSet {
+	for _, entry := range managedFields {
+		if entry.Manager == SelfConfigFieldManager && entry.Operation == metav1.ManagedFieldsOperationApply {
+			if entry.FieldsV1 == nil {
+				return nil
+			}
+			var fields managedFieldsSet
+			if err := json.Unmarshal(entry.FieldsV1.Raw, &fields); err != nil {
+				return nil
+			}
+			return fields
+		}
+	}
+	return nil
+}
+
+// navigateFields traverses a managedFieldsSet through the given path segments.
+// Each segment should be a field key like "f:spec" or "f:skills".
+func navigateFields(fields managedFieldsSet, path ...string) managedFieldsSet {
+	current := fields
+	for _, segment := range path {
+		if current == nil {
+			return nil
+		}
+		next, ok := current[segment]
+		if !ok {
+			return nil
+		}
+		nextMap, ok := next.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		current = managedFieldsSet(nextMap)
+	}
+	return current
+}
+
+// findFieldManagerByKey searches all managed field entries for one that owns
+// the given key at the specified field path. Returns the field manager name
+// or empty string if not found.
+func findFieldManagerByKey(managedFields []metav1.ManagedFieldsEntry, key string, path ...string) string {
+	for _, entry := range managedFields {
+		if entry.FieldsV1 == nil {
+			continue
+		}
+		var fields managedFieldsSet
+		if err := json.Unmarshal(entry.FieldsV1.Raw, &fields); err != nil {
+			continue
+		}
+		container := navigateFields(fields, path...)
+		if container == nil {
+			continue
+		}
+		if _, ok := container[key]; ok {
+			return entry.Manager
+		}
+	}
+	return ""
+}
+
+// extractOwnedSkills returns the set of skill names owned by the SelfConfig field manager.
+func extractOwnedSkills(managedFields []metav1.ManagedFieldsEntry) map[string]bool {
+	fields := findSelfConfigFields(managedFields)
+	if fields == nil {
+		return nil
+	}
+
+	skillsContainer := navigateFields(fields, "f:spec", "f:skills")
+	if skillsContainer == nil {
+		return nil
+	}
+
+	result := make(map[string]bool)
+	for key := range skillsContainer {
+		// Set items use the format v:"skill-name"
+		if strings.HasPrefix(key, "v:") {
+			result[key[2:]] = true
+		}
+	}
+	return result
+}
+
+// extractOwnedEnvVars returns the set of env var names owned by the SelfConfig field manager.
+func extractOwnedEnvVars(managedFields []metav1.ManagedFieldsEntry) map[string]bool {
+	fields := findSelfConfigFields(managedFields)
+	if fields == nil {
+		return nil
+	}
+
+	envContainer := navigateFields(fields, "f:spec", "f:env")
+	if envContainer == nil {
+		return nil
+	}
+
+	result := make(map[string]bool)
+	for key := range envContainer {
+		// Map items use the format k:{"name":"VAR_NAME"}
+		if strings.HasPrefix(key, "k:") {
+			name := extractNameFromMapKey(key)
+			if name != "" {
+				result[name] = true
+			}
+		}
+	}
+	return result
+}
+
+// extractOwnedWorkspaceFiles returns the set of workspace file names owned by the SelfConfig field manager.
+func extractOwnedWorkspaceFiles(managedFields []metav1.ManagedFieldsEntry) map[string]bool {
+	fields := findSelfConfigFields(managedFields)
+	if fields == nil {
+		return nil
+	}
+
+	filesContainer := navigateFields(fields, "f:spec", "f:workspace", "f:initialFiles")
+	if filesContainer == nil {
+		return nil
+	}
+
+	result := make(map[string]bool)
+	for key := range filesContainer {
+		// Map fields use the format f:filename
+		if strings.HasPrefix(key, "f:") {
+			result[key[2:]] = true
+		}
+	}
+	return result
+}
+
+// findSkillFieldManager returns the field manager that owns a given skill.
+func findSkillFieldManager(managedFields []metav1.ManagedFieldsEntry, skill string) string {
+	return findFieldManagerByKey(managedFields, "v:"+skill, "f:spec", "f:skills")
+}
+
+// findEnvVarFieldManager returns the field manager that owns a given env var.
+func findEnvVarFieldManager(managedFields []metav1.ManagedFieldsEntry, name string) string {
+	key := `k:{"name":"` + name + `"}`
+	return findFieldManagerByKey(managedFields, key, "f:spec", "f:env")
+}
+
+// findWorkspaceFileFieldManager returns the field manager that owns a given workspace file.
+func findWorkspaceFileFieldManager(managedFields []metav1.ManagedFieldsEntry, filename string) string {
+	return findFieldManagerByKey(managedFields, "f:"+filename, "f:spec", "f:workspace", "f:initialFiles")
+}
+
+// extractNameFromMapKey extracts the "name" value from an SSA map key like k:{"name":"VAR_NAME"}.
+func extractNameFromMapKey(key string) string {
+	// key format: k:{"name":"VAR_NAME"}
+	jsonPart := key[2:] // strip "k:"
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(jsonPart), &parsed); err != nil {
+		return ""
+	}
+	return parsed["name"]
+}

--- a/internal/controller/selfconfig_managed_fields_test.go
+++ b/internal/controller/selfconfig_managed_fields_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// buildManagedFieldsEntry creates a ManagedFieldsEntry with the given manager name
+// and raw JSON fields, using the Apply operation.
+func buildManagedFieldsEntry(manager string, fieldsJSON string) metav1.ManagedFieldsEntry {
+	return metav1.ManagedFieldsEntry{
+		Manager:   manager,
+		Operation: metav1.ManagedFieldsOperationApply,
+		FieldsV1:  &metav1.FieldsV1{Raw: []byte(fieldsJSON)},
+	}
+}
+
+func TestExtractOwnedSkills(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry(SelfConfigFieldManager, `{
+			"f:spec": {
+				"f:skills": {
+					"v:mcp-server-fetch": {},
+					"v:mcp-server-puppeteer": {}
+				}
+			}
+		}`),
+		buildManagedFieldsEntry("kubectl-client-side-apply", `{
+			"f:spec": {
+				"f:skills": {
+					"v:bootstrap-skill": {}
+				}
+			}
+		}`),
+	}
+
+	owned := extractOwnedSkills(managedFields)
+	if owned == nil {
+		t.Fatal("expected non-nil owned skills")
+	}
+	if !owned["mcp-server-fetch"] {
+		t.Error("expected mcp-server-fetch to be owned")
+	}
+	if !owned["mcp-server-puppeteer"] {
+		t.Error("expected mcp-server-puppeteer to be owned")
+	}
+	if owned["bootstrap-skill"] {
+		t.Error("bootstrap-skill should not be owned by selfconfig")
+	}
+}
+
+func TestExtractOwnedSkills_NoSelfConfigManager(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry("kubectl", `{
+			"f:spec": {
+				"f:skills": {
+					"v:some-skill": {}
+				}
+			}
+		}`),
+	}
+
+	owned := extractOwnedSkills(managedFields)
+	if owned != nil {
+		t.Errorf("expected nil, got %v", owned)
+	}
+}
+
+func TestExtractOwnedSkills_NoSkillsField(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry(SelfConfigFieldManager, `{
+			"f:spec": {
+				"f:config": {}
+			}
+		}`),
+	}
+
+	owned := extractOwnedSkills(managedFields)
+	if owned != nil {
+		t.Errorf("expected nil, got %v", owned)
+	}
+}
+
+func TestExtractOwnedEnvVars(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry(SelfConfigFieldManager, `{
+			"f:spec": {
+				"f:env": {
+					"k:{\"name\":\"MY_VAR\"}": {},
+					"k:{\"name\":\"OTHER_VAR\"}": {}
+				}
+			}
+		}`),
+	}
+
+	owned := extractOwnedEnvVars(managedFields)
+	if owned == nil {
+		t.Fatal("expected non-nil owned env vars")
+	}
+	if !owned["MY_VAR"] {
+		t.Error("expected MY_VAR to be owned")
+	}
+	if !owned["OTHER_VAR"] {
+		t.Error("expected OTHER_VAR to be owned")
+	}
+}
+
+func TestExtractOwnedEnvVars_NoManager(t *testing.T) {
+	owned := extractOwnedEnvVars(nil)
+	if owned != nil {
+		t.Errorf("expected nil, got %v", owned)
+	}
+}
+
+func TestExtractOwnedWorkspaceFiles(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry(SelfConfigFieldManager, `{
+			"f:spec": {
+				"f:workspace": {
+					"f:initialFiles": {
+						"f:notes.md": {},
+						"f:plan.txt": {}
+					}
+				}
+			}
+		}`),
+	}
+
+	owned := extractOwnedWorkspaceFiles(managedFields)
+	if owned == nil {
+		t.Fatal("expected non-nil owned workspace files")
+	}
+	if !owned["notes.md"] {
+		t.Error("expected notes.md to be owned")
+	}
+	if !owned["plan.txt"] {
+		t.Error("expected plan.txt to be owned")
+	}
+}
+
+func TestExtractOwnedWorkspaceFiles_NoManager(t *testing.T) {
+	owned := extractOwnedWorkspaceFiles(nil)
+	if owned != nil {
+		t.Errorf("expected nil, got %v", owned)
+	}
+}
+
+func TestFindSkillFieldManager(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry(SelfConfigFieldManager, `{
+			"f:spec": {
+				"f:skills": {
+					"v:selfconfig-skill": {}
+				}
+			}
+		}`),
+		buildManagedFieldsEntry("flux-system", `{
+			"f:spec": {
+				"f:skills": {
+					"v:gitops-skill": {}
+				}
+			}
+		}`),
+	}
+
+	manager := findSkillFieldManager(managedFields, "gitops-skill")
+	if manager != "flux-system" {
+		t.Errorf("expected flux-system, got %q", manager)
+	}
+
+	manager = findSkillFieldManager(managedFields, "selfconfig-skill")
+	if manager != SelfConfigFieldManager {
+		t.Errorf("expected %s, got %q", SelfConfigFieldManager, manager)
+	}
+
+	manager = findSkillFieldManager(managedFields, "unknown-skill")
+	if manager != "" {
+		t.Errorf("expected empty, got %q", manager)
+	}
+}
+
+func TestFindEnvVarFieldManager(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry("argocd", `{
+			"f:spec": {
+				"f:env": {
+					"k:{\"name\":\"ARGO_VAR\"}": {}
+				}
+			}
+		}`),
+		buildManagedFieldsEntry(SelfConfigFieldManager, `{
+			"f:spec": {
+				"f:env": {
+					"k:{\"name\":\"SELF_VAR\"}": {}
+				}
+			}
+		}`),
+	}
+
+	manager := findEnvVarFieldManager(managedFields, "ARGO_VAR")
+	if manager != "argocd" {
+		t.Errorf("expected argocd, got %q", manager)
+	}
+
+	manager = findEnvVarFieldManager(managedFields, "SELF_VAR")
+	if manager != SelfConfigFieldManager {
+		t.Errorf("expected %s, got %q", SelfConfigFieldManager, manager)
+	}
+
+	manager = findEnvVarFieldManager(managedFields, "UNKNOWN")
+	if manager != "" {
+		t.Errorf("expected empty, got %q", manager)
+	}
+}
+
+func TestFindWorkspaceFileFieldManager(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		buildManagedFieldsEntry("flux-system", `{
+			"f:spec": {
+				"f:workspace": {
+					"f:initialFiles": {
+						"f:gitops-file.md": {}
+					}
+				}
+			}
+		}`),
+		buildManagedFieldsEntry(SelfConfigFieldManager, `{
+			"f:spec": {
+				"f:workspace": {
+					"f:initialFiles": {
+						"f:agent-file.md": {}
+					}
+				}
+			}
+		}`),
+	}
+
+	manager := findWorkspaceFileFieldManager(managedFields, "gitops-file.md")
+	if manager != "flux-system" {
+		t.Errorf("expected flux-system, got %q", manager)
+	}
+
+	manager = findWorkspaceFileFieldManager(managedFields, "agent-file.md")
+	if manager != SelfConfigFieldManager {
+		t.Errorf("expected %s, got %q", SelfConfigFieldManager, manager)
+	}
+
+	manager = findWorkspaceFileFieldManager(managedFields, "unknown.md")
+	if manager != "" {
+		t.Errorf("expected empty, got %q", manager)
+	}
+}
+
+func TestExtractNameFromMapKey(t *testing.T) {
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{`k:{"name":"MY_VAR"}`, "MY_VAR"},
+		{`k:{"name":""}`, ""},
+		{`k:invalid`, ""},
+	}
+
+	for _, tt := range tests {
+		got := extractNameFromMapKey(tt.key)
+		if got != tt.want {
+			t.Errorf("extractNameFromMapKey(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}

--- a/internal/controller/selfconfig_managed_fields_test.go
+++ b/internal/controller/selfconfig_managed_fields_test.go
@@ -24,7 +24,7 @@ import (
 
 // buildManagedFieldsEntry creates a ManagedFieldsEntry with the given manager name
 // and raw JSON fields, using the Apply operation.
-func buildManagedFieldsEntry(manager string, fieldsJSON string) metav1.ManagedFieldsEntry {
+func buildManagedFieldsEntry(manager, fieldsJSON string) metav1.ManagedFieldsEntry {
 	return metav1.ManagedFieldsEntry{
 		Manager:   manager,
 		Operation: metav1.ManagedFieldsOperationApply,
@@ -265,6 +265,27 @@ func TestFindWorkspaceFileFieldManager(t *testing.T) {
 	manager = findWorkspaceFileFieldManager(managedFields, "unknown.md")
 	if manager != "" {
 		t.Errorf("expected empty, got %q", manager)
+	}
+}
+
+func TestFindFieldManagerByKey_SkipsUpdateEntries(t *testing.T) {
+	managedFields := []metav1.ManagedFieldsEntry{
+		{
+			Manager:   "kubectl-edit",
+			Operation: metav1.ManagedFieldsOperationUpdate,
+			FieldsV1:  &metav1.FieldsV1{Raw: []byte(`{"f:spec":{"f:skills":{"v:update-skill":{}}}}`)},
+		},
+		buildManagedFieldsEntry("flux-system", `{"f:spec":{"f:skills":{"v:apply-skill":{}}}}`),
+	}
+
+	manager := findSkillFieldManager(managedFields, "update-skill")
+	if manager != "" {
+		t.Errorf("expected empty (Update entry should be skipped), got %q", manager)
+	}
+
+	manager = findSkillFieldManager(managedFields, "apply-skill")
+	if manager != "flux-system" {
+		t.Errorf("expected flux-system, got %q", manager)
 	}
 }
 

--- a/test/e2e/e2e_selfconfig_test.go
+++ b/test/e2e/e2e_selfconfig_test.go
@@ -237,6 +237,127 @@ var _ = Describe("OpenClawSelfConfig Controller", func() {
 			Expect(updatedInstance.Spec.Skills).To(ContainElement("@anthropic/mcp-server-fetch"))
 			Expect(updatedInstance.Spec.Skills).To(ContainElement("existing-skill"))
 
+			// Verify that the selfconfig field manager appears in managed fields
+			managedFields := updatedInstance.GetManagedFields()
+			var foundSelfConfigManager bool
+			for _, entry := range managedFields {
+				if entry.Manager == "openclaw-selfconfig" {
+					foundSelfConfigManager = true
+					break
+				}
+			}
+			Expect(foundSelfConfigManager).To(BeTrue(),
+				"openclaw-selfconfig field manager should appear in managed fields after SSA apply")
+
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+
+		It("Should preserve field ownership across multiple SelfConfig applies", func() {
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instanceName := "sc-multi-apply-test"
+
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Skills: []string{"bootstrap-skill"},
+					SelfConfigure: openclawv1alpha1.SelfConfigureSpec{
+						Enabled: true,
+						AllowedActions: []openclawv1alpha1.SelfConfigAction{
+							openclawv1alpha1.SelfConfigActionSkills,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// Wait for initial reconciliation
+			Eventually(func() string {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instanceName,
+					Namespace: namespace,
+				}, &appsv1.StatefulSet{})
+				if err == nil {
+					return "found"
+				}
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				phase := "unknown"
+				if getErr := k8sClient.Get(ctx, types.NamespacedName{
+					Name: instanceName, Namespace: namespace,
+				}, inst); getErr == nil {
+					phase = inst.Status.Phase
+				}
+				return "not found (instance phase: " + phase + ")"
+			}, timeout, interval).Should(Equal("found"),
+				"StatefulSet should be created by reconcile")
+
+			// First SelfConfig: add skill 1
+			sc1 := &openclawv1alpha1.OpenClawSelfConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "add-skill-1",
+					Namespace: namespace,
+				},
+				Spec: openclawv1alpha1.OpenClawSelfConfigSpec{
+					InstanceRef: instanceName,
+					AddSkills:   []string{"added-skill-1"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sc1)).Should(Succeed())
+
+			Eventually(func() openclawv1alpha1.SelfConfigPhase {
+				fetched := &openclawv1alpha1.OpenClawSelfConfig{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: "add-skill-1", Namespace: namespace,
+				}, fetched); err != nil {
+					return ""
+				}
+				return fetched.Status.Phase
+			}, timeout, interval).Should(Equal(openclawv1alpha1.SelfConfigPhaseApplied))
+
+			// Second SelfConfig: add skill 2
+			sc2 := &openclawv1alpha1.OpenClawSelfConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "add-skill-2",
+					Namespace: namespace,
+				},
+				Spec: openclawv1alpha1.OpenClawSelfConfigSpec{
+					InstanceRef: instanceName,
+					AddSkills:   []string{"added-skill-2"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sc2)).Should(Succeed())
+
+			Eventually(func() openclawv1alpha1.SelfConfigPhase {
+				fetched := &openclawv1alpha1.OpenClawSelfConfig{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name: "add-skill-2", Namespace: namespace,
+				}, fetched); err != nil {
+					return ""
+				}
+				return fetched.Status.Phase
+			}, timeout, interval).Should(Equal(openclawv1alpha1.SelfConfigPhaseApplied))
+
+			// Verify all three skills coexist
+			updatedInstance := &openclawv1alpha1.OpenClawInstance{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: instanceName, Namespace: namespace,
+			}, updatedInstance)).To(Succeed())
+			Expect(updatedInstance.Spec.Skills).To(ContainElement("bootstrap-skill"))
+			Expect(updatedInstance.Spec.Skills).To(ContainElement("added-skill-1"))
+			Expect(updatedInstance.Spec.Skills).To(ContainElement("added-skill-2"))
+
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})
 


### PR DESCRIPTION
Follow-up to #439 -- adds managed fields awareness, warning events, and the "remove all" correctness fix to the SelfConfig SSA implementation.

- Add managed fields parser to extract SelfConfig-owned items from Kubernetes `managedFields` metadata
- Emit `Warning`/`SelfConfigSkippedRemoval` events when removal targets items owned by another field manager (e.g. FluxCD), identifying the owner by name
- Fix "remove all" edge case: use `unstructured.Unstructured` for the SSA apply so empty slices/maps are preserved in JSON instead of being silently omitted by `omitempty` (which prevented ownership release)
- Add E2E tests verifying field manager presence in `managedFields` and multi-apply skill coexistence
- Document SSA field ownership model and GitOps coexistence in README and API reference

### Why

The merged SSA implementation (#439) works with `instance.Spec` (the full current state) rather than `managedFields`. This means:
  1. Removing a skill owned by Flux silently does nothing -- no feedback to the user
  2. Removing all SelfConfig-owned skills produces an empty slice, which `omitempty` drops from JSON, so SSA never releases ownership and the items remain

## Test plan

- [x] `make test`
- [x] `make`, `make vet` clean
- [ ] Controller integration tests (envtest) -- CI
- [ ] E2E tests: field manager verification + multi-apply coexistence -- CI
