### PR TITLE
fix: preserve third-party annotations and labels when reconciling managed resources

### DIFF
--- a/internal/controller/maps.go
+++ b/internal/controller/maps.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// mergeStringMap merges desired entries into current for any map[string]string
+// (labels, annotations, or similar), preserving keys not present in desired
+// that were added by external controllers or other actors.
+//
+// Known limitation: keys the operator previously managed but no longer desires
+// are not removed. They remain on the object but the operator ignores them.
+// Implementing pruning without touching external keys would require tracking
+// operator-owned keys across reconciles (added complexity, minimal practical
+// value).
+func mergeStringMap(current, desired map[string]string) map[string]string {
+	if current == nil {
+		current = make(map[string]string)
+	}
+	for k, v := range desired {
+		current[k] = v
+	}
+	return current
+}

--- a/internal/controller/maps_test.go
+++ b/internal/controller/maps_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+)
+
+func TestMergeStringMap_NilCurrent(t *testing.T) {
+	result := mergeStringMap(nil, map[string]string{"foo": "bar"})
+	if result["foo"] != "bar" {
+		t.Errorf("expected foo=bar, got %q", result["foo"])
+	}
+}
+
+func TestMergeStringMap_PreservesExternalAnnotations(t *testing.T) {
+	current := map[string]string{
+		"field.cattle.io/publicEndpoints": "external-value",
+	}
+	result := mergeStringMap(current, map[string]string{"operator.io/key": "v1"})
+	if result["field.cattle.io/publicEndpoints"] != "external-value" {
+		t.Error("external annotation was stripped")
+	}
+	if result["operator.io/key"] != "v1" {
+		t.Error("desired annotation was not set")
+	}
+}
+
+func TestMergeStringMap_UpdatesExistingOperatorAnnotation(t *testing.T) {
+	current := map[string]string{"operator.io/key": "v1"}
+	result := mergeStringMap(current, map[string]string{"operator.io/key": "v2"})
+	if result["operator.io/key"] != "v2" {
+		t.Errorf("expected v2, got %q", result["operator.io/key"])
+	}
+}
+
+func TestMergeStringMap_StaleOperatorAnnotationsRetained(t *testing.T) {
+	// Stale operator annotations are intentionally not pruned; see mergeStringMap doc.
+	current := map[string]string{"operator.io/old-key": "v1"}
+	result := mergeStringMap(current, map[string]string{"operator.io/new-key": "v2"})
+	if result["operator.io/old-key"] != "v1" {
+		t.Error("stale annotation should be retained, not pruned")
+	}
+	if result["operator.io/new-key"] != "v2" {
+		t.Error("new annotation was not set")
+	}
+}
+
+func TestMergeStringMap_Labels(t *testing.T) {
+	current := map[string]string{
+		"app.kubernetes.io/managed-by": "external-tool",
+	}
+	result := mergeStringMap(current, map[string]string{"operator.io/label": "v1"})
+	if result["app.kubernetes.io/managed-by"] != "external-tool" {
+		t.Error("external label was stripped")
+	}
+	if result["operator.io/label"] != "v1" {
+		t.Error("desired label was not set")
+	}
+}

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -497,8 +497,8 @@ func (r *OpenClawInstanceReconciler) reconcileRBAC(ctx context.Context, instance
 		}
 		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
 			desired := resources.BuildServiceAccount(instance)
-			sa.Labels = desired.Labels
-			sa.Annotations = desired.Annotations
+			sa.Labels = mergeStringMap(sa.Labels, desired.Labels)
+			sa.Annotations = mergeStringMap(sa.Annotations, desired.Annotations)
 			sa.AutomountServiceAccountToken = desired.AutomountServiceAccountToken
 			return controllerutil.SetControllerReference(instance, sa, r.Scheme)
 		}); err != nil {
@@ -515,7 +515,7 @@ func (r *OpenClawInstanceReconciler) reconcileRBAC(ctx context.Context, instance
 		}
 		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, role, func() error {
 			desired := resources.BuildRole(instance)
-			role.Labels = desired.Labels
+			role.Labels = mergeStringMap(role.Labels, desired.Labels)
 			role.Rules = desired.Rules
 			return controllerutil.SetControllerReference(instance, role, r.Scheme)
 		}); err != nil {
@@ -532,7 +532,7 @@ func (r *OpenClawInstanceReconciler) reconcileRBAC(ctx context.Context, instance
 		}
 		if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, roleBinding, func() error {
 			desired := resources.BuildRoleBinding(instance)
-			roleBinding.Labels = desired.Labels
+			roleBinding.Labels = mergeStringMap(roleBinding.Labels, desired.Labels)
 			roleBinding.RoleRef = desired.RoleRef
 			roleBinding.Subjects = desired.Subjects
 			return controllerutil.SetControllerReference(instance, roleBinding, r.Scheme)
@@ -577,7 +577,7 @@ func (r *OpenClawInstanceReconciler) reconcileNetworkPolicy(ctx context.Context,
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, np, func() error {
 		desired := resources.BuildNetworkPolicy(instance)
-		np.Labels = desired.Labels
+		np.Labels = mergeStringMap(np.Labels, desired.Labels)
 		np.Spec = desired.Spec
 		return controllerutil.SetControllerReference(instance, np, r.Scheme)
 	}); err != nil {
@@ -679,7 +679,7 @@ func (r *OpenClawInstanceReconciler) reconcileGatewayTokenSecret(ctx context.Con
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		desired := resources.BuildGatewayTokenSecret(instance, tokenHex)
-		secret.Labels = desired.Labels
+		secret.Labels = mergeStringMap(secret.Labels, desired.Labels)
 		// Only set data if this is a new Secret (don't overwrite user edits)
 		if secret.Data == nil {
 			secret.Data = desired.Data
@@ -709,7 +709,7 @@ func (r *OpenClawInstanceReconciler) reconcileTailscaleStateSecret(ctx context.C
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		desired := resources.BuildTailscaleStateSecret(instance)
-		secret.Labels = desired.Labels
+		secret.Labels = mergeStringMap(secret.Labels, desired.Labels)
 		// Do not overwrite Data - containerboot manages the content
 		return controllerutil.SetControllerReference(instance, secret, r.Scheme)
 	}); err != nil {
@@ -770,7 +770,7 @@ func (r *OpenClawInstanceReconciler) reconcileConfigMap(ctx context.Context, ins
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
-		cm.Labels = desired.Labels
+		cm.Labels = mergeStringMap(cm.Labels, desired.Labels)
 		cm.Data = desired.Data
 		return controllerutil.SetControllerReference(instance, cm, r.Scheme)
 	}); err != nil {
@@ -950,7 +950,7 @@ func (r *OpenClawInstanceReconciler) reconcileWorkspaceConfigMap(ctx context.Con
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
-		cm.Labels = desired.Labels
+		cm.Labels = mergeStringMap(cm.Labels, desired.Labels)
 		cm.Data = desired.Data
 		return controllerutil.SetControllerReference(instance, cm, r.Scheme)
 	}); err != nil {
@@ -1118,7 +1118,7 @@ func (r *OpenClawInstanceReconciler) reconcilePDB(ctx context.Context, instance 
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, pdb, func() error {
 		desired := resources.BuildPDB(instance)
-		pdb.Labels = desired.Labels
+		pdb.Labels = mergeStringMap(pdb.Labels, desired.Labels)
 		pdb.Spec = desired.Spec
 		return controllerutil.SetControllerReference(instance, pdb, r.Scheme)
 	}); err != nil {
@@ -1151,7 +1151,7 @@ func (r *OpenClawInstanceReconciler) reconcileHPA(ctx context.Context, instance 
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, hpa, func() error {
 		desired := resources.BuildHPA(instance)
-		hpa.Labels = desired.Labels
+		hpa.Labels = mergeStringMap(hpa.Labels, desired.Labels)
 		hpa.Spec = desired.Spec
 		return controllerutil.SetControllerReference(instance, hpa, r.Scheme)
 	}); err != nil {
@@ -1286,7 +1286,7 @@ func (r *OpenClawInstanceReconciler) reconcileStatefulSet(ctx context.Context, i
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, sts, func() error {
-		sts.Labels = desired.Labels
+		sts.Labels = mergeStringMap(sts.Labels, desired.Labels)
 		// Preserve current replica count when HPA manages scaling
 		existingReplicas := sts.Spec.Replicas
 		sts.Spec = desired.Spec
@@ -1371,8 +1371,8 @@ func (r *OpenClawInstanceReconciler) reconcileService(ctx context.Context, insta
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
 		desired := resources.BuildService(instance)
-		service.Labels = desired.Labels
-		service.Annotations = desired.Annotations
+		service.Labels = mergeStringMap(service.Labels, desired.Labels)
+		service.Annotations = mergeStringMap(service.Annotations, desired.Annotations)
 		// Preserve ClusterIP — it is assigned by the API server and immutable
 		clusterIP := service.Spec.ClusterIP
 		clusterIPs := service.Spec.ClusterIPs
@@ -1415,7 +1415,7 @@ func (r *OpenClawInstanceReconciler) reconcileChromiumCDPService(ctx context.Con
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, svc, func() error {
 		desired := resources.BuildChromiumCDPService(instance)
-		svc.Labels = desired.Labels
+		svc.Labels = mergeStringMap(svc.Labels, desired.Labels)
 		svc.Spec = desired.Spec
 		return controllerutil.SetControllerReference(instance, svc, r.Scheme)
 	}); err != nil {
@@ -1458,8 +1458,8 @@ func (r *OpenClawInstanceReconciler) reconcileIngress(ctx context.Context, insta
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, ingress, func() error {
 		desired := resources.BuildIngress(instance)
-		ingress.Labels = desired.Labels
-		ingress.Annotations = desired.Annotations
+		ingress.Labels = mergeStringMap(ingress.Labels, desired.Labels)
+		ingress.Annotations = mergeStringMap(ingress.Annotations, desired.Annotations)
 		ingress.Spec = desired.Spec
 		return controllerutil.SetControllerReference(instance, ingress, r.Scheme)
 	}); err != nil {
@@ -1513,7 +1513,7 @@ func (r *OpenClawInstanceReconciler) reconcileBasicAuthSecret(ctx context.Contex
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
 		desired := resources.BuildBasicAuthSecret(instance, password)
-		secret.Labels = desired.Labels
+		secret.Labels = mergeStringMap(secret.Labels, desired.Labels)
 		if secret.Data == nil {
 			secret.Data = desired.Data
 		}
@@ -1699,8 +1699,8 @@ func (r *OpenClawInstanceReconciler) reconcileGrafanaDashboards(ctx context.Cont
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, opCM, func() error {
 		desired := resources.BuildGrafanaDashboardOperator(instance)
-		opCM.Labels = desired.Labels
-		opCM.Annotations = desired.Annotations
+		opCM.Labels = mergeStringMap(opCM.Labels, desired.Labels)
+		opCM.Annotations = mergeStringMap(opCM.Annotations, desired.Annotations)
 		opCM.Data = desired.Data
 		return controllerutil.SetControllerReference(instance, opCM, r.Scheme)
 	}); err != nil {
@@ -1717,8 +1717,8 @@ func (r *OpenClawInstanceReconciler) reconcileGrafanaDashboards(ctx context.Cont
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, instCM, func() error {
 		desired := resources.BuildGrafanaDashboardInstance(instance)
-		instCM.Labels = desired.Labels
-		instCM.Annotations = desired.Annotations
+		instCM.Labels = mergeStringMap(instCM.Labels, desired.Labels)
+		instCM.Annotations = mergeStringMap(instCM.Annotations, desired.Annotations)
 		instCM.Data = desired.Data
 		return controllerutil.SetControllerReference(instance, instCM, r.Scheme)
 	}); err != nil {


### PR DESCRIPTION
Closes #446.

## Problem

Issue #446 identified four resources where `CreateOrUpdate` mutate funcs replaced the annotation map wholesale:

```go
obj.Annotations = desired.Annotations
```

On any cluster where an external controller annotates operator-managed resources, the operator strips those annotations on every reconcile, causing the external controller to re-add them, triggering another reconcile -- a tight loop. Confirmed trigger: Rancher stamps `field.cattle.io/publicEndpoints` on Ingresses and Services.

On closer inspection the same bug affects **labels** across **all** operator-managed resources, for the same reason: `obj.Labels = desired.Labels` is wholesale replacement. Any external tool that labels an operator-managed resource (monitoring agents, cost tooling, admission webhooks) hits the same loop.

## Fix

Introduce a `mergeStringMap` helper that merges desired entries into the existing map rather than replacing it:

```go
func mergeStringMap(current, desired map[string]string) map[string]string {
    if current == nil {
        current = make(map[string]string)
    }
    for k, v := range desired {
        current[k] = v
    }
    return current
}
```

Apply it to every `.Labels` and `.Annotations` assignment across all `CreateOrUpdate` mutate funcs in the controller (17 label sites, 5 annotation sites).

**Known limitation:** keys the operator previously managed but no longer desires are not removed -- they remain on the object but the operator ignores them. Implementing pruning without touching external keys would require tracking operator-owned keys across reconciles. The added complexity is not worth it; a stale label or annotation the operator no longer cares about causes no harm.

## Changes

- `internal/controller/annotations.go` -- new `mergeStringMap` helper with doc comment covering the known limitation
- `internal/controller/openclawinstance_controller.go` -- all `.Labels = desired.Labels` and `.Annotations = desired.Annotations` assignments replaced with `mergeStringMap`
- `internal/controller/annotations_test.go` -- unit tests covering nil current, external key preservation, update, stale-key retention, and label case