### PR TITLE
feat(helm): add logLevel value to control operator log verbosity

### DIFF
--- a/charts/openclaw-operator/templates/deployment.yaml
+++ b/charts/openclaw-operator/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             {{- else }}
             - --metrics-bind-address=0
             {{- end }}
+            - --zap-log-level={{ .Values.logLevel }}
             {{- if .Values.otlp.enabled }}
             {{- if not .Values.otlp.endpoint }}
             {{- fail "otlp.endpoint is required when otlp.enabled is true" }}

--- a/charts/openclaw-operator/values.yaml
+++ b/charts/openclaw-operator/values.yaml
@@ -76,6 +76,9 @@ tolerations: []
 # Affinity rules for pod scheduling
 affinity: {}
 
+# Log level for the operator (passed as --zap-log-level). Valid values: debug, info, error, or an integer (0=info, 1=debug).
+logLevel: info
+
 # Leader election configuration
 leaderElection:
   enabled: true


### PR DESCRIPTION
Closes #444.

Wires `--zap-log-level` into the deployment args via a new `logLevel` Helm value (default: `info`). The flag is already accepted by the binary via `opts.BindFlags` — this just exposes it.

```yaml
# suppress debug output in production
logLevel: info

# re-enable for troubleshooting
logLevel: debug
```