### PR TITLE
fix: update stale openclaw-rocks org references to paperclipinc

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ dockers_v2:
     ids:
       - manager
     images:
-      - "ghcr.io/openclaw-rocks/openclaw-operator"
+      - "ghcr.io/paperclipinc/openclaw-operator"
     tags:
       - "{{ .Tag }}"
       - "{{ .Major }}.{{ .Minor }}"
@@ -70,5 +70,5 @@ release:
   draft: true
   replace_existing_artifacts: true
   github:
-    owner: openclaw-rocks
+    owner: paperclipinc
     name: openclaw-operator

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Go-based Kubernetes operator for managing OpenClaw instances, built with control
 
 - **Module:** `github.com/openclawrocks/openclaw-operator`
 - **Go version:** 1.25
-- **GitHub:** `openclaw-rocks/openclaw-operator` (GHCR org: `openclaw-rocks`)
+- **GitHub:** `paperclipinc/openclaw-operator` (GHCR org: `paperclipinc`)
 
 ## Commands
 
@@ -202,7 +202,7 @@ Automated via release-please + GoReleaser:
 5. Cosign signs images, SBOM is generated and attested
 6. SBOM uploaded to draft release, then release is published (using PAT)
 7. Published release triggers `operatorhub.yaml`: auto-submits bundle PR to `k8s-operatorhub/community-operators`
-8. Helm chart is packaged and pushed to `oci://ghcr.io/openclaw-rocks/charts`
+8. Helm chart is packaged and pushed to `oci://ghcr.io/paperclipinc/charts`
 
 **Key config files:**
 - `release-please-config.json` — `skip-github-release: true` (GoReleaser manages the release lifecycle)
@@ -214,4 +214,4 @@ Automated via release-please + GoReleaser:
 
 **Manual trigger:** `gh workflow run "OperatorHub Submission" -f tag=vX.Y.Z`
 
-Image: `ghcr.io/openclaw-rocks/openclaw-operator`
+Image: `ghcr.io/paperclipinc/openclaw-operator`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Self-host [OpenClaw](https://openclaw.ai) AI agents on Kubernetes with production-grade security, observability, and lifecycle management.**
 
-OpenClaw is an AI agent platform that acts on your behalf across Telegram, Discord, WhatsApp, and Signal. It manages your inbox, calendar, smart home, and more through 50+ integrations. While [OpenClaw.rocks](https://openclaw.rocks) offers fully managed hosting, this operator lets you run OpenClaw on your own infrastructure with the same operational rigor.
+OpenClaw is an AI agent platform that acts on your behalf across Telegram, Discord, WhatsApp, and Signal. It manages your inbox, calendar, smart home, and more through 50+ integrations. While [Paperclip Inc.](https://github.com/paperclipinc) offers fully managed hosting, this operator lets you run OpenClaw on your own infrastructure with the same operational rigor.
 
 ---
 
@@ -143,7 +143,7 @@ Every request is validated against the instance's allowlist policy. Protected co
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-operator-system \
   --create-namespace
 ```
@@ -156,7 +156,7 @@ helm install openclaw-operator \
 make install
 
 # Deploy the operator
-make deploy IMG=ghcr.io/openclaw-rocks/openclaw-operator:latest
+make deploy IMG=ghcr.io/paperclipinc/openclaw-operator:latest
 ```
 
 </details>
@@ -172,7 +172,7 @@ to that list (plus the operator's own namespace, for backup credentials).
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-operator-system \
   --create-namespace \
   --set 'watchNamespaces={team-a,team-b}'
@@ -185,7 +185,7 @@ SecurityCenter policy), disable chart-managed RBAC:
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-operator-system \
   --create-namespace \
   --set rbac.create=false
@@ -483,8 +483,8 @@ Skill packs bundle multiple files (SKILL.md, scripts, config) into a single inst
 ```yaml
 spec:
   skills:
-    - "pack:openclaw-rocks/skills/image-gen"            # latest from default branch
-    - "pack:openclaw-rocks/skills/image-gen@v1.0.0"     # pinned to tag
+    - "pack:paperclipinc/skills/image-gen"            # latest from default branch
+    - "pack:paperclipinc/skills/image-gen@v1.0.0"     # pinned to tag
     - "pack:myorg/private-skills/custom-tool@main"       # private repo (requires GITHUB_TOKEN)
 ```
 
@@ -1111,7 +1111,7 @@ spec:
         enabled: true
         labels:
           release: kube-prometheus-stack  # must match Prometheus ruleSelector
-        runbookBaseURL: https://openclaw.rocks/docs/runbooks  # default
+        runbookBaseURL: https://github.com/paperclipinc/openclaw-operator/tree/main/docs/runbooks  # default
 ```
 
 Alerts: `OpenClawReconcileErrors`, `OpenClawInstanceDegraded`, `OpenClawSlowReconciliation`, `OpenClawPodCrashLooping`, `OpenClawPodOOMKilled`, `OpenClawPVCNearlyFull`, `OpenClawAutoUpdateRollback`
@@ -1277,7 +1277,7 @@ See the full [roadmap](ROADMAP.md) for details.
 
 ## Don't Want to Self-Host?
 
-[OpenClaw.rocks](https://openclaw.rocks) offers fully managed hosting starting at **EUR 15/mo**. No Kubernetes cluster required. Setup, updates, and 24/7 uptime handled for you.
+[Paperclip Inc.](https://github.com/paperclipinc) offers fully managed hosting starting at **EUR 15/mo**. No Kubernetes cluster required. Setup, updates, and 24/7 uptime handled for you.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@
 # OpenClaw Kubernetes Operator
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Go Report Card](https://goreportcard.com/badge/github.com/OpenClaw-rocks/openclaw-operator)](https://goreportcard.com/report/github.com/OpenClaw-rocks/openclaw-operator)
-[![CI](https://github.com/OpenClaw-rocks/openclaw-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/OpenClaw-rocks/openclaw-operator/actions/workflows/ci.yaml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/paperclipinc/openclaw-operator)](https://goreportcard.com/report/github.com/paperclipinc/openclaw-operator)
+[![CI](https://github.com/paperclipinc/openclaw-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/paperclipinc/openclaw-operator/actions/workflows/ci.yaml)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-1.28%2B-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io)
 [![Go](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go&logoColor=white)](https://go.dev)
 
 **Self-host [OpenClaw](https://openclaw.ai) AI agents on Kubernetes with production-grade security, observability, and lifecycle management.**
 
 OpenClaw is an AI agent platform that acts on your behalf across Telegram, Discord, WhatsApp, and Signal. It manages your inbox, calendar, smart home, and more through 50+ integrations. While [Paperclip Inc.](https://github.com/paperclipinc) offers fully managed hosting, this operator lets you run OpenClaw on your own infrastructure with the same operational rigor.
+
+> **Migration notice (May 2026):** This project moved from the `openclaw-rocks` GitHub org to **`paperclipinc`**. The container registry and Helm chart OCI path changed accordingly:
+>
+> | | Old (no longer available) | New |
+> |---|---|---|
+> | Helm chart | `oci://ghcr.io/openclaw-rocks/charts/openclaw-operator` | `oci://ghcr.io/paperclipinc/charts/openclaw-operator` |
+> | Container image | `ghcr.io/openclaw-rocks/openclaw-operator` | `ghcr.io/paperclipinc/openclaw-operator` |
+>
+> If you pin the image in your values, update `image.repository` to `ghcr.io/paperclipinc/openclaw-operator`.
+> CRD API group (`openclaw.rocks/v1alpha1`) is unchanged — no cluster-side migration needed.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,8 @@ If you discover a security vulnerability in the OpenClaw Kubernetes Operator, pl
 
 ### How to Report
 
-1. Email: Send a detailed report to **security@openclaw.rocks**
-2. GitHub: Use [GitHub's private vulnerability reporting](https://github.com/OpenClaw-rocks/openclaw-operator/security/advisories/new)
+1. Email: Send a detailed report to **jannes@paperclip.inc**
+2. GitHub: Use [GitHub's private vulnerability reporting](https://github.com/paperclipinc/openclaw-operator/security/advisories/new)
 
 ### What to Include
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
 repositoryID: 0ee43d67-67cc-4efb-8b56-ee4fc577cb6c
 owners:
   - name: Jannes Stubbemann
-    email: jannes@openclaw.rocks
+    email: jannes@paperclip.inc

--- a/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
+++ b/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     capabilities: "Auto Pilot"
     categories: "AI/Machine Learning, Developer Tools, Application Runtime"
-    containerImage: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+    containerImage: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
     createdAt: "2026-02-11T00:00:00Z"
     support: OpenClaw.rocks
     repository: https://github.com/OpenClaw-rocks/openclaw-operator
@@ -224,7 +224,7 @@ spec:
       supported: true
   relatedImages:
     - name: openclaw-operator
-      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+      image: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
     - name: openclaw
       image: ghcr.io/openclaw/openclaw:latest
     - name: chromium-sidecar
@@ -588,7 +588,7 @@ spec:
                 terminationGracePeriodSeconds: 10
                 containers:
                   - name: manager
-                    image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+                    image: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
                     command:
                       - /manager
                     args:

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -15,13 +15,13 @@ keywords:
   - llm
   - automation
   - agent
-home: https://openclaw.rocks
-icon: https://openclaw.rocks/favicon.svg
+home: https://github.com/paperclipinc/openclaw-operator
+icon: https://raw.githubusercontent.com/paperclipinc/openclaw-operator/main/docs-site/docs/assets/logo.svg
 sources:
-  - https://github.com/OpenClaw-rocks/openclaw-operator
+  - https://github.com/paperclipinc/openclaw-operator
 maintainers:
   - name: Jannes Stubbemann
-    email: jannes@openclaw.rocks
+    email: jannes@paperclip.inc
     url: https://github.com/stubbi
 kubeVersion: '>=1.28.0-0'
 annotations:
@@ -32,15 +32,15 @@ annotations:
   artifacthub.io/prerelease: 'false'
   artifacthub.io/links: |
     - name: Website
-      url: https://openclaw.rocks
+      url: https://github.com/paperclipinc/openclaw-operator
     - name: Documentation
-      url: https://openclaw.rocks/docs/operator/0.10
+      url: https://github.com/paperclipinc/openclaw-operator/tree/main/docs
     - name: OperatorHub
       url: https://operatorhub.io/operator/openclaw-operator
     - name: Artifact Hub
       url: https://artifacthub.io/packages/olm/community-operators/openclaw-operator
     - name: support
-      url: https://github.com/OpenClaw-rocks/openclaw-operator/issues
+      url: https://github.com/paperclipinc/openclaw-operator/issues
   artifacthub.io/crds: |
     - kind: OpenClawInstance
       version: v1alpha1
@@ -67,7 +67,7 @@ annotations:
             size: 10Gi
   artifacthub.io/images: |
     - name: openclaw-operator
-      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+      image: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
   artifacthub.io/changes: |
     - kind: added
       description: PVC backup-on-delete and restore-from-backup via rclone/S3

--- a/charts/openclaw-operator/values.yaml
+++ b/charts/openclaw-operator/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 # Operator image configuration
 image:
-  repository: ghcr.io/openclaw-rocks/openclaw-operator
+  repository: ghcr.io/paperclipinc/openclaw-operator
   pullPolicy: IfNotPresent
   tag: ""  # Defaults to chart appVersion
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: controller
-    newName: ghcr.io/openclaw-rocks/openclaw-operator
+    newName: ghcr.io/paperclipinc/openclaw-operator
     newTag: latest

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,7 +1,7 @@
 # Docs site for openclaw-operator
 
 This directory contains the mkdocs-material project that publishes
-[openclaw.rocks/docs/operator/](https://openclaw.rocks/docs/operator/latest/).
+[paperclipinc.github.io/openclaw-operator/](https://paperclipinc.github.io/openclaw-operator/latest/).
 
 ## Local preview
 
@@ -42,7 +42,7 @@ run `make api-docs` and commit the result in the same PR.
 out the released tag, runs `mike deploy <minor> latest`, and pushes to
 `gh-pages`. GH Pages serves the result at
 `docs-operator.openclaw.rocks`, and Caddy on the openclaw.rocks box
-reverse-proxies `openclaw.rocks/docs/operator/*` to it.
+reverse-proxies `paperclipinc.github.io/openclaw-operator/*` to it.
 
 ## Republishing a specific tag manually
 

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -1,11 +1,11 @@
 site_name: OpenClaw Operator
-site_url: https://openclaw.rocks/docs/operator/
+site_url: https://paperclipinc.github.io/openclaw-operator/
 site_description: Kubernetes operator for managing OpenClaw AI agent instances with production-grade security, observability, and lifecycle management.
-site_author: OpenClaw.rocks
-repo_url: https://github.com/openclaw-rocks/openclaw-operator
-repo_name: openclaw-rocks/openclaw-operator
+site_author: Paperclip Inc.
+repo_url: https://github.com/paperclipinc/openclaw-operator
+repo_name: paperclipinc/openclaw-operator
 edit_uri: edit/main/docs/
-copyright: Copyright &copy; OpenClaw.rocks
+copyright: Copyright &copy; Paperclip Inc.
 
 docs_dir: ../docs
 exclude_docs: |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -146,7 +146,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -263,7 +263,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -383,7 +383,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -458,7 +458,7 @@ kubectl get storageclass
 ```bash
 # Add the OCI registry (no separate repo add needed for OCI)
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -474,7 +474,7 @@ cd openclaw-operator
 make install
 
 # Deploy the operator
-make deploy IMG=ghcr.io/openclaw-rocks/openclaw-operator:v0.1.0
+make deploy IMG=ghcr.io/paperclipinc/openclaw-operator:v0.1.0
 ```
 
 ### 4. Create an Instance


### PR DESCRIPTION
## Summary

- Fixes all container/Helm registry references from `ghcr.io/openclaw-rocks` → `ghcr.io/paperclipinc`
- Updates GoReleaser release owner, Chart.yaml metadata, docs, README, SECURITY.md, artifacthub, bundle manifests
- CRD API group (`openclaw.rocks`) and operator annotations intentionally preserved (changing those = breaking migration)

Closes #510

## Files changed (12)

| Category | Files |
|----------|-------|
| Release pipeline | `.goreleaser.yaml` |
| Helm chart | `charts/openclaw-operator/Chart.yaml`, `values.yaml` |
| Kustomize | `config/manager/kustomization.yaml` |
| OLM bundle | `bundle/manifests/...clusterserviceversion.yaml` |
| Docs | `README.md`, `docs/deployment.md`, `docs-site/mkdocs.yml`, `docs-site/README.md`, `CLAUDE.md` |
| Metadata | `artifacthub-repo.yml`, `SECURITY.md` |

## Test plan

- [x] Verified no CRD apiVersion/group strings were modified
- [x] Verified no remaining `openclaw-rocks` or `ghcr.io/openclaw-rocks` in non-historical files
- [ ] CI passes
- [ ] After merge + release: `helm pull oci://ghcr.io/paperclipinc/charts/openclaw-operator` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)