### PR TITLE
feat(chart): aggregate OpenClaw CRD permissions into admin/edit/view roles

### DIFF
--- a/charts/openclaw-operator/templates/rbac-aggregated.yaml
+++ b/charts/openclaw-operator/templates/rbac-aggregated.yaml
@@ -1,0 +1,56 @@
+{{- /*
+Aggregated ClusterRoles that extend the built-in Kubernetes admin/edit/view
+ClusterRoles with permissions for OpenClaw CRDs. Without these, a user
+bound to the standard `admin` ClusterRole in a namespace cannot manage
+OpenClawInstance / OpenClawSelfConfig resources in that namespace
+(see issue #479).
+
+Only namespaced CRDs are aggregated here. OpenClawClusterDefaults is
+cluster-scoped and is intentionally not added to namespace-level roles;
+cluster-admins already have access via cluster-admin / system:masters.
+*/ -}}
+{{- if and .Values.rbac.create .Values.rbac.aggregateToDefaultRoles -}}
+{{- $fullname := include "openclaw-operator.fullname" . -}}
+{{- $labels := include "openclaw-operator.labels" . -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullname }}-aggregate-to-admin
+  labels:
+    {{- $labels | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["openclaw.rocks"]
+    resources:
+      - openclawinstances
+      - openclawselfconfigs
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullname }}-aggregate-to-edit
+  labels:
+    {{- $labels | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["openclaw.rocks"]
+    resources:
+      - openclawinstances
+      - openclawselfconfigs
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullname }}-aggregate-to-view
+  labels:
+    {{- $labels | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["openclaw.rocks"]
+    resources:
+      - openclawinstances
+      - openclawselfconfigs
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/openclaw-operator/values.yaml
+++ b/charts/openclaw-operator/values.yaml
@@ -25,6 +25,13 @@ rbac:
   # Whether the chart should render the operator's RBAC (ClusterRole/Role
   # and bindings). Set to false to disable and supply your own out-of-band.
   create: true
+  # Whether to install aggregated ClusterRoles that extend the built-in
+  # Kubernetes admin/edit/view ClusterRoles with permissions for the
+  # OpenClaw CRDs. With this enabled, users bound to the standard
+  # `admin`/`edit`/`view` ClusterRole in a namespace can manage
+  # OpenClawInstance and OpenClawSelfConfig resources in that namespace.
+  # Disable if your cluster manages CRD access via a separate policy.
+  aggregateToDefaultRoles: true
 
 # Restrict the operator to a fixed list of namespaces. When empty (default),
 # the operator watches OpenClawInstance resources cluster-wide and the chart


### PR DESCRIPTION
## Summary
- Adds three aggregated `ClusterRole`s labeled with `rbac.authorization.k8s.io/aggregate-to-{admin,edit,view}` so users bound to Kubernetes' standard `admin`/`edit`/`view` `ClusterRole` in a namespace can manage `OpenClawInstance` and `OpenClawSelfConfig` resources there.
- New values toggle `rbac.aggregateToDefaultRoles` (default `true`) for clusters that manage CRD access out-of-band.
- Cluster-scoped `OpenClawClusterDefaults` is intentionally excluded from namespace-level aggregation.

Closes #479.

## Why
Per the issue: a namespace admin bound to the built-in `admin` ClusterRole can manage Deployments/Pods/Secrets but gets `Forbidden` on `kubectl apply` for an `OpenClawInstance`, because the chart only renders `openclaw.rocks` permissions onto the operator manager Role -- not into anything aggregated to the standard human-facing roles.

## Test plan
- [x] `helm lint charts/openclaw-operator` passes
- [x] `helm template ...` renders three ClusterRoles with the correct aggregation labels and verbs
- [x] `helm template --set rbac.aggregateToDefaultRoles=false` suppresses them
- [x] `helm template --set rbac.create=false` suppresses them (gating on the parent flag)
- [x] `bash hack/check-helm-rbac-sync.sh` still passes (manager rules unchanged)
- [ ] CI: lint, test, reconcile-guard, helm-rbac-sync, build, e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)