### PR TITLE
fix(init): mount full data volume in init-uv/init-pip for hostPath PVCs

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -5064,6 +5064,84 @@ func TestBuildStatefulSet_WritablePVCSubPaths(t *testing.T) {
 	}
 }
 
+// TestBuildStatefulSet_InitUvPipMountFullDataVolume verifies that init-uv and
+// init-pip mount the data PVC in full (not via SubPath .local). This is
+// required so that on hostPath-backed storage (where fsGroup is not applied),
+// the init containers create .local, .cache, and skills subdirectories with
+// the pod UID as owner. Every downstream container that mounts these paths via
+// SubPath inherits the correct ownership from the pre-created directory.
+// See https://github.com/openclaw-rocks/openclaw-operator/issues/448.
+func TestBuildStatefulSet_InitUvPipMountFullDataVolume(t *testing.T) {
+	instance := newTestInstance("init-uv-hostpath")
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+
+	var initUv, initPip *corev1.Container
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		c := &sts.Spec.Template.Spec.InitContainers[i]
+		switch c.Name {
+		case "init-uv":
+			initUv = c
+		case "init-pip":
+			initPip = c
+		}
+	}
+	if initUv == nil {
+		t.Fatal("init-uv container not found")
+	}
+	if initPip == nil {
+		t.Fatal("init-pip container not found")
+	}
+
+	// Both init containers must mount data in full at /data with no SubPath,
+	// otherwise kubelet creates the missing SubPath dir as root:root on
+	// hostPath PVCs and the non-root init container cannot write to it.
+	assertDataMountFull := func(t *testing.T, c *corev1.Container) {
+		t.Helper()
+		var found bool
+		for _, m := range c.VolumeMounts {
+			if m.Name != "data" {
+				continue
+			}
+			if m.SubPath != "" {
+				t.Errorf("%s data mount must not use SubPath (got %q): SubPath dirs are created root:root by kubelet on hostPath PVCs", c.Name, m.SubPath)
+			}
+			if m.MountPath != "/data" {
+				t.Errorf("%s data mount path = %q, want %q", c.Name, m.MountPath, "/data")
+			}
+			found = true
+		}
+		if !found {
+			t.Errorf("%s: data volume mount not found", c.Name)
+		}
+	}
+	assertDataMountFull(t, initUv)
+	assertDataMountFull(t, initPip)
+
+	// init-uv must pre-create all SubPath subdirectories so every downstream
+	// container (main, init-pip, init-skills, ...) inherits UID ownership.
+	script := ""
+	if len(initUv.Command) >= 3 {
+		script = initUv.Command[2]
+	}
+	for _, dir := range []string{"/data/.local/bin", "/data/.cache", "/data/skills"} {
+		if !strings.Contains(script, dir) {
+			t.Errorf("init-uv script should pre-create %s, got:\n%s", dir, script)
+		}
+	}
+
+	// init-pip must set HOME=/data so ensurepip --user writes to /data/.local
+	// (not /home/openclaw/.local, which would be an unmounted path now).
+	var homeEnv string
+	for _, e := range initPip.Env {
+		if e.Name == "HOME" {
+			homeEnv = e.Value
+		}
+	}
+	if homeEnv != "/data" {
+		t.Errorf("init-pip HOME = %q, want %q (so ~/.local resolves to /data/.local)", homeEnv, "/data")
+	}
+}
+
 func TestBuildStatefulSet_TmpVolumeAndMount(t *testing.T) {
 	instance := newTestInstance("tmp-vol")
 	sts := BuildStatefulSet(instance, "", nil, nil, nil)

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1164,12 +1164,20 @@ pnpm --version`
 // access to "uv pip install" for Python packages and "uv tool install" for CLI
 // tools without any manual bootstrapping. The check is idempotent - subsequent
 // pod starts skip the copy if uv is already present.
+//
+// The data volume is mounted in full at /data (not via a SubPath) so this
+// container also seeds the .local, .cache, and skills subdirectories with the
+// pod UID as owner. kubelet would otherwise create missing SubPath directories
+// as root:root, which breaks on hostPath-backed PVCs where fsGroup ownership
+// is not applied (e.g. Rancher local-path-provisioner on Talos). Every
+// downstream container that mounts these paths via SubPath inherits the
+// correct ownership from the pre-created directory. See #448.
 func buildUvInitContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Container {
 	script := `set -e
-if [ -x /home/openclaw/.local/bin/uv ]; then echo "uv already installed"; exit 0; fi
-mkdir -p /home/openclaw/.local/bin
-cp /usr/local/bin/uv /home/openclaw/.local/bin/uv
-echo "uv $(/home/openclaw/.local/bin/uv --version) installed"`
+mkdir -p /data/.local/bin /data/.cache /data/skills
+if [ -x /data/.local/bin/uv ]; then echo "uv already installed"; exit 0; fi
+cp /usr/local/bin/uv /data/.local/bin/uv
+echo "uv $(/data/.local/bin/uv --version) installed"`
 
 	return corev1.Container{
 		Name:                     "init-uv",
@@ -1191,7 +1199,7 @@ echo "uv $(/home/openclaw/.local/bin/uv --version) installed"`
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{Name: "data", MountPath: "/home/openclaw/.local", SubPath: ".local"},
+			{Name: "data", MountPath: "/data"},
 		},
 	}
 }
@@ -1200,6 +1208,12 @@ echo "uv $(/home/openclaw/.local/bin/uv --version) installed"`
 // Uses the same image as the main container so pip targets the correct Python version.
 // Combined with PIP_USER=1 env var, "pip install <pkg>" writes to the writable
 // ~/.local/ PVC subpath. Runs on every pod start (fast, no network needed).
+//
+// HOME is set to /data (the full data volume mount) so ensurepip --user
+// resolves ~/.local to /data/.local. This avoids a SubPath mount that kubelet
+// would otherwise create as root:root on hostPath-backed PVCs where fsGroup
+// is not applied. The resulting files land in the same PVC location the main
+// container reads via its SubPath .local mount. See #448.
 func buildPipInitContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Container {
 	script := `python3 -m ensurepip --upgrade --user 2>/dev/null || echo "ensurepip unavailable, skipping"`
 
@@ -1212,7 +1226,7 @@ func buildPipInitContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.C
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		Resources:                corev1.ResourceRequirements{},
 		Env: []corev1.EnvVar{
-			{Name: "HOME", Value: "/home/openclaw"},
+			{Name: "HOME", Value: "/data"},
 		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: Ptr(false),
@@ -1226,7 +1240,7 @@ func buildPipInitContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.C
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{Name: "data", MountPath: "/home/openclaw/.local", SubPath: ".local"},
+			{Name: "data", MountPath: "/data"},
 			{Name: "tmp", MountPath: "/tmp"},
 		},
 	}

--- a/test/e2e/e2e_init_uv_hostpath_test.go
+++ b/test/e2e/e2e_init_uv_hostpath_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	"github.com/openclawrocks/openclaw-operator/internal/resources"
+)
+
+// This suite verifies the regression fix for #448: init-uv failing with
+// "mkdir: cannot create directory '/home/openclaw/.local/bin': Permission
+// denied" on hostPath-backed PVCs (e.g. Rancher local-path-provisioner on
+// Talos). kind itself uses a hostPath-backed local-path storage class, so a
+// persistent OpenClawInstance running on kind exercises the same code path.
+//
+// The fix mounts the full data volume in init-uv and init-pip (instead of
+// SubPath .local). That lets the non-root init container create .local,
+// .cache, and skills with UID 1000 ownership before any SubPath mount is
+// attempted. Without this, kubelet creates the missing SubPath directories
+// as root:root and fsGroup cannot chown hostPath volumes.
+var _ = Describe("Init containers on hostPath-backed PVCs (#448)", func() {
+	Context("When creating a persistent OpenClawInstance", func() {
+		var namespace string
+
+		BeforeEach(func() {
+			namespace = "test-init-hostpath-" + time.Now().Format("20060102150405")
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			_ = k8sClient.Delete(ctx, ns)
+		})
+
+		It("Should configure init-uv/init-pip to mount the full data volume (not SubPath .local)", func() {
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instanceName := "init-hostpath"
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Storage: openclawv1alpha1.StorageSpec{
+						Persistence: openclawv1alpha1.PersistenceSpec{
+							Size: "1Gi",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			sts := &appsv1.StatefulSet{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.StatefulSetName(instance),
+					Namespace: namespace,
+				}, sts)
+			}, 60*time.Second, 2*time.Second).Should(Succeed())
+
+			var initUv, initPip *corev1.Container
+			for i := range sts.Spec.Template.Spec.InitContainers {
+				c := &sts.Spec.Template.Spec.InitContainers[i]
+				switch c.Name {
+				case "init-uv":
+					initUv = c
+				case "init-pip":
+					initPip = c
+				}
+			}
+			Expect(initUv).NotTo(BeNil(), "init-uv container missing from StatefulSet")
+			Expect(initPip).NotTo(BeNil(), "init-pip container missing from StatefulSet")
+
+			// Neither init container may mount the data PVC via a SubPath.
+			// SubPath directories created by kubelet are root:root on
+			// hostPath-backed PVCs where fsGroup ownership is not applied,
+			// so a non-root init container could not write into them.
+			assertFullDataMount := func(c *corev1.Container) {
+				var found bool
+				for _, m := range c.VolumeMounts {
+					if m.Name != "data" {
+						continue
+					}
+					Expect(m.SubPath).To(BeEmpty(),
+						"%s: data mount must not use SubPath (got %q) - SubPath dirs are created root:root on hostPath PVCs",
+						c.Name, m.SubPath)
+					Expect(m.MountPath).To(Equal("/data"),
+						"%s: data mount path should be /data", c.Name)
+					found = true
+				}
+				Expect(found).To(BeTrue(), "%s: data volume mount not found", c.Name)
+			}
+			assertFullDataMount(initUv)
+			assertFullDataMount(initPip)
+
+			// init-uv must pre-create the SubPath dirs so later containers
+			// mounting .local, .cache, and skills via SubPath inherit the
+			// UID 1000 ownership from the pre-existing directory.
+			Expect(initUv.Command).To(HaveLen(3), "init-uv should use sh -c <script>")
+			script := initUv.Command[2]
+			for _, dir := range []string{"/data/.local/bin", "/data/.cache", "/data/skills"} {
+				Expect(strings.Contains(script, dir)).To(BeTrue(),
+					"init-uv script must pre-create %s with UID 1000 ownership, got:\n%s", dir, script)
+			}
+
+			// init-pip must set HOME=/data so ensurepip --user writes to
+			// /data/.local (the now-mounted path) instead of the old
+			// /home/openclaw/.local SubPath.
+			var homeVal string
+			for _, e := range initPip.Env {
+				if e.Name == "HOME" {
+					homeVal = e.Value
+				}
+			}
+			Expect(homeVal).To(Equal("/data"),
+				"init-pip HOME should be /data so ~/.local resolves to /data/.local")
+
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #448 - `init-uv` failing with `mkdir: cannot create directory '/home/openclaw/.local/bin': Permission denied` on hostPath-backed PVCs such as Rancher local-path-provisioner on Talos.

Kubernetes does not apply `fsGroup` ownership to `hostPath` volumes ([docs](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath)), so kubelet creates the missing `.local` SubPath directory as `root:root`, and the non-root (UID 1000) init container cannot `mkdir` into it.

## Change

Implements option (a) from the triage on #448: mount the full data volume in `init-uv` and `init-pip` (instead of a SubPath) so the non-root init container creates `.local`, `.cache`, and `skills` itself. The parent `/data` is world-writable (mode 0777 is the default for local-path-provisioner), so creating the subdirectories as UID 1000 succeeds, and every downstream container that mounts those paths via SubPath inherits the correct ownership from the pre-existing directory.

- `init-uv` now mounts `data` at `/data` and runs `mkdir -p /data/.local/bin /data/.cache /data/skills` before copying the uv binary.
- `init-pip` mounts `data` at `/data` and sets `HOME=/data` so `ensurepip --user` resolves `~/.local` to `/data/.local`, producing the same PVC layout the main container reads through its SubPath `.local` mount.

No CRD or user-facing API change; this is purely internal to how the operator constructs the StatefulSet.

## Test plan

- [x] Unit test: `TestBuildStatefulSet_InitUvPipMountFullDataVolume` asserts both init containers use a full `/data` mount (no SubPath), that `init-uv` pre-creates the three SubPath subdirectories, and that `init-pip` sets `HOME=/data`.
- [x] Existing `TestBuildStatefulSet_WritablePVCSubPaths` (main container SubPath mounts) still passes.
- [x] `go vet ./...` and `go build ./...` clean.
- [x] E2E test: `e2e_init_uv_hostpath_test.go` exercises the same assertions against a live StatefulSet on kind (whose default storage class is also hostPath-backed, so this is a real regression guard).
- [ ] Manual verification on Talos + local-path-provisioner (confirmed in #448 triage that the reporter hits this failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)