### PR TITLE
fix(docs-site): correctly detect new CNAME file in gh-pages step

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -72,8 +72,8 @@ jobs:
           git fetch origin gh-pages
           git checkout gh-pages
           echo "docs-operator.openclaw.rocks" > CNAME
-          if ! git diff --quiet CNAME 2>/dev/null; then
-            git add CNAME
+          git add CNAME
+          if ! git diff --cached --quiet; then
             git commit -m "chore: ensure CNAME for docs-operator.openclaw.rocks"
             git push origin gh-pages
           fi


### PR DESCRIPTION
## Summary

The CNAME-write step in \`docs.yaml\` succeeded on the first auto-publish (v0.34.0) but didn't actually push anything because of a subtle git-diff bug. CNAME has been manually pushed to \`gh-pages\` to unblock the current state; this PR ensures future deploys preserve it correctly.

## Bug

\`\`\`yaml
echo "docs-operator.openclaw.rocks" > CNAME
if ! git diff --quiet CNAME 2>/dev/null; then
  git add CNAME
  git commit -m "..."
  git push origin gh-pages
fi
\`\`\`

\`git diff --quiet CNAME\` inspects the working tree against the index, but only for **tracked** files. A brand-new untracked CNAME (which is the situation on every fresh \`gh-pages\`) doesn't register as a diff, so the condition returns 0 and the if-body is silently skipped. The step reported success without doing anything.

## Fix

Always \`git add CNAME\` first, then check \`git diff --cached --quiet\` against the index. That correctly detects both new files and content changes, and stays a no-op when CNAME is already correct.

\`\`\`diff
   echo "docs-operator.openclaw.rocks" > CNAME
-  if ! git diff --quiet CNAME 2>/dev/null; then
-    git add CNAME
+  git add CNAME
+  if ! git diff --cached --quiet; then
     git commit -m "chore: ensure CNAME for docs-operator.openclaw.rocks"
     git push origin gh-pages
   fi
\`\`\`

## Test plan

- [x] CNAME directly pushed to \`gh-pages\` (commit \`e0d8576\`) -- unblocks current state until the user completes Phase 0 setup
- [ ] Next \`docs.yaml\` run (release-published or workflow_dispatch) confirms CNAME is preserved and the step is a no-op on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)