### PR TITLE
feat: shareProcessNamespace (default true) to reap zombies

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Every request is validated against the instance's allowlist policy. Protected co
 | **Extensible** | Sidecars & init containers | Chromium for browser automation, Ollama for local LLMs, Tailscale for tailnet access, plus custom init containers and sidecars |
 | **Cloud Native** | SA annotations & CA bundles | AWS IRSA / GCP Workload Identity via ServiceAccount annotations; CA bundle injection for corporate proxies |
 | **Cluster Defaults** | Singleton CR | `OpenClawClusterDefaults` (name `cluster`) fills in unset instance fields - ideal for air-gapped / China regions where every instance would otherwise duplicate the same registry + mirror env boilerplate. Per-instance fields always win. |
+| **Zombie Reaping** | Shared PID namespace | `spec.shareProcessNamespace` defaults to `true` so the pause container becomes PID 1 and reaps defunct helper processes from QMD, git, plugins, and shells - no custom init image needed |
 
 
 ## Architecture
@@ -1218,6 +1219,19 @@ spec:
   podAnnotations:
     cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
 ```
+
+### Shared Process Namespace
+
+The OpenClaw gateway runs as PID 1 in its container, and the Node.js process does not call `waitpid()` on orphaned children. Long-running pods accumulate defunct processes from QMD memory indexing, git, plugin activity, and shells. With `shareProcessNamespace: true` (the default), all containers in the pod share a PID namespace, the Kubernetes `pause` container becomes PID 1, and zombies are reaped automatically.
+
+Opt out per instance only if you need strict per-container PID isolation (and have a tini/dumb-init wrapper in your image):
+
+```yaml
+spec:
+  shareProcessNamespace: false
+```
+
+Trade-off: with sharing enabled, every container in the pod can see and signal every other container's processes. A compromised sidecar (Tailscale, Ollama, browser, custom) could send signals to the gateway and vice versa. For most deployments the zombie-reaping benefit outweighs this, but if your threat model assumes mutually distrusting sidecars, set this to `false` and reap inside your image instead.
 
 Phases: `Pending` -> `Restoring` -> `Provisioning` -> `Running` | `Updating` | `BackingUp` | `Degraded` | `Failed` | `Terminating`
 

--- a/api/v1alpha1/openclawinstance_types.go
+++ b/api/v1alpha1/openclawinstance_types.go
@@ -67,6 +67,21 @@ type OpenClawInstanceSpec struct {
 	// +optional
 	Security SecuritySpec `json:"security,omitempty"`
 
+	// ShareProcessNamespace enables PID namespace sharing between all containers
+	// in the pod. When true, the infrastructure (pause) container becomes PID 1
+	// and reaps zombie processes, which prevents accumulation of defunct helper
+	// processes (git, plugins, QMD memory, shells) under a Node.js gateway that
+	// does not call waitpid(). Defaults to true.
+	//
+	// Security note: enabling this lets every container in the pod see and signal
+	// every other container's processes. A compromised sidecar (Tailscale, Ollama,
+	// browser, custom) could send signals to the gateway and vice versa. Set to
+	// false to keep per-container PID isolation; you are then responsible for
+	// reaping zombies (e.g. by baking tini or dumb-init into the image).
+	// +kubebuilder:default=true
+	// +optional
+	ShareProcessNamespace *bool `json:"shareProcessNamespace,omitempty"`
+
 	// Storage specifies persistent storage configuration
 	// +optional
 	Storage StorageSpec `json:"storage,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1073,6 +1073,11 @@ func (in *OpenClawInstanceSpec) DeepCopyInto(out *OpenClawInstanceSpec) {
 	}
 	out.Resources = in.Resources
 	in.Security.DeepCopyInto(&out.Security)
+	if in.ShareProcessNamespace != nil {
+		in, out := &in.ShareProcessNamespace, &out.ShareProcessNamespace
+		*out = new(bool)
+		**out = **in
+	}
 	in.Storage.DeepCopyInto(&out.Storage)
 	in.Chromium.DeepCopyInto(&out.Chromium)
 	in.Tailscale.DeepCopyInto(&out.Tailscale)

--- a/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
+++ b/charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml
@@ -6051,6 +6051,21 @@ spec:
                       When true, the agent can create OpenClawSelfConfig resources to modify its own spec.
                     type: boolean
                 type: object
+              shareProcessNamespace:
+                default: true
+                description: |-
+                  ShareProcessNamespace enables PID namespace sharing between all containers
+                  in the pod. When true, the infrastructure (pause) container becomes PID 1
+                  and reaps zombie processes, which prevents accumulation of defunct helper
+                  processes (git, plugins, QMD memory, shells) under a Node.js gateway that
+                  does not call waitpid(). Defaults to true.
+
+                  Security note: enabling this lets every container in the pod see and signal
+                  every other container's processes. A compromised sidecar (Tailscale, Ollama,
+                  browser, custom) could send signals to the gateway and vice versa. Set to
+                  false to keep per-container PID isolation; you are then responsible for
+                  reaping zombies (e.g. by baking tini or dumb-init into the image).
+                type: boolean
               sidecarVolumes:
                 description: SidecarVolumes is a list of additional volumes to make
                   available to sidecar containers.

--- a/config/crd/bases/openclaw.rocks_openclawinstances.yaml
+++ b/config/crd/bases/openclaw.rocks_openclawinstances.yaml
@@ -6045,6 +6045,21 @@ spec:
                       When true, the agent can create OpenClawSelfConfig resources to modify its own spec.
                     type: boolean
                 type: object
+              shareProcessNamespace:
+                default: true
+                description: |-
+                  ShareProcessNamespace enables PID namespace sharing between all containers
+                  in the pod. When true, the infrastructure (pause) container becomes PID 1
+                  and reaps zombie processes, which prevents accumulation of defunct helper
+                  processes (git, plugins, QMD memory, shells) under a Node.js gateway that
+                  does not call waitpid(). Defaults to true.
+
+                  Security note: enabling this lets every container in the pod see and signal
+                  every other container's processes. A compromised sidecar (Tailscale, Ollama,
+                  browser, custom) could send signals to the gateway and vice versa. Set to
+                  false to keep per-container PID isolation; you are then responsible for
+                  reaping zombies (e.g. by baking tini or dumb-init into the image).
+                type: boolean
               sidecarVolumes:
                 description: SidecarVolumes is a list of additional volumes to make
                   available to sidecar containers.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -349,6 +349,22 @@ spec:
       key: ca-bundle.crt
 ```
 
+### spec.shareProcessNamespace
+
+| Field                   | Type    | Default | Description                                                                                                                                                                                                                                                                                                                                                                          |
+|-------------------------|---------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `shareProcessNamespace` | `*bool` | `true`  | When `true`, all containers in the pod share a PID namespace. The Kubernetes `pause` container becomes PID 1 and reaps zombie processes, preventing accumulation of defunct helpers (QMD, git, plugins, shells) under a Node.js gateway that does not call `waitpid()`. Set to `false` to keep per-container PID isolation; you are then responsible for reaping zombies in-image. |
+
+**Security implication.** With PID-namespace sharing enabled, every container in the pod can see and signal every other container's processes. A compromised sidecar (Tailscale, Ollama, browser, custom) could send signals to the gateway and vice versa. For most deployments this is an acceptable trade-off for zombie reaping; if your threat model assumes mutually distrusting sidecars, disable this and add a `tini`/`dumb-init` wrapper to your main image instead.
+
+**Upgrade note.** Existing instances created before this field existed will have `nil` in their stored spec. The operator treats `nil` as `true`, so the next reconcile rolls the pod template to enable sharing. Plan a maintenance window if you operate a large fleet.
+
+```yaml
+# Opt out of shared PID namespace
+spec:
+  shareProcessNamespace: false
+```
+
 ### spec.storage
 
 Persistent storage configuration.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -1292,6 +1292,47 @@ func TestBuildStatefulSet_RuntimeClassName_Unset(t *testing.T) {
 	}
 }
 
+func TestBuildStatefulSet_ShareProcessNamespace_DefaultsTrue(t *testing.T) {
+	instance := newTestInstance("spn-default")
+
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+	podSpec := sts.Spec.Template.Spec
+
+	if podSpec.ShareProcessNamespace == nil {
+		t.Fatal("expected ShareProcessNamespace to be set when field unset")
+	}
+	if !*podSpec.ShareProcessNamespace {
+		t.Error("ShareProcessNamespace should default to true")
+	}
+}
+
+func TestBuildStatefulSet_ShareProcessNamespace_ExplicitTrue(t *testing.T) {
+	instance := newTestInstance("spn-true")
+	instance.Spec.ShareProcessNamespace = Ptr(true)
+
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+	podSpec := sts.Spec.Template.Spec
+
+	if podSpec.ShareProcessNamespace == nil || !*podSpec.ShareProcessNamespace {
+		t.Errorf("ShareProcessNamespace = %v, want true", podSpec.ShareProcessNamespace)
+	}
+}
+
+func TestBuildStatefulSet_ShareProcessNamespace_ExplicitFalse(t *testing.T) {
+	instance := newTestInstance("spn-false")
+	instance.Spec.ShareProcessNamespace = Ptr(false)
+
+	sts := BuildStatefulSet(instance, "", nil, nil, nil)
+	podSpec := sts.Spec.Template.Spec
+
+	if podSpec.ShareProcessNamespace == nil {
+		t.Fatal("expected ShareProcessNamespace to be set")
+	}
+	if *podSpec.ShareProcessNamespace {
+		t.Error("ShareProcessNamespace should be false when explicitly disabled")
+	}
+}
+
 func TestBuildStatefulSet_PodAnnotations_UserAnnotationsPresent(t *testing.T) {
 	instance := newTestInstance("pod-ann-test")
 	instance.Spec.PodAnnotations = map[string]string{

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -76,6 +76,7 @@ func BuildStatefulSet(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenS
 					ServiceAccountName:            ServiceAccountName(instance),
 					DeprecatedServiceAccount:      ServiceAccountName(instance),
 					AutomountServiceAccountToken:  Ptr(instance.Spec.SelfConfigure.Enabled || instance.Spec.Tailscale.Enabled),
+					ShareProcessNamespace:         shareProcessNamespace(instance),
 					SecurityContext:               buildPodSecurityContext(instance),
 					InitContainers:                buildInitContainers(instance, externalWorkspaceFiles, additionalExternalFiles, skillPacks),
 					Containers:                    buildContainers(instance, gwSecretName),
@@ -139,6 +140,17 @@ func buildPodAnnotations(instance *openclawv1alpha1.OpenClawInstance, externalWo
 	}
 	annotations["openclaw.rocks/config-hash"] = calculateConfigHash(instance, externalWorkspaceFiles, additionalExternalFiles)
 	return annotations
+}
+
+// shareProcessNamespace returns the effective ShareProcessNamespace value, defaulting
+// to true. The kubebuilder default would otherwise populate this at the API server,
+// but explicit handling lets existing instances stored before the field was added
+// still get the zombie-reaping behavior on the next reconcile.
+func shareProcessNamespace(instance *openclawv1alpha1.OpenClawInstance) *bool {
+	if instance.Spec.ShareProcessNamespace != nil {
+		return instance.Spec.ShareProcessNamespace
+	}
+	return Ptr(true)
 }
 
 // buildPodSecurityContext creates the pod-level security context

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -675,6 +675,88 @@ var _ = Describe("OpenClawInstance Controller", func() {
 
 			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 		})
+
+		It("Should default shareProcessNamespace to true", func() {
+			instanceName := "spn-default"
+
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			statefulSet := &appsv1.StatefulSet{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instanceName,
+					Namespace: namespace,
+				}, statefulSet)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(statefulSet.Spec.Template.Spec.ShareProcessNamespace).ToNot(BeNil(),
+				"ShareProcessNamespace should be set so the pause container reaps zombies")
+			Expect(*statefulSet.Spec.Template.Spec.ShareProcessNamespace).To(BeTrue(),
+				"ShareProcessNamespace should default to true")
+
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+
+		It("Should honor shareProcessNamespace=false override", func() {
+			instanceName := "spn-disabled"
+
+			if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+				Skip("Skipping resource validation in minimal mode")
+			}
+
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      instanceName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"openclaw.rocks/skip-backup": "true",
+					},
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{
+					Image: openclawv1alpha1.ImageSpec{
+						Repository: "ghcr.io/openclaw/openclaw",
+						Tag:        "latest",
+					},
+					ShareProcessNamespace: resources.Ptr(false),
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			statefulSet := &appsv1.StatefulSet{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      instanceName,
+					Namespace: namespace,
+				}, statefulSet)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(statefulSet.Spec.Template.Spec.ShareProcessNamespace).ToNot(BeNil())
+			Expect(*statefulSet.Spec.Template.Spec.ShareProcessNamespace).To(BeFalse(),
+				"ShareProcessNamespace should be false when explicitly disabled")
+
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
 	})
 
 	Context("When deleting an OpenClawInstance without S3 backup credentials", func() {


### PR DESCRIPTION
## Summary

Adds `spec.shareProcessNamespace` (default `true`) to `OpenClawInstance`. When enabled, all containers in the pod share a PID namespace and the Kubernetes `pause` container becomes PID 1, automatically reaping zombie processes that accumulate under the Node.js gateway (which does not call `waitpid()` on orphaned children).

Closes #471.
Supersedes #476 — incorporates @alexander-morris's production-validated approach with the docs, unit tests, e2e tests, and field placement requested in [the review on #476](https://github.com/openclaw-rocks/openclaw-operator/pull/476#pullrequestreview-).

## Background

[#471](https://github.com/openclaw-rocks/openclaw-operator/issues/471) reported 28 defunct processes accumulating under PID 1 on a production OpenClaw pod (QMD, git, shells, plugin helpers). Image-level fixes (`tini` in the entrypoint) are the most durable long-term solution and are tracked upstream at openclaw/openclaw#74083, but operator users have no clean way to wrap the entrypoint today. PID-namespace sharing is the standard Kubernetes-native answer and stacks harmlessly with a future upstream init process.

@alexander-morris validated the approach in production (28 agents, 7+ hours, zero zombie accumulation, zero unrelated restarts on 24/28 pods).

## Changes

**Core:**
- `api/v1alpha1/openclawinstance_types.go` — `ShareProcessNamespace *bool` with `+kubebuilder:default=true`, placed next to `Security` (pod-level runtime/security cluster) per review feedback on #476.
- `internal/resources/statefulset.go` — `shareProcessNamespace()` helper; treats `nil` as `true` so instances stored before the field existed still get the fix on next reconcile.

**Generated (do not hand-edit):**
- `api/v1alpha1/zz_generated.deepcopy.go`
- `config/crd/bases/openclaw.rocks_openclawinstances.yaml`
- `charts/openclaw-operator/templates/crds/openclaw.rocks_openclawinstances.yaml`

**Tests:**
- `internal/resources/resources_test.go` — three new builder cases: default-true (field unset), explicit-true, explicit-false. Pattern matches the existing `AutomountServiceAccountToken` tests.
- `test/e2e/e2e_suite_test.go` — two new specs in the controller suite: default-true and explicit-false override. Pattern matches the adjacent `runtimeClassName` spec.

**Docs:**
- `README.md` — new feature-table row and a "Shared Process Namespace" subsection with opt-out snippet and security trade-off.
- `docs/api-reference.md` — `spec.shareProcessNamespace` field reference with type/default/behavior, security implication, and upgrade note about pod-template rollout for existing instances.

## Security trade-off (called out in docs)

With sharing enabled, every container in the pod can see and signal every other container's processes. A compromised sidecar (Tailscale, Ollama, browser, custom) could send signals to the gateway and vice versa. For most deployments the zombie-reaping benefit clearly outweighs this; users with mutually-distrusting sidecars can opt out per instance and reap inside their image (`tini`/`dumb-init`).

## Upgrade impact

Flipping the default to `true` means every existing `OpenClawInstance` will get a one-time pod-template change on next reconcile, rolling pods. Operators running large fleets should plan a maintenance window. Called out in the api-reference upgrade note.

## Test plan

- [x] `go test ./internal/resources/` passes (3 new tests covering default/true/false)
- [x] `make lint` passes (golangci-lint v1.64.5)
- [x] `go vet ./...` clean
- [x] `make generate manifests sync-chart-crds` regenerates cleanly (no manual edits to generated files)
- [ ] E2E suite passes in CI on a real kind cluster (new specs follow the existing `runtimeClassName` pattern)

## Credit

Production validation and original PR by @alexander-morris in #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)