### PR TITLE
fix(plugins): install plugins under ~/.openclaw/extensions for auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ The operator resolves packs via the GitHub Contents + Git Trees APIs (cached for
 
 ### Plugin installation
 
-Install plugins declaratively. The operator runs a dedicated init container that installs each plugin via `npm install` before the agent starts:
+Install plugins declaratively. The operator runs a dedicated init container that installs each plugin into `~/.openclaw/extensions/<name>/` before the agent starts, where `<name>` is the unscoped npm package basename (so `@openclaw/brave-plugin` becomes `~/.openclaw/extensions/brave-plugin/`):
 
 ```yaml
 spec:
@@ -529,7 +529,11 @@ spec:
     - "some-other-plugin"
 ```
 
-npm lifecycle scripts are disabled globally on the init container (`NPM_CONFIG_IGNORE_SCRIPTS=true`) to mitigate supply chain attacks. Plugins are installed into the PVC-backed `~/.openclaw/node_modules` directory and persist across pod restarts.
+This is the layout the OpenClaw gateway's plugin discovery expects - it scans direct subdirectories of `~/.openclaw/extensions/` for plugin manifests and skips `node_modules/` entirely. Each install is staged via `npm pack`, populated with its runtime dependencies via `npm install --omit=dev`, and atomically renamed into place so a partial install is never visible to the gateway.
+
+npm lifecycle scripts are disabled globally on the init container (`NPM_CONFIG_IGNORE_SCRIPTS=true`) to mitigate supply chain attacks. The PVC backs `~/.openclaw/`, so installs persist across pod restarts.
+
+> If you previously worked around the install-path bug by adding `plugins.load.paths` entries to your gateway config (pointing at `~/.openclaw/node_modules/<pkg>`), that workaround is no longer needed and can be removed - plugins now land in the documented location and are auto-discovered.
 
 ### Workspace seeding
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -232,7 +232,11 @@ spec:
     - "some-other-plugin"
 ```
 
-Plugins are installed via `npm install` in a dedicated `init-plugins` init container. They are stored in the PVC-backed `~/.openclaw/node_modules` directory and persist across pod restarts.
+Plugins are installed in a dedicated `init-plugins` init container into `~/.openclaw/extensions/<name>/`, where `<name>` is the unscoped npm package basename (so `@openclaw/brave-plugin` becomes `~/.openclaw/extensions/brave-plugin/`). This is the layout the OpenClaw gateway's plugin discovery walks - subdirectories of `~/.openclaw/extensions/` containing a `package.json`, bundle manifest, or default entry file are auto-loaded, while `node_modules/` is explicitly skipped by the loader.
+
+The init container stages each install via `npm pack` into a tmp dir, runs `npm install --omit=dev` in the extracted package to populate per-plugin runtime deps, and then atomically renames the result into place so a partial/failed install is never visible to the gateway. The PVC backs `~/.openclaw/`, so installs persist across pod restarts.
+
+> Migrating from earlier operator versions (<= 0.31.0): plugins were installed under `~/.openclaw/node_modules/<pkg>/` and were not auto-discovered. Users typically worked around this by adding `plugins.load.paths` entries to their gateway config pointing at the node_modules path. Once upgraded, that workaround can be removed - plugins land in the documented `~/.openclaw/extensions/<name>/` location and the gateway picks them up automatically. The stale node_modules entries are left in place to avoid disturbing other PVC state and are harmless.
 
 ### spec.envFrom
 

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -6036,7 +6036,7 @@ func TestBuildStatefulSet_SkillsOnly_HasBothInitContainers(t *testing.T) {
 
 func TestParsePluginEntry_Basic(t *testing.T) {
 	got := parsePluginEntry("@martian-engineering/lossless-claw")
-	want := "cd /home/openclaw/.openclaw && npm install '@martian-engineering/lossless-claw'"
+	want := "_install_plugin '@martian-engineering/lossless-claw' 'lossless-claw'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -6044,7 +6044,7 @@ func TestParsePluginEntry_Basic(t *testing.T) {
 
 func TestParsePluginEntry_WithNpmPrefix(t *testing.T) {
 	got := parsePluginEntry("npm:@openclaw/some-plugin")
-	want := "cd /home/openclaw/.openclaw && npm install '@openclaw/some-plugin'"
+	want := "_install_plugin '@openclaw/some-plugin' 'some-plugin'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -6052,9 +6052,42 @@ func TestParsePluginEntry_WithNpmPrefix(t *testing.T) {
 
 func TestParsePluginEntry_Unscoped(t *testing.T) {
 	got := parsePluginEntry("some-plugin")
-	want := "cd /home/openclaw/.openclaw && npm install 'some-plugin'"
+	want := "_install_plugin 'some-plugin' 'some-plugin'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParsePluginEntry_Versioned(t *testing.T) {
+	cases := []struct {
+		entry, want string
+	}{
+		{"brave-plugin@1.2.3", "_install_plugin 'brave-plugin@1.2.3' 'brave-plugin'"},
+		{"@openclaw/brave-plugin@1.2.3", "_install_plugin '@openclaw/brave-plugin@1.2.3' 'brave-plugin'"},
+		{"npm:@openclaw/brave-plugin@1.2.3", "_install_plugin '@openclaw/brave-plugin@1.2.3' 'brave-plugin'"},
+	}
+	for _, c := range cases {
+		if got := parsePluginEntry(c.entry); got != c.want {
+			t.Errorf("parsePluginEntry(%q) = %q, want %q", c.entry, got, c.want)
+		}
+	}
+}
+
+func TestPluginDirName(t *testing.T) {
+	cases := []struct {
+		spec, want string
+	}{
+		{"brave-plugin", "brave-plugin"},
+		{"@openclaw/brave-plugin", "brave-plugin"},
+		{"brave-plugin@1.2.3", "brave-plugin"},
+		{"@openclaw/brave-plugin@1.2.3", "brave-plugin"},
+		{"npm:@openclaw/brave-plugin@1.2.3", "brave-plugin"},
+		{"@martian-engineering/lossless-claw", "lossless-claw"},
+	}
+	for _, c := range cases {
+		if got := pluginDirName(c.spec); got != c.want {
+			t.Errorf("pluginDirName(%q) = %q, want %q", c.spec, got, c.want)
+		}
 	}
 }
 
@@ -6075,11 +6108,42 @@ func TestBuildPluginsScript_WithPlugins(t *testing.T) {
 	if !strings.HasPrefix(script, "set -e\n") {
 		t.Error("script should start with set -e")
 	}
-	if !strings.Contains(script, "npm install '@martian-engineering/lossless-claw'") {
-		t.Error("script should contain npm install for lossless-claw")
+	// Issue #474: plugins must be installed under ~/.openclaw/extensions/, not node_modules
+	if !strings.Contains(script, "mkdir -p /home/openclaw/.openclaw/extensions") {
+		t.Error("script should ensure ~/.openclaw/extensions exists")
 	}
-	if !strings.Contains(script, "npm install 'another-plugin'") {
-		t.Error("script should contain npm install for another-plugin")
+	if !strings.Contains(script, "_install_plugin() (") {
+		t.Error("script should define the _install_plugin helper")
+	}
+	if !strings.Contains(script, "_install_plugin '@martian-engineering/lossless-claw' 'lossless-claw'") {
+		t.Error("script should call _install_plugin for lossless-claw with the unscoped dir name")
+	}
+	if !strings.Contains(script, "_install_plugin 'another-plugin' 'another-plugin'") {
+		t.Error("script should call _install_plugin for another-plugin")
+	}
+	// Regression guard: don't emit the old broken layout
+	if strings.Contains(script, "cd /home/openclaw/.openclaw && npm install") {
+		t.Error("script must not install plugins into ~/.openclaw/node_modules (issue #474)")
+	}
+}
+
+func TestBuildPluginsScript_StagesViaNpmPack(t *testing.T) {
+	instance := newTestInstance("stage-plugins")
+	instance.Spec.Plugins = []string{"some-plugin"}
+
+	script := BuildPluginsScript(instance)
+
+	// Helper must use npm pack + atomic rename to avoid leaving partial state
+	// visible to the gateway's plugin discovery.
+	for _, want := range []string{
+		`npm pack "$spec"`,
+		`tar -xzf "$tarball"`,
+		`npm install --omit=dev`,
+		`mv "$dest.tmp" "$dest"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("install helper missing %q\nfull script:\n%s", want, script)
+		}
 	}
 }
 
@@ -6088,17 +6152,22 @@ func TestBuildPluginsScript_Deterministic(t *testing.T) {
 	instance.Spec.Plugins = []string{"z-plugin", "a-plugin"}
 
 	script := BuildPluginsScript(instance)
-	lines := strings.Split(script, "\n")
 
-	// After "set -e", entries should be sorted alphabetically
-	if len(lines) != 3 {
-		t.Fatalf("expected 3 lines, got %d: %v", len(lines), lines)
+	// Find the lines that invoke the install helper for our plugins.
+	var pluginCalls []string
+	for _, line := range strings.Split(script, "\n") {
+		if strings.HasPrefix(line, "_install_plugin '") {
+			pluginCalls = append(pluginCalls, line)
+		}
 	}
-	if !strings.Contains(lines[1], "a-plugin") {
-		t.Errorf("expected a-plugin first, got %q", lines[1])
+	if len(pluginCalls) != 2 {
+		t.Fatalf("expected 2 _install_plugin calls, got %d: %v", len(pluginCalls), pluginCalls)
 	}
-	if !strings.Contains(lines[2], "z-plugin") {
-		t.Errorf("expected z-plugin second, got %q", lines[2])
+	if !strings.Contains(pluginCalls[0], "'a-plugin'") {
+		t.Errorf("expected a-plugin first, got %q", pluginCalls[0])
+	}
+	if !strings.Contains(pluginCalls[1], "'z-plugin'") {
+		t.Errorf("expected z-plugin second, got %q", pluginCalls[1])
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1014,19 +1014,90 @@ func buildSkillsInitContainer(instance *openclawv1alpha1.OpenClawInstance) *core
 	}
 }
 
-// parsePluginEntry returns the shell command to install a single plugin entry.
-// Entries are npm package names. An optional "npm:" prefix is stripped.
-// Installs into the PVC-backed ~/.openclaw/ node_modules via `npm install`.
+// pluginInstallHelper is a POSIX-sh function that installs an npm-published
+// OpenClaw plugin into ~/.openclaw/extensions/<name>/.
+//
+// The OpenClaw gateway discovers plugins as direct subdirectories of
+// ~/.openclaw/extensions (see openclaw/openclaw src/plugins/discovery.ts:
+// node_modules is in SCANNED_DIRECTORY_IGNORE_NAMES, and the loader only scans
+// one level deep). So `npm install <pkg>` from ~/.openclaw — which places the
+// package under ~/.openclaw/node_modules/<pkg> — was never auto-discovered.
+//
+// The helper:
+//  1. Stages an `npm pack <spec>` to a tmp dir (extracts the published package).
+//  2. Runs `npm install --omit=dev` inside the extracted dir to populate its
+//     own node_modules with runtime deps. Per-plugin isolation; deps are
+//     resolved by Node from each plugin's local node_modules without needing
+//     NODE_PATH.
+//  3. Atomically replaces ~/.openclaw/extensions/<dir_name>/ via rename of a
+//     staged sibling, so a partial/failed install is never visible to the
+//     gateway.
+//
+// Lifecycle scripts are disabled globally for this container via
+// NPM_CONFIG_IGNORE_SCRIPTS=true (set on the container env, not here).
+const pluginInstallHelper = `_install_plugin() (
+  set -e
+  spec="$1"
+  dir_name="$2"
+  dest="/home/openclaw/.openclaw/extensions/$dir_name"
+
+  stage=$(mktemp -d)
+  trap 'rm -rf "$stage"' EXIT INT TERM
+
+  cd "$stage"
+  tarball=$(npm pack "$spec" --silent | tail -n 1)
+  mkdir extracted
+  tar -xzf "$tarball" -C extracted --strip-components=1
+  ( cd extracted && npm install --omit=dev --no-audit --no-fund --loglevel=error )
+
+  mkdir -p "$(dirname "$dest")"
+  rm -rf "$dest" "$dest.tmp"
+  mv "$stage/extracted" "$dest.tmp"
+  mv "$dest.tmp" "$dest"
+)`
+
+// pluginDirName derives the on-disk directory name for an npm package spec.
+// The OpenClaw plugin loader uses the package's package.json `name` (with
+// scope stripped) as the canonical id, so the directory name should match the
+// unscoped package name to keep IDs stable.
+//
+// Examples:
+//
+//	"brave-plugin"                     -> "brave-plugin"
+//	"@openclaw/brave-plugin"           -> "brave-plugin"
+//	"brave-plugin@1.2.3"               -> "brave-plugin"
+//	"@openclaw/brave-plugin@1.2.3"     -> "brave-plugin"
+//	"npm:@openclaw/brave-plugin@1.2.3" -> "brave-plugin"
+func pluginDirName(spec string) string {
+	if after, ok := strings.CutPrefix(spec, "npm:"); ok {
+		spec = after
+	}
+	// Strip a trailing version selector. The leading "@" of a scope is at
+	// index 0, so look for "@" only after the first character.
+	if idx := strings.LastIndex(spec, "@"); idx > 0 {
+		spec = spec[:idx]
+	}
+	if strings.HasPrefix(spec, "@") {
+		if slash := strings.Index(spec, "/"); slash != -1 {
+			spec = spec[slash+1:]
+		}
+	}
+	return spec
+}
+
+// parsePluginEntry returns the shell command(s) to install a single plugin
+// entry. Entries are npm package specs. An optional "npm:" prefix is stripped.
+// Installs into the PVC-backed ~/.openclaw/extensions/<name>/ directory, which
+// is the layout the OpenClaw gateway's plugin discovery expects (#474).
 func parsePluginEntry(entry string) string {
 	pkg := entry
 	if after, ok := strings.CutPrefix(entry, "npm:"); ok {
 		pkg = after
 	}
-	return fmt.Sprintf("cd /home/openclaw/.openclaw && npm install %s", shellQuote(pkg))
+	return fmt.Sprintf("_install_plugin %s %s", shellQuote(pkg), shellQuote(pluginDirName(entry)))
 }
 
 // BuildPluginsScript generates the shell script for the plugins init container.
-// Each entry produces an `npm install` command.
 // Entries are sorted for determinism. Returns "" if no plugins are defined.
 func BuildPluginsScript(instance *openclawv1alpha1.OpenClawInstance) string {
 	plugins := instance.Spec.Plugins
@@ -1038,8 +1109,11 @@ func BuildPluginsScript(instance *openclawv1alpha1.OpenClawInstance) string {
 	copy(sorted, plugins)
 	sort.Strings(sorted)
 
-	var lines []string
-	lines = append(lines, "set -e")
+	lines := []string{
+		"set -e",
+		"mkdir -p /home/openclaw/.openclaw/extensions",
+		pluginInstallHelper,
+	}
 	for _, plugin := range sorted {
 		lines = append(lines, parsePluginEntry(plugin))
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -2024,10 +2024,17 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			}
 			Expect(pluginsContainer).NotTo(BeNil(), "init-plugins container should exist")
 
-			// Script should contain npm install for plugin
+			// Script must install via _install_plugin into ~/.openclaw/extensions/
+			// (issue #474 - the previous `cd ~/.openclaw && npm install` layout
+			// landed plugins in node_modules/, which the gateway loader
+			// explicitly skips).
 			script := pluginsContainer.Command[2]
-			Expect(script).To(ContainSubstring("npm install '@martian-engineering/lossless-claw'"),
-				"plugin should use npm install")
+			Expect(script).To(ContainSubstring("mkdir -p /home/openclaw/.openclaw/extensions"),
+				"init-plugins must ensure the extensions directory exists")
+			Expect(script).To(ContainSubstring("_install_plugin '@martian-engineering/lossless-claw' 'lossless-claw'"),
+				"plugin should be installed via _install_plugin into the unscoped extensions/<name> dir")
+			Expect(script).NotTo(ContainSubstring("cd /home/openclaw/.openclaw && npm install"),
+				"plugins must not be installed into ~/.openclaw/node_modules (issue #474)")
 
 			// NPM_CONFIG_IGNORE_SCRIPTS should be set
 			envMap := map[string]string{}


### PR DESCRIPTION
## Summary

Fixes #474. The init-plugins container was installing OpenClaw plugins into `~/.openclaw/node_modules/<pkg>/`, where the gateway's plugin loader cannot find them. This rewrites the install layout to match what the loader actually scans: `~/.openclaw/extensions/<unscoped-name>/`.

## Background — what the gateway loader expects

From upstream `openclaw/openclaw` `src/plugins/discovery.ts`:

- The global plugin root is `~/.openclaw/extensions/` (`src/plugins/roots.ts:23`).
- `discoverInDirectory` reads that directory **non-recursively** and treats each direct subdirectory as a plugin candidate if it has a `package.json` with extension entries, a bundle manifest, or a recognized index file.
- `node_modules` is in `SCANNED_DIRECTORY_IGNORE_NAMES` (`discovery.ts:52`), so anything under `extensions/node_modules/` is **explicitly skipped**.

So the operator's previous `cd ~/.openclaw && npm install <pkg>` (which lands packages under `~/.openclaw/node_modules/<pkg>/`) was outside the loader's scan path entirely. Users worked around it by injecting `plugins.load.paths` entries into their gateway config.

## Implementation

Each plugin entry is installed by a new POSIX-sh `_install_plugin` helper that:

1. Stages an `npm pack <spec>` to a tmp dir, extracts it.
2. Runs `npm install --omit=dev` inside the extracted package to populate the plugin's own `node_modules/`. Per-plugin isolation; deps resolve from each plugin's local `node_modules` without needing `NODE_PATH`.
3. Atomically renames the staged result to `~/.openclaw/extensions/<dir-name>/` so a partial/failed install is never visible to the gateway.

Directory naming strips the npm scope and version selector to match the canonical plugin id:

| Spec | Installed at |
|---|---|
| `brave-plugin` | `~/.openclaw/extensions/brave-plugin/` |
| `@openclaw/brave-plugin` | `~/.openclaw/extensions/brave-plugin/` |
| `brave-plugin@1.2.3` | `~/.openclaw/extensions/brave-plugin/` |
| `npm:@openclaw/brave-plugin@1.2.3` | `~/.openclaw/extensions/brave-plugin/` |

`NPM_CONFIG_IGNORE_SCRIPTS=true` remains set on the init container, so lifecycle scripts are still disabled for supply-chain safety.

## Test plan
- [x] Builder unit tests in `internal/resources/resources_test.go`:
  - `TestPluginDirName` covers all spec variants (scoped, versioned, npm: prefix).
  - `TestParsePluginEntry_*` cover the per-entry shell line.
  - `TestBuildPluginsScript_WithPlugins` asserts the new layout (`mkdir -p ~/.openclaw/extensions`, `_install_plugin` helper, no `cd ~/.openclaw && npm install`).
  - `TestBuildPluginsScript_StagesViaNpmPack` verifies the helper uses `npm pack` + `tar -xzf` + `npm install --omit=dev` + atomic rename.
  - Existing tests for env propagation, init container ordering, CA bundle, plugins-tmp volume, config-hash continue to pass.
- [x] E2E test `Should produce an init-plugins container with npm install for plugins` updated to assert the new install layout and to reject the old broken layout.
- [x] `go test ./internal/resources/` passes.
- [x] `make lint` passes.

## Migration

Existing users who added the workaround:
```yaml
plugins:
  load:
    paths:
      - '~/.openclaw/node_modules/@openclaw/brave-plugin'
```
can remove it after upgrading. The plugin will be at `~/.openclaw/extensions/brave-plugin/` and auto-discovered by the gateway. Stale entries under `~/.openclaw/node_modules/` are not cleaned up (could be relied upon by `npm:`-prefixed skills) and are harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)