### PR TITLE
fix(statefulset): symlink plugin-runtime-deps/node_modules/openclaw to /app

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -495,7 +495,7 @@ spec:
 |------------------|-----------------|---------|--------------------------------------------------------------------------|
 | `initContainers` | `[]Container`   | --      | Additional init containers to run before the main container. They run after the operator-managed init containers. Max 10 items. |
 
-Standard Kubernetes `Container` spec. The following names are reserved by the operator and rejected by the webhook: `init-config`, `init-pnpm`, `init-python`, `init-skills`, `init-plugins`, `init-ollama`.
+Standard Kubernetes `Container` spec. The following names are reserved by the operator and rejected by the webhook: `init-config`, `init-pnpm`, `init-python`, `init-skills`, `init-plugins`, `init-ollama`, `init-plugin-runtime-deps`.
 
 ```yaml
 spec:

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -867,8 +867,8 @@ func TestBuildStatefulSet_ConfigVolume_RawConfig(t *testing.T) {
 
 	// Init container should copy config from ConfigMap to data volume
 	initContainers := sts.Spec.Template.Spec.InitContainers
-	if len(initContainers) != 3 {
-		t.Fatalf("expected 3 init containers (init-config + init-uv + init-pip), got %d", len(initContainers))
+	if len(initContainers) != 4 {
+		t.Fatalf("expected 4 init containers (init-config + init-uv + init-pip + init-plugin-runtime-deps), got %d", len(initContainers))
 	}
 	initC := initContainers[0]
 	if initC.Name != "init-config" {
@@ -912,8 +912,8 @@ func TestBuildStatefulSet_ConfigVolume_ConfigMapRef(t *testing.T) {
 	// The controller reads the external CM and writes enriched content into the
 	// operator-managed CM under "openclaw.json", so the init container always uses that key.
 	initContainers := sts.Spec.Template.Spec.InitContainers
-	if len(initContainers) != 3 {
-		t.Fatalf("expected 3 init containers (init-config + init-uv + init-pip), got %d", len(initContainers))
+	if len(initContainers) != 4 {
+		t.Fatalf("expected 4 init containers (init-config + init-uv + init-pip + init-plugin-runtime-deps), got %d", len(initContainers))
 	}
 	initC := initContainers[0]
 	assertVolumeMount(t, initC.VolumeMounts, "data", "/data")
@@ -947,8 +947,8 @@ func TestBuildStatefulSet_ConfigMapRef_DefaultKey(t *testing.T) {
 
 	// Init container should use "openclaw.json" (operator-managed key)
 	initContainers := sts.Spec.Template.Spec.InitContainers
-	if len(initContainers) != 3 {
-		t.Fatalf("expected 3 init containers (init-config + init-uv + init-pip), got %d", len(initContainers))
+	if len(initContainers) != 4 {
+		t.Fatalf("expected 4 init containers (init-config + init-uv + init-pip + init-plugin-runtime-deps), got %d", len(initContainers))
 	}
 	expectedPrefix := "cp /config/'openclaw.json' /data/openclaw.json"
 	if !strings.HasPrefix(initContainers[0].Command[2], expectedPrefix) {
@@ -971,9 +971,9 @@ func TestBuildStatefulSet_VanillaDeployment_HasInitContainer(t *testing.T) {
 
 	sts := BuildStatefulSet(instance, "", nil, nil, nil)
 
-	// Vanilla deployments get init-config + init-uv + init-pip
-	if len(sts.Spec.Template.Spec.InitContainers) != 3 {
-		t.Fatalf("expected 3 init containers for vanilla deployment, got %d", len(sts.Spec.Template.Spec.InitContainers))
+	// Vanilla deployments get init-config + init-uv + init-pip + init-plugin-runtime-deps
+	if len(sts.Spec.Template.Spec.InitContainers) != 4 {
+		t.Fatalf("expected 4 init containers for vanilla deployment, got %d", len(sts.Spec.Template.Spec.InitContainers))
 	}
 	if sts.Spec.Template.Spec.InitContainers[0].Name != "init-config" {
 		t.Errorf("init container name = %q, want %q", sts.Spec.Template.Spec.InitContainers[0].Name, "init-config")
@@ -5147,6 +5147,66 @@ func TestBuildStatefulSet_InitUvPipMountFullDataVolume(t *testing.T) {
 	}
 }
 
+// TestBuildStatefulSet_PluginRuntimeDepsSymlink verifies that every StatefulSet
+// includes the init-plugin-runtime-deps container, which points the bundled-plugin
+// openclaw import at the current container image. Without this symlink, bundled
+// plugins (e.g. discord) crash loop after an image upgrade because they resolve
+// "openclaw" against the stale npm-cached package on the PVC.
+// See https://github.com/openclaw-rocks/openclaw-operator/issues/462.
+func TestBuildStatefulSet_PluginRuntimeDepsSymlink(t *testing.T) {
+	instance := newTestInstance("plugin-runtime-deps")
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+
+	var c *corev1.Container
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == "init-plugin-runtime-deps" {
+			c = &sts.Spec.Template.Spec.InitContainers[i]
+			break
+		}
+	}
+	if c == nil {
+		t.Fatal("init-plugin-runtime-deps container not found")
+	}
+
+	// Must use the OpenClaw image so /app resolves correctly in the main container
+	// (the symlink target is evaluated at access time in whatever container dereferences it).
+	if c.Image != GetImage(instance) {
+		t.Errorf("init-plugin-runtime-deps image = %q, want %q", c.Image, GetImage(instance))
+	}
+
+	// Must mount data at /data in full (not via SubPath). The symlink must land at
+	// /data/plugin-runtime-deps/node_modules/openclaw so that, in the main
+	// container (data mounted at /home/openclaw/.openclaw), Node's ESM resolver
+	// finds ~/.openclaw/plugin-runtime-deps/node_modules/openclaw.
+	assertVolumeMount(t, c.VolumeMounts, "data", "/data")
+	for _, m := range c.VolumeMounts {
+		if m.Name == "data" && m.SubPath != "" {
+			t.Errorf("init-plugin-runtime-deps data mount must not use SubPath, got %q", m.SubPath)
+		}
+	}
+
+	// Script must be idempotent (mkdir -p + ln -sfn) so re-running on every pod
+	// start is safe, and must create the version-agnostic symlink.
+	if len(c.Command) != 3 {
+		t.Fatalf("init-plugin-runtime-deps command = %v, want [sh -c <script>]", c.Command)
+	}
+	script := c.Command[2]
+	if !strings.Contains(script, "mkdir -p /data/plugin-runtime-deps/node_modules") {
+		t.Errorf("script must create plugin-runtime-deps/node_modules, got:\n%s", script)
+	}
+	if !strings.Contains(script, "ln -sfn /app /data/plugin-runtime-deps/node_modules/openclaw") {
+		t.Errorf("script must symlink openclaw -> /app, got:\n%s", script)
+	}
+
+	// Security context should match the other read-only init containers.
+	if c.SecurityContext == nil {
+		t.Fatal("init-plugin-runtime-deps security context is nil")
+	}
+	if c.SecurityContext.ReadOnlyRootFilesystem == nil || !*c.SecurityContext.ReadOnlyRootFilesystem {
+		t.Error("init-plugin-runtime-deps should have ReadOnlyRootFilesystem=true")
+	}
+}
+
 func TestBuildStatefulSet_TmpVolumeAndMount(t *testing.T) {
 	instance := newTestInstance("tmp-vol")
 	sts := BuildStatefulSet(instance, "", nil, nil, nil)
@@ -7050,8 +7110,8 @@ func TestBuildStatefulSet_CustomInitContainers_AfterOperatorManaged(t *testing.T
 	sts := BuildStatefulSet(instance, "", nil, nil, nil)
 	initContainers := sts.Spec.Template.Spec.InitContainers
 
-	if len(initContainers) != 5 {
-		t.Fatalf("expected 5 init containers, got %d", len(initContainers))
+	if len(initContainers) != 6 {
+		t.Fatalf("expected 6 init containers, got %d", len(initContainers))
 	}
 	if initContainers[0].Name != "init-config" {
 		t.Errorf("initContainers[0] = %q, want init-config", initContainers[0].Name)
@@ -7062,11 +7122,14 @@ func TestBuildStatefulSet_CustomInitContainers_AfterOperatorManaged(t *testing.T
 	if initContainers[2].Name != "init-pip" {
 		t.Errorf("initContainers[2] = %q, want init-pip", initContainers[2].Name)
 	}
-	if initContainers[3].Name != "init-skills" {
-		t.Errorf("initContainers[3] = %q, want init-skills", initContainers[3].Name)
+	if initContainers[3].Name != "init-plugin-runtime-deps" {
+		t.Errorf("initContainers[3] = %q, want init-plugin-runtime-deps", initContainers[3].Name)
 	}
-	if initContainers[4].Name != "user-init" {
-		t.Errorf("initContainers[4] = %q, want user-init", initContainers[4].Name)
+	if initContainers[4].Name != "init-skills" {
+		t.Errorf("initContainers[4] = %q, want init-skills", initContainers[4].Name)
+	}
+	if initContainers[5].Name != "user-init" {
+		t.Errorf("initContainers[5] = %q, want user-init", initContainers[5].Name)
 	}
 }
 
@@ -7410,7 +7473,7 @@ func TestBuildStatefulSet_RuntimeDeps_InitContainerOrder(t *testing.T) {
 	sts := BuildStatefulSet(instance, "", nil, nil, nil)
 	initContainers := sts.Spec.Template.Spec.InitContainers
 
-	expected := []string{"init-config", "init-uv", "init-pip", "init-pnpm", "init-python", "init-skills", "user-init"}
+	expected := []string{"init-config", "init-uv", "init-pip", "init-plugin-runtime-deps", "init-pnpm", "init-python", "init-skills", "user-init"}
 	if len(initContainers) != len(expected) {
 		t.Fatalf("expected %d init containers, got %d: %v", len(expected), len(initContainers),
 			func() []string {

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -611,7 +611,14 @@ func buildInitContainers(instance *openclawv1alpha1.OpenClawInstance, externalWo
 	// - init-uv: copies uv binary so agents can "uv tool install" CLI tools
 	// - init-pip: bootstraps pip via ensurepip so agents can "pip install <pkg>"
 	//   (PIP_USER=1 makes pip write to the writable ~/.local/ PVC subpath)
-	initContainers = append(initContainers, buildUvInitContainer(instance), buildPipInitContainer(instance))
+	// - init-plugin-runtime-deps: points bundled-plugin imports of "openclaw"
+	//   at the current container image so version upgrades don't crash loop (#462).
+	initContainers = append(
+		initContainers,
+		buildUvInitContainer(instance),
+		buildPipInitContainer(instance),
+		buildPluginRuntimeDepsInitContainer(instance),
+	)
 
 	// Runtime dependency init containers (run before skills so skills can use pnpm/python)
 	if instance.Spec.RuntimeDeps.Pnpm {
@@ -1247,6 +1254,55 @@ func buildPipInitContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.C
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "data", MountPath: "/data"},
 			{Name: "tmp", MountPath: "/tmp"},
+		},
+	}
+}
+
+// buildPluginRuntimeDepsInitContainer creates an init container that points the
+// bundled-plugin runtime-dep lookup path at the current container image.
+//
+// OpenClaw ships bundled plugin extensions under
+// ~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/dist/extensions/.
+// These extensions import "openclaw/..." as bare ESM specifiers. Node's
+// resolver walks up the tree looking for `openclaw` in node_modules. Without
+// this symlink, the resolver either finds nothing or falls back to a stale
+// npm-cached package from an earlier image version on the PVC, causing
+// crash loops like "Cannot find package 'openclaw'" or "Package subpath
+// '...' is not defined by exports" after an image upgrade (#462).
+//
+// The symlink ~/.openclaw/plugin-runtime-deps/node_modules/openclaw -> /app
+// is version-agnostic: Node's resolver finds it from any
+// openclaw-<version>-<hash>/ subdirectory, and the target always resolves
+// against /app in the main container (the current image's openclaw package).
+//
+// ln -sfn is idempotent, so re-running on every pod start is safe. Using
+// HOME=/data is unnecessary -- this container only writes under /data.
+func buildPluginRuntimeDepsInitContainer(instance *openclawv1alpha1.OpenClawInstance) corev1.Container {
+	script := `set -e
+mkdir -p /data/plugin-runtime-deps/node_modules
+ln -sfn /app /data/plugin-runtime-deps/node_modules/openclaw`
+
+	return corev1.Container{
+		Name:                     "init-plugin-runtime-deps",
+		Image:                    GetImage(instance),
+		Command:                  []string{"sh", "-c", script},
+		ImagePullPolicy:          getPullPolicy(instance),
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+		Resources:                corev1.ResourceRequirements{},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: Ptr(false),
+			ReadOnlyRootFilesystem:   Ptr(true),
+			RunAsNonRoot:             Ptr(podRunAsNonRoot(instance)),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "data", MountPath: "/data"},
 		},
 	}
 }

--- a/internal/webhook/openclawinstance_webhook.go
+++ b/internal/webhook/openclawinstance_webhook.go
@@ -554,12 +554,13 @@ func validateConfigSchema(instance *openclawv1alpha1.OpenClawInstance) admission
 
 // reservedInitContainerNames are names used by operator-managed init containers.
 var reservedInitContainerNames = map[string]bool{
-	"init-config":  true,
-	"init-pnpm":    true,
-	"init-python":  true,
-	"init-skills":  true,
-	"init-plugins": true,
-	"init-ollama":  true,
+	"init-config":              true,
+	"init-pnpm":                true,
+	"init-python":              true,
+	"init-skills":              true,
+	"init-plugins":             true,
+	"init-ollama":              true,
+	"init-plugin-runtime-deps": true,
 }
 
 // validateInitContainers checks custom init container names.

--- a/test/e2e/e2e_plugin_runtime_deps_test.go
+++ b/test/e2e/e2e_plugin_runtime_deps_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	"github.com/openclawrocks/openclaw-operator/internal/resources"
+)
+
+// This suite verifies the regression fix for #462: bundled plugin extensions
+// (confirmed: discord) crash loop after an OpenClaw image upgrade because they
+// import "openclaw/..." as bare ESM specifiers and the Node resolver either
+// finds nothing or finds a stale npm-cached package from the previous image.
+//
+// The fix adds an init-plugin-runtime-deps container that creates the symlink
+// ~/.openclaw/plugin-runtime-deps/node_modules/openclaw -> /app on every pod
+// start, so bundled plugins always resolve against the current image.
+var _ = Describe("init-plugin-runtime-deps symlink (#462)", func() {
+	Context("When creating any OpenClawInstance", func() {
+		var namespace string
+
+		BeforeEach(func() {
+			namespace = "test-plugin-runtime-deps-" + time.Now().Format("20060102150405")
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			_ = k8sClient.Delete(ctx, ns)
+		})
+
+		It("Should include an init-plugin-runtime-deps container that points openclaw at /app", func() {
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "plugin-runtime-deps",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Storage: openclawv1alpha1.StorageSpec{
+						Persistence: openclawv1alpha1.PersistenceSpec{
+							Size: "1Gi",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			sts := &appsv1.StatefulSet{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.StatefulSetName(instance),
+					Namespace: namespace,
+				}, sts)
+			}, 60*time.Second, 2*time.Second).Should(Succeed())
+
+			var c *corev1.Container
+			for i := range sts.Spec.Template.Spec.InitContainers {
+				if sts.Spec.Template.Spec.InitContainers[i].Name == "init-plugin-runtime-deps" {
+					c = &sts.Spec.Template.Spec.InitContainers[i]
+					break
+				}
+			}
+			Expect(c).NotTo(BeNil(), "init-plugin-runtime-deps container missing from StatefulSet")
+
+			// Must mount data at /data with no SubPath, so the symlink is written
+			// into the PVC root (visible in the main container under ~/.openclaw).
+			var found bool
+			for _, m := range c.VolumeMounts {
+				if m.Name != "data" {
+					continue
+				}
+				Expect(m.SubPath).To(BeEmpty(),
+					"init-plugin-runtime-deps data mount must not use SubPath (got %q)", m.SubPath)
+				Expect(m.MountPath).To(Equal("/data"))
+				found = true
+			}
+			Expect(found).To(BeTrue(), "init-plugin-runtime-deps: data volume mount not found")
+
+			// Script must create the version-agnostic symlink, idempotently.
+			Expect(c.Command).To(HaveLen(3), "init-plugin-runtime-deps should use sh -c <script>")
+			script := c.Command[2]
+			Expect(strings.Contains(script, "mkdir -p /data/plugin-runtime-deps/node_modules")).To(BeTrue(),
+				"script must create plugin-runtime-deps/node_modules, got:\n%s", script)
+			Expect(strings.Contains(script, "ln -sfn /app /data/plugin-runtime-deps/node_modules/openclaw")).To(BeTrue(),
+				"script must symlink openclaw -> /app, got:\n%s", script)
+
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #462.

Bundled OpenClaw plugin extensions (e.g. `discord`) under `~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/dist/extensions/` import `openclaw/...` as bare ESM specifiers. Node's resolver walks up looking for `openclaw` in `node_modules`.

After an image upgrade (e.g. `2026.4.11` → `2026.4.22`) the operator refreshes `/app` and the binary symlink, but the npm-cached `openclaw` package on the PVC (under `/home/openclaw/.local/lib/node_modules/`) stays on the previous version. The resolver either finds nothing or falls back to the stale package, producing `Cannot find package 'openclaw'` or `Package subpath '...' is not defined by exports` crash loops in every bundled plugin.

This PR adds an always-running init container, `init-plugin-runtime-deps`, which creates the version-agnostic symlink

```
~/.openclaw/plugin-runtime-deps/node_modules/openclaw -> /app
```

on every pod start. Node's bare-specifier resolver finds it from any `openclaw-<version>-<hash>/` subdirectory, and the target always resolves against the current image's openclaw package — so bundled plugins are immune to stale PVC-cached versions after an upgrade.

- New init container: small, read-only root, `data` PVC mounted at `/data`, script is `mkdir -p /data/plugin-runtime-deps/node_modules && ln -sfn /app /data/plugin-runtime-deps/node_modules/openclaw` (idempotent).
- Reserved in the webhook so users can't collide via `spec.initContainers`.
- Unit test asserts the container's image, mounts, security context, and script contents.
- E2E test verifies the StatefulSet contains the container with the correct mount and command.

The workaround described in the issue (creating the symlink manually) is now applied automatically by the operator.

## Test plan

- [x] `go test ./internal/resources/`
- [x] `go test ./internal/webhook/`
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] CI: lint + unit + e2e on kind
- [ ] Manual: deploy, upgrade image version across a breaking npm cache, confirm discord provider no longer crash loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)