### PR TITLE
fix(config): inject gateway.mode=local for openclaw >= v2026.5.18

### DIFF
--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -148,6 +148,13 @@ const (
 	// is no "all" keyword, so a raw IP is required here.
 	GatewayBindAllInterfaces = "0.0.0.0"
 
+	// GatewayModeLocal is the gateway.mode value the operator injects. Since
+	// v2026.5.18 the upstream openclaw binary refuses to start unless
+	// gateway.mode is set, treating its absence as "suspicious or clobbered
+	// config". The operator always runs the gateway in-cluster (no remote
+	// onboarding), so "local" is the correct mode.
+	GatewayModeLocal = "local"
+
 	// DefaultHandshakeTimeoutMs is the WebSocket handshake timeout injected
 	// into gateway.handshakeTimeoutMs. OpenClaw v2026.3.12 reduced the
 	// hardcoded default from ~10s to 3s as a security measure, but 3s is too

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -55,7 +55,10 @@ func BuildConfigMapFromBytes(instance *openclawv1alpha1.OpenClawInstance, baseCo
 		configBytes = []byte("{}")
 	}
 
-	// Enrichment pipeline: OTel metrics -> gateway auth -> device auth -> tailscale -> browser -> gateway bind -> trusted proxies -> control UI origins -> skill packs
+	// Enrichment pipeline: gateway mode -> OTel metrics -> gateway auth -> device auth -> tailscale -> browser -> gateway bind -> trusted proxies -> control UI origins -> skill packs
+	if enriched, err := enrichConfigWithGatewayMode(configBytes); err == nil {
+		configBytes = enriched
+	}
 	if IsMetricsEnabled(instance) {
 		if enriched, err := enrichConfigWithOTelMetrics(configBytes); err == nil {
 			configBytes = enriched
@@ -459,6 +462,33 @@ func enrichConfigWithBrowser(configJSON []byte) ([]byte, error) {
 
 	browser["profiles"] = profiles
 	config["browser"] = browser
+
+	return json.Marshal(config)
+}
+
+// enrichConfigWithGatewayMode injects gateway.mode=local into the config JSON.
+// Upstream openclaw (>= v2026.5.18) refuses to start without this field,
+// emitting "Gateway start blocked: existing config is missing gateway.mode".
+// The operator always deploys the gateway in-cluster, so "local" is the
+// correct mode. If the user has already set gateway.mode, the config is
+// returned unchanged (user override wins).
+func enrichConfigWithGatewayMode(configJSON []byte) ([]byte, error) {
+	var config map[string]interface{}
+	if err := json.Unmarshal(configJSON, &config); err != nil {
+		return configJSON, nil // not a JSON object, return unchanged
+	}
+
+	gw, _ := config["gateway"].(map[string]interface{})
+	if gw == nil {
+		gw = make(map[string]interface{})
+	}
+
+	if _, ok := gw["mode"]; ok {
+		return configJSON, nil
+	}
+
+	gw["mode"] = GatewayModeLocal
+	config["gateway"] = gw
 
 	return json.Marshal(config)
 }

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2193,6 +2193,54 @@ func TestBuildConfigMap_InvalidJSON_RawPreserved(t *testing.T) {
 	}
 }
 
+// TestBuildConfigMap_InjectsGatewayMode verifies the operator sets
+// gateway.mode=local on a default instance. Upstream openclaw >= v2026.5.18
+// refuses to start without this field.
+func TestBuildConfigMap_InjectsGatewayMode(t *testing.T) {
+	instance := newTestInstance("cm-gateway-mode")
+
+	cm := BuildConfigMap(instance, "tok", nil)
+	content := cm.Data["openclaw.json"]
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+	gw, ok := parsed["gateway"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway key after enrichment")
+	}
+	if gw["mode"] != "local" {
+		t.Errorf("gateway.mode = %v, want %q", gw["mode"], "local")
+	}
+}
+
+// TestBuildConfigMap_PreservesUserGatewayMode verifies the operator does not
+// overwrite a gateway.mode that the user has explicitly set.
+func TestBuildConfigMap_PreservesUserGatewayMode(t *testing.T) {
+	instance := newTestInstance("cm-gateway-mode-user")
+	instance.Spec.Config.Raw = &openclawv1alpha1.RawConfig{
+		RawExtension: runtime.RawExtension{
+			Raw: []byte(`{"gateway":{"mode":"remote"}}`),
+		},
+	}
+
+	cm := BuildConfigMap(instance, "tok", nil)
+	content := cm.Data["openclaw.json"]
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+	gw, ok := parsed["gateway"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected gateway key after enrichment")
+	}
+	if gw["mode"] != "remote" {
+		t.Errorf("gateway.mode = %v, want %q (user override should win)", gw["mode"], "remote")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // BuildConfigMapFromBytes tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Upstream `ghcr.io/openclaw/openclaw:latest` (v2026.5.18, built 2026-05-18) added a boot-time safety check that refuses to start when `gateway.mode` is missing from the config: `Gateway start blocked: existing config is missing gateway.mode`.
- The operator never set this field, so every pod CrashLoops against the current upstream image.
- This is why the e2e suite has been fully red on every PR since 2026-05-18 - including unrelated changes such as #499 (doc-only) and #500 (forcePaths). The "postStart container restart" test was misleading; the smoke test caught the same crash.
- Fix: add a `gateway.mode` enrichment to the configmap pipeline, defaulting to `"local"` (the operator always deploys the gateway in-cluster, never as a remote tunnel). User-supplied `gateway.mode` in `spec.config.raw` is preserved, consistent with every other enrichment.

## Reproduction (before the fix)

```
$ kubectl logs <pod> -c openclaw --previous
2026-05-20T... [gateway] loading configuration…
2026-05-20T... [gateway] resolving authentication…
2026-05-20T... Gateway start blocked: existing config is missing gateway.mode. ...
                set gateway.mode=local manually, or pass --allow-unconfigured.
```

Reproduced locally on a fresh kind cluster with `main` (no PR diffs) using the same setup as CI; pod restart count climbs to 4+ within 90s, identical to the e2e failure mode.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/resources/ -count=1` (added `TestBuildConfigMap_InjectsGatewayMode` and `TestBuildConfigMap_PreservesUserGatewayMode`)
- [ ] E2E in CI - the same failing suite should go green once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)