### PR TITLE
fix(environment-skill): document openclaw CLI availability

### DIFF
--- a/internal/resources/environment_skill.go
+++ b/internal/resources/environment_skill.go
@@ -36,6 +36,17 @@ You run in a hardened Kubernetes pod. The root filesystem is read-only.
 
 Everything else is read-only. Do NOT attempt writing to system paths.
 
+## OpenClaw CLI
+
+The ` + "`openclaw`" + ` command is available on your PATH (symlinked to /app/openclaw.mjs).
+Use it directly - you do NOT need to invoke node manually.
+
+` + "```" + `bash
+openclaw --help        # list commands
+openclaw doctor        # run healthchecks
+openclaw --version
+` + "```" + `
+
 ## Installing packages
 
 uv is pre-installed at ~/.local/bin/uv and already in your PATH.


### PR DESCRIPTION
## Summary

- Adds a short "OpenClaw CLI" section to the `ENVIRONMENT.md` skill injected into every workspace, telling the agent that the `openclaw` command is available on PATH (symlinked to `/app/openclaw.mjs` by the upstream image) and giving a couple of examples (`--help`, `doctor`, `--version`).
- No behavioral change to the pod itself - the CLI was always available; the agent just had no way to discover it.

## Context

Closes #498. Reporter's agent kept claiming it couldn't run `openclaw` and resorted to suggesting `node openclaw.mjs` in `/app`. Verified against `ghcr.io/openclaw/openclaw:latest` that `which openclaw` resolves to `/usr/local/bin/openclaw` (the npm `bin` symlink) and `openclaw --help` works as expected. The operator's PATH handling preserves `/usr/local/bin`, so the CLI is always reachable - the gap was purely documentation.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/resources/ -count=1`
- [ ] Confirm a new instance picks up the updated `ENVIRONMENT.md` in its workspace ConfigMap on next reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)