### PR TITLE
fix(workspace): support nested paths in spec.workspace.initialFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,13 @@ spec:
       README.md: |
         # My Workspace
         This workspace is managed by OpenClaw.
+      agents/AGENT.md: |              # nested paths are supported
+        # Agent
+      skills/redmine/SKILL.md: |
+        # Skill
 ```
+
+Keys may contain `/` for nested files; the operator encodes them for ConfigMap storage and recreates the directory layout when seeding the workspace. The same path safety rules as `initialDirectories` apply (no leading `/`, no `..`, no segment starting with `.`).
 
 **External ConfigMap reference:**
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -86,7 +86,7 @@ Configures initial workspace files seeded into the instance. Files are copied on
 | Field                  | Type                      | Default | Description                                                                                       |
 |------------------------|---------------------------|---------|---------------------------------------------------------------------------------------------------|
 | `configMapRef`         | `ConfigMapNameSelector`   | --      | Reference to an external ConfigMap whose keys become workspace files. See sub-fields below. |
-| `initialFiles`         | `map[string]string`       | --      | Maps filenames to their content. Each file is written to the workspace directory only if it does not already exist. Max 50 entries. |
+| `initialFiles`         | `map[string]string`       | --      | Maps file paths to their content. Each file is written to the workspace directory only if it does not already exist. Keys may contain `/` for nested paths (e.g. `agents/AGENT.md`); the operator encodes them as ConfigMap-safe keys (`/` → `--`) and the init container recreates the directory layout when seeding. Path safety rules: max 253 chars, no `\`, no `..` segment, no segment starting with `.`, no leading or trailing `/`. `openclaw.json` is reserved at the root. Max 50 entries. |
 | `initialDirectories`   | `[]string`                | --      | Directories to create (`mkdir -p`) inside the workspace directory. Nested paths like `tools/scripts` are allowed. Max 20 items. |
 | `additionalWorkspaces` | `[]AdditionalWorkspace`   | --      | Additional agent workspaces for multi-agent setups. Each entry seeds files to `~/.openclaw/workspace-<name>/`. Max 10 items. See sub-fields below. |
 | `bootstrap`            | `BootstrapSpec`           | --      | Controls operator-managed `BOOTSTRAP.md` injection. See sub-fields below. |
@@ -132,7 +132,7 @@ Each entry configures a named workspace for a secondary agent. The operator seed
 |--------------------|-------------------------|---------|---------------------------------------------------------------------------------------------------|
 | `name`             | `string`                | --      | **(Required)** Workspace identifier. Must be a DNS label (`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`), max 63 chars. Seeds to `~/.openclaw/workspace-<name>/`. |
 | `configMapRef`     | `ConfigMapNameSelector` | --      | Reference to an external ConfigMap whose keys become workspace files. |
-| `initialFiles`     | `map[string]string`     | --      | Maps filenames to their content. Max 50 entries. |
+| `initialFiles`     | `map[string]string`     | --      | Maps file paths to their content. Same path rules as the default workspace `initialFiles`, including support for nested paths like `agents/AGENT.md`. Max 50 entries. |
 | `initialDirectories` | `[]string`            | --      | Directories to create inside this workspace. Max 20 items. |
 
 Per-workspace merge priority (highest wins): operator-injected `ENVIRONMENT.md` > inline `initialFiles` > external `configMapRef`. Note: `BOOTSTRAP.md`, self-configure files, and skill packs are only injected into the default workspace.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -4586,6 +4586,71 @@ func TestBuildWorkspaceConfigMap_WithFiles(t *testing.T) {
 	}
 }
 
+// TestBuildWorkspaceConfigMap_NestedInitialFiles verifies that user-defined
+// initialFiles paths containing '/' are stored under ConfigMap-safe keys
+// (slashes encoded as '--'), since Kubernetes rejects '/' in data keys (#482).
+func TestBuildWorkspaceConfigMap_NestedInitialFiles(t *testing.T) {
+	instance := newTestInstance("ws-nested")
+	instance.Spec.Workspace = &openclawv1alpha1.WorkspaceSpec{
+		InitialFiles: map[string]string{
+			"agents/AGENT.md":         "# Agent",
+			"skills/redmine/SKILL.md": "# Skill",
+			"SOUL.md":                 "# Soul",
+		},
+	}
+
+	cm := BuildWorkspaceConfigMap(instance, nil, nil, nil)
+	if cm == nil {
+		t.Fatal("expected non-nil ConfigMap")
+	}
+	if got, want := cm.Data["agents--AGENT.md"], "# Agent"; got != want {
+		t.Errorf("encoded key agents--AGENT.md: got %q, want %q", got, want)
+	}
+	if got, want := cm.Data["skills--redmine--SKILL.md"], "# Skill"; got != want {
+		t.Errorf("encoded key skills--redmine--SKILL.md: got %q, want %q", got, want)
+	}
+	// Flat keys must remain unchanged.
+	if got, want := cm.Data["SOUL.md"], "# Soul"; got != want {
+		t.Errorf("flat key SOUL.md: got %q, want %q", got, want)
+	}
+	// Raw nested keys must not appear (Kubernetes would reject them).
+	for k := range cm.Data {
+		if strings.Contains(k, "/") {
+			t.Errorf("ConfigMap data key %q contains '/' which is invalid", k)
+		}
+	}
+}
+
+// TestBuildWorkspaceConfigMap_AdditionalWorkspaceNestedFiles verifies that
+// nested initialFiles inside additionalWorkspaces are also encoded (#482).
+func TestBuildWorkspaceConfigMap_AdditionalWorkspaceNestedFiles(t *testing.T) {
+	instance := newTestInstance("ws-aw-nested")
+	instance.Spec.Workspace = &openclawv1alpha1.WorkspaceSpec{
+		AdditionalWorkspaces: []openclawv1alpha1.AdditionalWorkspace{
+			{
+				Name: "research",
+				InitialFiles: map[string]string{
+					"docs/PLAN.md": "# Plan",
+				},
+			},
+		},
+	}
+
+	cm := BuildWorkspaceConfigMap(instance, nil, nil, nil)
+	if cm == nil {
+		t.Fatal("expected non-nil ConfigMap")
+	}
+	want := AdditionalWorkspaceCMKey("research", "docs--PLAN.md")
+	if got := cm.Data[want]; got != "# Plan" {
+		t.Errorf("key %q: got %q, want %q", want, got, "# Plan")
+	}
+	for k := range cm.Data {
+		if strings.Contains(k, "/") {
+			t.Errorf("ConfigMap data key %q contains '/'", k)
+		}
+	}
+}
+
 // TestBuildWorkspaceConfigMap_BootstrapDisabled verifies that setting
 // spec.workspace.bootstrap.enabled=false suppresses the operator-injected
 // BOOTSTRAP.md. OpenClaw deletes the file after applying it, so re-seeding
@@ -4916,6 +4981,60 @@ func TestBuildInitScript_ShellQuotesSpecialChars(t *testing.T) {
 	expected := "cp /config/'openclaw.json' /data/openclaw.json\nmkdir -p /data/workspace\n[ -f /data/workspace/'BOOTSTRAP.md' ] || cp /workspace-init/'BOOTSTRAP.md' /data/workspace/'BOOTSTRAP.md'\n[ -f /data/workspace/'ENVIRONMENT.md' ] || cp /workspace-init/'ENVIRONMENT.md' /data/workspace/'ENVIRONMENT.md'\n[ -f /data/workspace/'it'\\''s a file.md' ] || cp /workspace-init/'it'\\''s a file.md' /data/workspace/'it'\\''s a file.md'"
 	if script != expected {
 		t.Errorf("unexpected script:\ngot:  %q\nwant: %q", script, expected)
+	}
+}
+
+// TestBuildInitScript_NestedInitialFiles verifies that nested initialFiles
+// paths produce a `mkdir -p` of the parent and a `cp` from the encoded source
+// key to the original workspace path (#482).
+func TestBuildInitScript_NestedInitialFiles(t *testing.T) {
+	instance := newTestInstance("init-nested")
+	instance.Spec.Workspace = &openclawv1alpha1.WorkspaceSpec{
+		InitialFiles: map[string]string{
+			"agents/AGENT.md":         "# Agent",
+			"skills/redmine/SKILL.md": "# Skill",
+		},
+	}
+
+	script := BuildInitScript(instance, nil, nil, nil)
+	wants := []string{
+		"mkdir -p /data/workspace/'agents'",
+		"mkdir -p /data/workspace/'skills/redmine'",
+		"[ -f /data/workspace/'agents/AGENT.md' ] || cp /workspace-init/'agents--AGENT.md' /data/workspace/'agents/AGENT.md'",
+		"[ -f /data/workspace/'skills/redmine/SKILL.md' ] || cp /workspace-init/'skills--redmine--SKILL.md' /data/workspace/'skills/redmine/SKILL.md'",
+	}
+	for _, w := range wants {
+		if !strings.Contains(script, w) {
+			t.Errorf("script missing %q\n%s", w, script)
+		}
+	}
+}
+
+// TestBuildInitScript_AdditionalWorkspaceNestedFiles verifies nested seeding
+// works for additionalWorkspaces too (#482).
+func TestBuildInitScript_AdditionalWorkspaceNestedFiles(t *testing.T) {
+	instance := newTestInstance("init-aw-nested")
+	instance.Spec.Workspace = &openclawv1alpha1.WorkspaceSpec{
+		AdditionalWorkspaces: []openclawv1alpha1.AdditionalWorkspace{
+			{
+				Name: "research",
+				InitialFiles: map[string]string{
+					"docs/PLAN.md": "# Plan",
+				},
+			},
+		},
+	}
+
+	script := BuildInitScript(instance, nil, nil, nil)
+	expectedCMKey := AdditionalWorkspaceCMKey("research", "docs--PLAN.md")
+	wants := []string{
+		"mkdir -p /data/'workspace-research'/'docs'",
+		"[ -f /data/'workspace-research'/'docs/PLAN.md' ] || cp /workspace-init/'" + expectedCMKey + "' /data/'workspace-research'/'docs/PLAN.md'",
+	}
+	for _, w := range wants {
+		if !strings.Contains(script, w) {
+			t.Errorf("script missing %q\n%s", w, script)
+		}
 	}
 }
 

--- a/internal/resources/skillpacks.go
+++ b/internal/resources/skillpacks.go
@@ -63,7 +63,9 @@ func FilterNonPackSkills(skills []string) []string {
 }
 
 // SkillPackCMKey converts a workspace-relative path to a ConfigMap-safe key.
-// Replaces "/" with "--" to comply with ConfigMap key naming rules.
+// Replaces "/" with "--" to comply with ConfigMap key naming rules. Also used
+// for inline spec.workspace.initialFiles paths that contain '/' (#482); the
+// init script decodes the key back to the original path when seeding.
 func SkillPackCMKey(wsPath string) string {
 	return strings.ReplaceAll(wsPath, "/", "--")
 }

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 
@@ -733,38 +734,57 @@ func BuildInitScript(instance *openclawv1alpha1.OpenClawInstance, externalWorksp
 	// Collect all workspace file names from both user-defined and operator-injected sources
 	hasFiles := hasWorkspaceFiles(instance, skillPacks)
 	if hasFiles {
-		allFiles := make(map[string]bool)
-		// External configMapRef files
+		// Flat (single-segment) seeds share source and destination filenames.
+		// User initialFiles paths that contain '/' need encoded source keys
+		// and explicit mkdir -p of the parent directory; collect them
+		// separately and emit them in their own loop below.
+		flatFiles := make(map[string]bool)
+		var nestedUserPaths []string
+		// External configMapRef files (keys are always flat)
 		for name := range externalWorkspaceFiles {
-			allFiles[name] = true
+			flatFiles[name] = true
 		}
 		if ws != nil {
 			for name := range ws.InitialFiles {
-				allFiles[name] = true
+				if strings.Contains(name, "/") {
+					nestedUserPaths = append(nestedUserPaths, name)
+				} else {
+					flatFiles[name] = true
+				}
 			}
 		}
 		// Always inject operator files
-		allFiles["ENVIRONMENT.md"] = true
+		flatFiles["ENVIRONMENT.md"] = true
 		// BOOTSTRAP.md injection is opt-out (#463).
 		if bootstrapEnabled(instance) {
-			allFiles["BOOTSTRAP.md"] = true
+			flatFiles["BOOTSTRAP.md"] = true
 		}
 		if instance.Spec.SelfConfigure.Enabled {
-			allFiles["SELFCONFIG.md"] = true
-			allFiles["selfconfig.sh"] = true
+			flatFiles["SELFCONFIG.md"] = true
+			flatFiles["selfconfig.sh"] = true
 		}
 
 		// Ensure the workspace directory exists (may not on first run with emptyDir)
 		lines = append(lines, "mkdir -p /data/workspace")
 		// Sort keys for deterministic output
-		sorted := make([]string, 0, len(allFiles))
-		for name := range allFiles {
+		sorted := make([]string, 0, len(flatFiles))
+		for name := range flatFiles {
 			sorted = append(sorted, name)
 		}
 		sort.Strings(sorted)
 		for _, name := range sorted {
 			q := shellQuote(name)
 			lines = append(lines, fmt.Sprintf("[ -f /data/workspace/%s ] || cp /workspace-init/%s /data/workspace/%s", q, q, q))
+		}
+
+		// Nested user initialFiles: encoded ConfigMap key, mkdir parent, cp to original path (#482).
+		sort.Strings(nestedUserPaths)
+		for _, wsPath := range nestedUserPaths {
+			cmKey := SkillPackCMKey(wsPath)
+			lines = append(lines,
+				fmt.Sprintf("mkdir -p /data/workspace/%s", shellQuote(path.Dir(wsPath))),
+				fmt.Sprintf("[ -f /data/workspace/%s ] || cp /workspace-init/%s /data/workspace/%s",
+					shellQuote(wsPath), shellQuote(cmKey), shellQuote(wsPath)))
 		}
 
 		// Skill pack files use mapped paths (ConfigMap key differs from workspace path)
@@ -803,25 +823,32 @@ func BuildInitScript(instance *openclawv1alpha1.OpenClawInstance, externalWorksp
 				lines = append(lines, fmt.Sprintf("mkdir -p /data/%s/%s", shellQuote(wsDir), shellQuote(dir)))
 			}
 
-			// Collect all file names for this workspace
-			awFiles := make(map[string]bool)
+			// Collect file names for this workspace. Flat names map source→dest 1:1;
+			// nested user initialFiles paths need parent-dir creation and encoded
+			// ConfigMap keys (#482).
+			flatNames := make(map[string]bool)
+			var nestedAWPaths []string
 
-			// External configMapRef files
+			// External configMapRef files (keys are always flat)
 			if extFiles, ok := additionalExternalFiles[aw.Name]; ok {
 				for name := range extFiles {
-					awFiles[name] = true
+					flatNames[name] = true
 				}
 			}
 			// Inline initialFiles
 			for name := range aw.InitialFiles {
-				awFiles[name] = true
+				if strings.Contains(name, "/") {
+					nestedAWPaths = append(nestedAWPaths, name)
+				} else {
+					flatNames[name] = true
+				}
 			}
 			// Operator-injected ENVIRONMENT.md
-			awFiles["ENVIRONMENT.md"] = true
+			flatNames["ENVIRONMENT.md"] = true
 
-			// Seed files (only if not present)
-			sorted := make([]string, 0, len(awFiles))
-			for name := range awFiles {
+			// Seed flat files (only if not present)
+			sorted := make([]string, 0, len(flatNames))
+			for name := range flatNames {
 				sorted = append(sorted, name)
 			}
 			sort.Strings(sorted)
@@ -831,6 +858,18 @@ func BuildInitScript(instance *openclawv1alpha1.OpenClawInstance, externalWorksp
 					shellQuote(wsDir), shellQuote(name),
 					shellQuote(cmKey),
 					shellQuote(wsDir), shellQuote(name)))
+			}
+
+			// Seed nested user initialFiles (#482).
+			sort.Strings(nestedAWPaths)
+			for _, wsPath := range nestedAWPaths {
+				cmKey := AdditionalWorkspaceCMKey(aw.Name, SkillPackCMKey(wsPath))
+				lines = append(lines,
+					fmt.Sprintf("mkdir -p /data/%s/%s", shellQuote(wsDir), shellQuote(path.Dir(wsPath))),
+					fmt.Sprintf("[ -f /data/%s/%s ] || cp /workspace-init/%s /data/%s/%s",
+						shellQuote(wsDir), shellQuote(wsPath),
+						shellQuote(cmKey),
+						shellQuote(wsDir), shellQuote(wsPath)))
 			}
 		}
 	}

--- a/internal/resources/validation.go
+++ b/internal/resources/validation.go
@@ -22,8 +22,11 @@ import (
 )
 
 // ValidateWorkspaceFilename checks a single workspace filename.
-// Exported so both the webhook and the controller can validate filenames
-// (e.g. keys from an external ConfigMap referenced by spec.workspace.configMapRef).
+// Used for keys from an external ConfigMap referenced by spec.workspace.configMapRef,
+// where Kubernetes itself enforces that keys cannot contain '/'.
+//
+// For inline spec.workspace.initialFiles use ValidateWorkspaceFilePath, which
+// permits nested paths (the operator encodes them into ConfigMap-safe keys).
 func ValidateWorkspaceFilename(name string) error {
 	if name == "" {
 		return fmt.Errorf("filename must not be empty")
@@ -45,6 +48,52 @@ func ValidateWorkspaceFilename(name string) error {
 	}
 	if name == "openclaw.json" {
 		return fmt.Errorf("filename 'openclaw.json' is reserved for config")
+	}
+	return nil
+}
+
+// ValidateWorkspaceFilePath checks a workspace-relative file path. Unlike
+// ValidateWorkspaceFilename it allows '/' so callers can seed nested files
+// (e.g. "agents/AGENT.md"). The operator encodes '/' as '--' when storing the
+// content in a ConfigMap and decodes it back when seeding the workspace
+// (issue #482).
+//
+// Path safety rules (apply per segment as well as overall):
+//   - non-empty, max 253 chars
+//   - no backslashes
+//   - no ".." segment (or substring inside any segment)
+//   - no leading or trailing "/", no empty segments
+//   - no segment starting with "." (hidden file/dir)
+//   - "openclaw.json" reserved at the root only
+func ValidateWorkspaceFilePath(path string) error {
+	if path == "" {
+		return fmt.Errorf("path must not be empty")
+	}
+	if len(path) > 253 {
+		return fmt.Errorf("path must be at most 253 characters")
+	}
+	if strings.Contains(path, "\\") {
+		return fmt.Errorf("path must not contain '\\'")
+	}
+	if strings.HasPrefix(path, "/") {
+		return fmt.Errorf("path must not be absolute")
+	}
+	if strings.HasSuffix(path, "/") {
+		return fmt.Errorf("path must not end with '/'")
+	}
+	if path == "openclaw.json" {
+		return fmt.Errorf("path 'openclaw.json' is reserved for config")
+	}
+	for _, seg := range strings.Split(path, "/") {
+		if seg == "" {
+			return fmt.Errorf("path must not contain empty segments")
+		}
+		if strings.Contains(seg, "..") {
+			return fmt.Errorf("path segment %q must not contain '..'", seg)
+		}
+		if strings.HasPrefix(seg, ".") {
+			return fmt.Errorf("path segment %q must not start with '.'", seg)
+		}
 	}
 	return nil
 }

--- a/internal/resources/workspace_configmap.go
+++ b/internal/resources/workspace_configmap.go
@@ -30,8 +30,8 @@ const additionalWorkspaceKeySep = "--ws--"
 
 // BuildWorkspaceConfigMap creates a ConfigMap containing workspace seed files.
 // Returns nil if the instance has no workspace files (user-defined, operator-injected, or skill packs).
-// Skill pack files use ConfigMap-safe keys (/ replaced with --); the init script
-// maps them back to the correct workspace paths.
+// Skill pack files and inline initialFiles paths use ConfigMap-safe keys (/ replaced
+// with --); the init script maps them back to the correct workspace paths.
 //
 // externalFiles are the resolved contents of spec.workspace.configMapRef (may be nil).
 // additionalExternalFiles maps workspace name to resolved configMapRef contents (may be nil).
@@ -51,15 +51,18 @@ func BuildWorkspaceConfigMap(instance *openclawv1alpha1.OpenClawInstance, extern
 		}
 	}
 
-	// 3. External configMapRef entries
+	// 3. External configMapRef entries (keys already flat — ConfigMap data
+	// keys cannot contain '/').
 	for k, v := range externalFiles {
 		files[k] = v
 	}
 
-	// 2. User-defined inline workspace files
+	// 2. User-defined inline workspace files. Keys may contain '/' (nested
+	// paths) which is illegal for ConfigMap data keys, so encode them the same
+	// way skill packs do (#482).
 	if instance.Spec.Workspace != nil {
 		for k, v := range instance.Spec.Workspace.InitialFiles {
-			files[k] = v
+			files[SkillPackCMKey(k)] = v
 		}
 	}
 
@@ -95,9 +98,10 @@ func BuildWorkspaceConfigMap(instance *openclawv1alpha1.OpenClawInstance, extern
 				}
 			}
 
-			// 2. Inline initialFiles (overrides external)
+			// 2. Inline initialFiles (overrides external). Encode '/' in the
+			// filename portion before namespacing it under the workspace (#482).
 			for k, v := range ws.InitialFiles {
-				files[AdditionalWorkspaceCMKey(ws.Name, k)] = v
+				files[AdditionalWorkspaceCMKey(ws.Name, SkillPackCMKey(k))] = v
 			}
 
 			// 1. ENVIRONMENT.md only (no BOOTSTRAP.md for secondary agents)

--- a/internal/webhook/openclawinstance_webhook.go
+++ b/internal/webhook/openclawinstance_webhook.go
@@ -304,7 +304,7 @@ func validateWorkspaceSpec(ws *openclawv1alpha1.WorkspaceSpec) error {
 	}
 
 	for name := range ws.InitialFiles {
-		if err := resources.ValidateWorkspaceFilename(name); err != nil {
+		if err := resources.ValidateWorkspaceFilePath(name); err != nil {
 			return fmt.Errorf("workspace initialFiles key %q: %w", name, err)
 		}
 	}
@@ -332,7 +332,7 @@ func validateWorkspaceSpec(ws *openclawv1alpha1.WorkspaceSpec) error {
 			return fmt.Errorf("additionalWorkspaces[%d] %q configMapRef.name must not be empty", i, aw.Name)
 		}
 		for name := range aw.InitialFiles {
-			if err := resources.ValidateWorkspaceFilename(name); err != nil {
+			if err := resources.ValidateWorkspaceFilePath(name); err != nil {
 				return fmt.Errorf("additionalWorkspaces[%d] %q initialFiles key %q: %w", i, aw.Name, name, err)
 			}
 		}

--- a/internal/webhook/openclawinstance_webhook_test.go
+++ b/internal/webhook/openclawinstance_webhook_test.go
@@ -969,19 +969,46 @@ func TestValidateCreate_WorkspaceNil(t *testing.T) {
 	}
 }
 
-func TestValidateCreate_WorkspaceFileSlash(t *testing.T) {
+func TestValidateCreate_WorkspaceFileNestedPath(t *testing.T) {
+	// Nested paths in initialFiles must be accepted; the operator encodes '/'
+	// as '--' for ConfigMap storage and decodes it back in the init script (#482).
 	v := &OpenClawInstanceValidator{}
 	instance := newTestInstance()
 	instance.Spec.Workspace = &openclawv1alpha1.WorkspaceSpec{
-		InitialFiles: map[string]string{"sub/file.md": "content"},
+		InitialFiles: map[string]string{
+			"agents/AGENT.md":         "# Agent",
+			"skills/redmine/SKILL.md": "# Skill",
+		},
 	}
 
 	_, err := v.ValidateCreate(context.Background(), instance)
-	if err == nil {
-		t.Fatal("expected error for filename with '/'")
+	if err != nil {
+		t.Fatalf("expected nested initialFiles paths to be accepted, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "/") {
-		t.Fatalf("error should mention '/', got: %v", err)
+}
+
+func TestValidateCreate_WorkspaceFileNestedRejected(t *testing.T) {
+	v := &OpenClawInstanceValidator{}
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"absolute", "/etc/passwd"},
+		{"trailing slash", "agents/"},
+		{"empty segment", "agents//AGENT.md"},
+		{"dotdot segment", "agents/../escape.md"},
+		{"hidden middle segment", "agents/.secret/AGENT.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := newTestInstance()
+			instance.Spec.Workspace = &openclawv1alpha1.WorkspaceSpec{
+				InitialFiles: map[string]string{tc.path: "content"},
+			}
+			if _, err := v.ValidateCreate(context.Background(), instance); err == nil {
+				t.Fatalf("expected error for path %q", tc.path)
+			}
+		})
 	}
 }
 

--- a/test/e2e/e2e_workspace_nested_files_test.go
+++ b/test/e2e/e2e_workspace_nested_files_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
 	"github.com/openclawrocks/openclaw-operator/internal/resources"
@@ -124,24 +125,17 @@ var _ = Describe("Workspace initialFiles with nested paths", func() {
 			Expect(script).To(ContainSubstring(
 				"cp /workspace-init/'skills--redmine--SKILL.md' /data/workspace/'skills/redmine/SKILL.md'"))
 
-			// WorkspaceReady=True confirms the controller did not bail out
-			// with the old "Invalid value" ConfigMap error.
-			updatedInstance := &openclawv1alpha1.OpenClawInstance{}
-			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      instanceName,
-					Namespace: namespace,
-				}, updatedInstance); err != nil {
-					return false
-				}
-				for _, c := range updatedInstance.Status.Conditions {
-					if c.Type == openclawv1alpha1.ConditionTypeWorkspaceReady {
-						return c.Status == metav1.ConditionTrue
-					}
-				}
-				return false
-			}, 30*time.Second, 2*time.Second).Should(BeTrue(),
-				"WorkspaceReady condition should be True after reconcile")
+			// The pre-fix behaviour surfaced an "InvalidFilename" /
+			// "ReconcileFailed" event referencing the ConfigMap "Invalid value"
+			// error. The fact that we reached this point with the StatefulSet
+			// and workspace ConfigMap created already proves the fix; verify
+			// no such event was recorded.
+			events := &corev1.EventList{}
+			Expect(k8sClient.List(ctx, events, client.InNamespace(namespace))).To(Succeed())
+			for _, e := range events.Items {
+				Expect(e.Message).NotTo(ContainSubstring("must consist of alphanumeric characters"),
+					"event %q should not reference the pre-fix ConfigMap validation error", e.Name)
+			}
 
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})

--- a/test/e2e/e2e_workspace_nested_files_test.go
+++ b/test/e2e/e2e_workspace_nested_files_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 OpenClaw.rocks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	"github.com/openclawrocks/openclaw-operator/internal/resources"
+)
+
+// Regression for #482: nested paths in spec.workspace.initialFiles must
+// reconcile cleanly. Before the fix the operator wrote raw keys like
+// "agents/AGENT.md" into the ConfigMap data, which Kubernetes rejected with
+// "must consist of alphanumeric characters, '-', '_' or '.'", leaving the
+// workspace ConfigMap unreconciled.
+var _ = Describe("Workspace initialFiles with nested paths", func() {
+	Context("When initialFiles keys contain '/'", func() {
+		var namespace string
+
+		BeforeEach(func() {
+			namespace = "test-ws-nested-" + time.Now().Format("20060102150405")
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+		})
+
+		AfterEach(func() {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+			_ = k8sClient.Delete(ctx, ns)
+		})
+
+		It("Should reconcile the workspace ConfigMap with encoded keys and a mkdir+cp init script", func() {
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instanceName := "ws-nested-test"
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					Workspace: &openclawv1alpha1.WorkspaceSpec{
+						InitialFiles: map[string]string{
+							"agents/AGENT.md":         "# Agent",
+							"skills/redmine/SKILL.md": "# Skill",
+							"SOUL.md":                 "# Soul",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			// StatefulSet must be created — proves reconcile reached the end.
+			statefulSet := &appsv1.StatefulSet{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.StatefulSetName(instance),
+					Namespace: namespace,
+				}, statefulSet)
+			}, 60*time.Second, 2*time.Second).Should(Succeed())
+
+			// Workspace ConfigMap exists with encoded keys, never raw '/'.
+			workspaceCM := &corev1.ConfigMap{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      resources.WorkspaceConfigMapName(instance),
+					Namespace: namespace,
+				}, workspaceCM)
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+			Expect(workspaceCM.Data).To(HaveKeyWithValue("agents--AGENT.md", "# Agent"))
+			Expect(workspaceCM.Data).To(HaveKeyWithValue("skills--redmine--SKILL.md", "# Skill"))
+			Expect(workspaceCM.Data).To(HaveKeyWithValue("SOUL.md", "# Soul"))
+			for k := range workspaceCM.Data {
+				Expect(k).NotTo(ContainSubstring("/"),
+					"ConfigMap data key %q must not contain '/'", k)
+			}
+
+			// Init script must recreate the nested layout on the workspace volume.
+			var initConfig *corev1.Container
+			for i := range statefulSet.Spec.Template.Spec.InitContainers {
+				if statefulSet.Spec.Template.Spec.InitContainers[i].Name == "init-config" {
+					initConfig = &statefulSet.Spec.Template.Spec.InitContainers[i]
+					break
+				}
+			}
+			Expect(initConfig).NotTo(BeNil(), "init-config container should exist")
+			script := initConfig.Command[2]
+			Expect(script).To(ContainSubstring("mkdir -p /data/workspace/'agents'"))
+			Expect(script).To(ContainSubstring("mkdir -p /data/workspace/'skills/redmine'"))
+			Expect(script).To(ContainSubstring(
+				"cp /workspace-init/'agents--AGENT.md' /data/workspace/'agents/AGENT.md'"))
+			Expect(script).To(ContainSubstring(
+				"cp /workspace-init/'skills--redmine--SKILL.md' /data/workspace/'skills/redmine/SKILL.md'"))
+
+			// WorkspaceReady=True confirms the controller did not bail out
+			// with the old "Invalid value" ConfigMap error.
+			updatedInstance := &openclawv1alpha1.OpenClawInstance{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instanceName,
+					Namespace: namespace,
+				}, updatedInstance); err != nil {
+					return false
+				}
+				for _, c := range updatedInstance.Status.Conditions {
+					if c.Type == openclawv1alpha1.ConditionTypeWorkspaceReady {
+						return c.Status == metav1.ConditionTrue
+					}
+				}
+				return false
+			}, 30*time.Second, 2*time.Second).Should(BeTrue(),
+				"WorkspaceReady condition should be True after reconcile")
+
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+	})
+})

--- a/test/e2e/e2e_workspace_nested_files_test.go
+++ b/test/e2e/e2e_workspace_nested_files_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Workspace initialFiles with nested paths", func() {
 			Expect(script).To(ContainSubstring(
 				"cp /workspace-init/'skills--redmine--SKILL.md' /data/workspace/'skills/redmine/SKILL.md'"))
 
-			// The pre-fix behaviour surfaced an "InvalidFilename" /
+			// The pre-fix behavior surfaced an "InvalidFilename" /
 			// "ReconcileFailed" event referencing the ConfigMap "Invalid value"
 			// error. The fact that we reached this point with the StatefulSet
 			// and workspace ConfigMap created already proves the fix; verify


### PR DESCRIPTION
## Summary
- Encode `/` as `--` for inline `spec.workspace.initialFiles` keys when writing the workspace ConfigMap, matching the existing skill-packs encoding. Reconciliation no longer crashes on `agents/AGENT.md` etc. (closes #482).
- Init script now decodes the encoded key back to the original path and runs `mkdir -p <parent>` before the seed `cp`, for both the default workspace and `additionalWorkspaces[]`.
- Loosen the webhook's `initialFiles` validation to allow nested paths, enforcing the same safety rules per segment (no leading/trailing `/`, no `..`, no segment starting with `.`, etc.).
- Documented the new behavior in both README and `docs/api-reference.md`.

## Test plan
- [x] `go vet ./...`
- [x] `make lint` (golangci-lint v1.64.5)
- [x] `go test ./internal/resources/... ./internal/webhook/... ./internal/registry/... ./internal/skillpacks/...`
- [x] New unit coverage: encoded ConfigMap keys + init-script mkdir/cp lines for default and additional workspaces; webhook accept/reject cases for nested paths.
- [x] New e2e spec `test/e2e/e2e_workspace_nested_files_test.go` creating an instance with nested `initialFiles`, asserting the workspace ConfigMap has encoded keys and the init script seeds the right paths.
- [ ] (CI) envtest controller suite + kind e2e — not runnable locally.

Fixes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)