### PR TITLE
fix: rename openclaw-rocks → paperclipinc across chart, CI, docs, Go module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Default owners for everything in the repo
-* @OpenClaw-rocks/maintainers
+* @paperclipinc/maintainers
 
 # API changes require additional review
-/api/ @OpenClaw-rocks/maintainers
+/api/ @paperclipinc/maintainers
 
 # Security-related changes
-/internal/webhook/ @OpenClaw-rocks/maintainers
-/internal/security/ @OpenClaw-rocks/maintainers
+/internal/webhook/ @paperclipinc/maintainers
+/internal/security/ @paperclipinc/maintainers

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           # Detect bare r.Update/r.Create calls in the controller that bypass
           # controllerutil.CreateOrUpdate. Only r.Update(ctx, instance) and
           # r.Status().Update(ctx, instance) are allowed (CR-level updates).
-          # See: https://github.com/openclaw-rocks/openclaw-operator/issues/28
+          # See: https://github.com/paperclipinc/openclaw-operator/issues/28
           VIOLATIONS=$(grep -n 'r\.Update(ctx,' internal/controller/openclawinstance_controller.go \
             | grep -v 'instance)' \
             | grep -v '// reconcile-guard:allow' || true)

--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -39,7 +39,7 @@ jobs:
           # Copy and version the CSV
           sed \
             -e "s/openclaw-operator\.v[0-9]\+\.[0-9]\+\.[0-9]\+/openclaw-operator.v${VERSION}/g" \
-            -e "s|ghcr.io/openclaw-rocks/openclaw-operator:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/openclaw-rocks/openclaw-operator:${TAG}|g" \
+            -e "s|ghcr.io/paperclipinc/openclaw-operator:v[0-9]\+\.[0-9]\+\.[0-9]\+|ghcr.io/paperclipinc/openclaw-operator:${TAG}|g" \
             -e "s/createdAt: .*/createdAt: \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"/" \
             -e "s/^  version: [0-9]\+\.[0-9]\+\.[0-9]\+/  version: ${VERSION}/" \
             bundle/manifests/openclaw-operator.v*.clusterserviceversion.yaml \
@@ -96,14 +96,14 @@ jobs:
           ### Update to openclaw-operator
 
           **Version:** ${VERSION}
-          **Operator:** [OpenClaw Kubernetes Operator](https://github.com/openclaw-rocks/openclaw-operator)
+          **Operator:** [OpenClaw Kubernetes Operator](https://github.com/paperclipinc/openclaw-operator)
 
           #### Changes
-          See [release notes](https://github.com/openclaw-rocks/openclaw-operator/releases/tag/v${VERSION}).
+          See [release notes](https://github.com/paperclipinc/openclaw-operator/releases/tag/v${VERSION}).
 
           #### Testing
           - CI tests pass on the source repository
-          - Container image is published and signed at \`ghcr.io/openclaw-rocks/openclaw-operator:v${VERSION}\`
+          - Container image is published and signed at \`ghcr.io/paperclipinc/openclaw-operator:v${VERSION}\`
           EOF
           )"
           else

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,7 +44,7 @@ linters-settings:
       - performance
       - style
   goimports:
-    local-prefixes: github.com/openclawrocks/openclaw-operator
+    local-prefixes: github.com/paperclipinc/openclaw-operator
   govet:
     enable:
       - shadow

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ dockers_v2:
     ids:
       - manager
     images:
-      - "ghcr.io/openclaw-rocks/openclaw-operator"
+      - "ghcr.io/paperclipinc/openclaw-operator"
     tags:
       - "{{ .Tag }}"
       - "{{ .Major }}.{{ .Minor }}"
@@ -70,5 +70,5 @@ release:
   draft: true
   replace_existing_artifacts: true
   github:
-    owner: openclaw-rocks
+    owner: paperclipinc
     name: openclaw-operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,485 +5,485 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.34.4](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.34.3...v0.34.4) (2026-05-21)
+## [0.34.4](https://github.com/paperclipinc/openclaw-operator/compare/v0.34.3...v0.34.4) (2026-05-21)
 
 
 ### Bug Fixes
 
-* **plugins:** install via openclaw CLI to handle workspace:* deps ([#506](https://github.com/openclaw-rocks/openclaw-operator/issues/506)) ([00d08d9](https://github.com/openclaw-rocks/openclaw-operator/commit/00d08d98818e8d533a6de0533ca139aedd930f9f))
+* **plugins:** install via openclaw CLI to handle workspace:* deps ([#506](https://github.com/paperclipinc/openclaw-operator/issues/506)) ([00d08d9](https://github.com/paperclipinc/openclaw-operator/commit/00d08d98818e8d533a6de0533ca139aedd930f9f))
 
-## [0.34.3](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.34.2...v0.34.3) (2026-05-20)
-
-
-### Bug Fixes
-
-* **environment-skill:** document openclaw CLI availability ([#499](https://github.com/openclaw-rocks/openclaw-operator/issues/499)) ([5067192](https://github.com/openclaw-rocks/openclaw-operator/commit/5067192e9d94f9d58dcef2f3e7d38d04fedda582))
-
-## [0.34.2](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.34.1...v0.34.2) (2026-05-20)
+## [0.34.3](https://github.com/paperclipinc/openclaw-operator/compare/v0.34.2...v0.34.3) (2026-05-20)
 
 
 ### Bug Fixes
 
-* **config:** inject gateway.mode=local for openclaw &gt;= v2026.5.18 ([#502](https://github.com/openclaw-rocks/openclaw-operator/issues/502)) ([e114ce7](https://github.com/openclaw-rocks/openclaw-operator/commit/e114ce7291d4798e444e2a0ac18bbf30e50d5cae))
+* **environment-skill:** document openclaw CLI availability ([#499](https://github.com/paperclipinc/openclaw-operator/issues/499)) ([5067192](https://github.com/paperclipinc/openclaw-operator/commit/5067192e9d94f9d58dcef2f3e7d38d04fedda582))
 
-## [0.34.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.34.0...v0.34.1) (2026-05-12)
+## [0.34.2](https://github.com/paperclipinc/openclaw-operator/compare/v0.34.1...v0.34.2) (2026-05-20)
 
 
 ### Bug Fixes
 
-* **docs-site:** correctly detect new CNAME file in gh-pages step ([#490](https://github.com/openclaw-rocks/openclaw-operator/issues/490)) ([deb6b8c](https://github.com/openclaw-rocks/openclaw-operator/commit/deb6b8c2079329ba180d955fcbc135b9fa8c8a03))
+* **config:** inject gateway.mode=local for openclaw &gt;= v2026.5.18 ([#502](https://github.com/paperclipinc/openclaw-operator/issues/502)) ([e114ce7](https://github.com/paperclipinc/openclaw-operator/commit/e114ce7291d4798e444e2a0ac18bbf30e50d5cae))
 
-## [0.34.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.33.0...v0.34.0) (2026-05-12)
+## [0.34.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.34.0...v0.34.1) (2026-05-12)
+
+
+### Bug Fixes
+
+* **docs-site:** correctly detect new CNAME file in gh-pages step ([#490](https://github.com/paperclipinc/openclaw-operator/issues/490)) ([deb6b8c](https://github.com/paperclipinc/openclaw-operator/commit/deb6b8c2079329ba180d955fcbc135b9fa8c8a03))
+
+## [0.34.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.33.0...v0.34.0) (2026-05-12)
 
 
 ### Features
 
-* docs site at openclaw.rocks/docs/operator/ ([#488](https://github.com/openclaw-rocks/openclaw-operator/issues/488)) ([0a6aa43](https://github.com/openclaw-rocks/openclaw-operator/commit/0a6aa43f2c4c88367cadbc0de2e11905f69b272b))
+* docs site at openclaw.rocks/docs/operator/ ([#488](https://github.com/paperclipinc/openclaw-operator/issues/488)) ([0a6aa43](https://github.com/paperclipinc/openclaw-operator/commit/0a6aa43f2c4c88367cadbc0de2e11905f69b272b))
 
-## [0.33.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.32.1...v0.33.0) (2026-05-12)
-
-
-### Features
-
-* shareProcessNamespace (default true) to reap zombies ([#485](https://github.com/openclaw-rocks/openclaw-operator/issues/485)) ([4cbfd4d](https://github.com/openclaw-rocks/openclaw-operator/commit/4cbfd4da821b1b6610cf3f73db7d3401e7087aeb))
-
-## [0.32.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.32.0...v0.32.1) (2026-05-11)
-
-
-### Bug Fixes
-
-* **workspace:** support nested paths in spec.workspace.initialFiles ([#483](https://github.com/openclaw-rocks/openclaw-operator/issues/483)) ([efca189](https://github.com/openclaw-rocks/openclaw-operator/commit/efca189304f89a0005d2c3a1b4c2db55d8af82bf))
-
-## [0.32.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.31.1...v0.32.0) (2026-05-10)
+## [0.33.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.32.1...v0.33.0) (2026-05-12)
 
 
 ### Features
 
-* **chart:** aggregate OpenClaw CRD permissions into admin/edit/view roles ([#480](https://github.com/openclaw-rocks/openclaw-operator/issues/480)) ([8d06f81](https://github.com/openclaw-rocks/openclaw-operator/commit/8d06f81f1e828efa3b53cd180f3d09c8b3265181))
+* shareProcessNamespace (default true) to reap zombies ([#485](https://github.com/paperclipinc/openclaw-operator/issues/485)) ([4cbfd4d](https://github.com/paperclipinc/openclaw-operator/commit/4cbfd4da821b1b6610cf3f73db7d3401e7087aeb))
 
-## [0.31.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.31.0...v0.31.1) (2026-05-08)
+## [0.32.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.32.0...v0.32.1) (2026-05-11)
 
 
 ### Bug Fixes
 
-* **plugins:** install plugins under ~/.openclaw/extensions for auto-discovery ([#477](https://github.com/openclaw-rocks/openclaw-operator/issues/477)) ([de8c1c4](https://github.com/openclaw-rocks/openclaw-operator/commit/de8c1c477d27d978432efc8451b38d8a30e9a8f4))
+* **workspace:** support nested paths in spec.workspace.initialFiles ([#483](https://github.com/paperclipinc/openclaw-operator/issues/483)) ([efca189](https://github.com/paperclipinc/openclaw-operator/commit/efca189304f89a0005d2c3a1b4c2db55d8af82bf))
 
-## [0.31.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.30.0...v0.31.0) (2026-05-05)
+## [0.32.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.31.1...v0.32.0) (2026-05-10)
 
 
 ### Features
 
-* **chart:** allow disabling chart RBAC and scoping operator to namespaces ([#469](https://github.com/openclaw-rocks/openclaw-operator/issues/469)) ([46abfa4](https://github.com/openclaw-rocks/openclaw-operator/commit/46abfa4756b6fcc82cd9b7b9e8a5a85fc4afb7a1))
+* **chart:** aggregate OpenClaw CRD permissions into admin/edit/view roles ([#480](https://github.com/paperclipinc/openclaw-operator/issues/480)) ([8d06f81](https://github.com/paperclipinc/openclaw-operator/commit/8d06f81f1e828efa3b53cd180f3d09c8b3265181))
 
-## [0.30.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.29.0...v0.30.0) (2026-04-24)
+## [0.31.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.31.0...v0.31.1) (2026-05-08)
+
+
+### Bug Fixes
+
+* **plugins:** install plugins under ~/.openclaw/extensions for auto-discovery ([#477](https://github.com/paperclipinc/openclaw-operator/issues/477)) ([de8c1c4](https://github.com/paperclipinc/openclaw-operator/commit/de8c1c477d27d978432efc8451b38d8a30e9a8f4))
+
+## [0.31.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.30.0...v0.31.0) (2026-05-05)
 
 
 ### Features
 
-* **workspace:** add spec.workspace.bootstrap.enabled disable flag ([#465](https://github.com/openclaw-rocks/openclaw-operator/issues/465)) ([67bbf71](https://github.com/openclaw-rocks/openclaw-operator/commit/67bbf7125d6df23ab62ea6fcb59ce4472f25df66))
+* **chart:** allow disabling chart RBAC and scoping operator to namespaces ([#469](https://github.com/paperclipinc/openclaw-operator/issues/469)) ([46abfa4](https://github.com/paperclipinc/openclaw-operator/commit/46abfa4756b6fcc82cd9b7b9e8a5a85fc4afb7a1))
 
-
-### Bug Fixes
-
-* **statefulset:** symlink plugin-runtime-deps/node_modules/openclaw to /app ([#464](https://github.com/openclaw-rocks/openclaw-operator/issues/464)) ([c4c5f50](https://github.com/openclaw-rocks/openclaw-operator/commit/c4c5f50f44a12dfc3676923a11a97fdcb3280d01))
-
-## [0.29.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.28.1...v0.29.0) (2026-04-23)
+## [0.30.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.29.0...v0.30.0) (2026-04-24)
 
 
 ### Features
 
-* **cluster-defaults:** add OpenClawClusterDefaults singleton CRD ([#460](https://github.com/openclaw-rocks/openclaw-operator/issues/460)) ([0e3f6bc](https://github.com/openclaw-rocks/openclaw-operator/commit/0e3f6bc9b82a78855d1b6c896342ec21e0ae181b))
-
-## [0.28.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.28.0...v0.28.1) (2026-04-21)
+* **workspace:** add spec.workspace.bootstrap.enabled disable flag ([#465](https://github.com/paperclipinc/openclaw-operator/issues/465)) ([67bbf71](https://github.com/paperclipinc/openclaw-operator/commit/67bbf7125d6df23ab62ea6fcb59ce4472f25df66))
 
 
 ### Bug Fixes
 
-* **statefulset:** mount ~/.config as writable PVC subPath ([#458](https://github.com/openclaw-rocks/openclaw-operator/issues/458)) ([5ab8c08](https://github.com/openclaw-rocks/openclaw-operator/commit/5ab8c081bb1ce98e7668bbf39b3a4772e13aec9f))
+* **statefulset:** symlink plugin-runtime-deps/node_modules/openclaw to /app ([#464](https://github.com/paperclipinc/openclaw-operator/issues/464)) ([c4c5f50](https://github.com/paperclipinc/openclaw-operator/commit/c4c5f50f44a12dfc3676923a11a97fdcb3280d01))
 
-## [0.28.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.27.1...v0.28.0) (2026-04-17)
+## [0.29.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.28.1...v0.29.0) (2026-04-23)
 
 
 ### Features
 
-* **skillpacks:** install packs from plain git repos without skillpack.json ([#454](https://github.com/openclaw-rocks/openclaw-operator/issues/454)) ([78b92d7](https://github.com/openclaw-rocks/openclaw-operator/commit/78b92d73d7495d481121961bfc0591717009b008))
+* **cluster-defaults:** add OpenClawClusterDefaults singleton CRD ([#460](https://github.com/paperclipinc/openclaw-operator/issues/460)) ([0e3f6bc](https://github.com/paperclipinc/openclaw-operator/commit/0e3f6bc9b82a78855d1b6c896342ec21e0ae181b))
 
-## [0.27.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.27.0...v0.27.1) (2026-04-17)
+## [0.28.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.28.0...v0.28.1) (2026-04-21)
 
 
 ### Bug Fixes
 
-* **init:** mount full data volume in init-uv/init-pip for hostPath PVCs ([#450](https://github.com/openclaw-rocks/openclaw-operator/issues/450)) ([2eaaea9](https://github.com/openclaw-rocks/openclaw-operator/commit/2eaaea9dc1f468f3cc1806a2fc4466e297bc4df2))
+* **statefulset:** mount ~/.config as writable PVC subPath ([#458](https://github.com/paperclipinc/openclaw-operator/issues/458)) ([5ab8c08](https://github.com/paperclipinc/openclaw-operator/commit/5ab8c081bb1ce98e7668bbf39b3a4772e13aec9f))
 
-## [0.27.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.26.2...v0.27.0) (2026-04-14)
+## [0.28.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.27.1...v0.28.0) (2026-04-17)
 
 
 ### Features
 
-* **helm:** add logLevel value to control operator log verbosity ([#445](https://github.com/openclaw-rocks/openclaw-operator/issues/445)) ([4cab3f2](https://github.com/openclaw-rocks/openclaw-operator/commit/4cab3f274a24e9c4c89e0d19156c56e1e63f0b77))
+* **skillpacks:** install packs from plain git repos without skillpack.json ([#454](https://github.com/paperclipinc/openclaw-operator/issues/454)) ([78b92d7](https://github.com/paperclipinc/openclaw-operator/commit/78b92d73d7495d481121961bfc0591717009b008))
+
+## [0.27.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.27.0...v0.27.1) (2026-04-17)
 
 
 ### Bug Fixes
 
-* preserve third-party annotations and labels when reconciling managed resources ([#447](https://github.com/openclaw-rocks/openclaw-operator/issues/447)) ([3711bce](https://github.com/openclaw-rocks/openclaw-operator/commit/3711bce50b6de870d9f36c651bceacf0f044f5f9))
+* **init:** mount full data volume in init-uv/init-pip for hostPath PVCs ([#450](https://github.com/paperclipinc/openclaw-operator/issues/450)) ([2eaaea9](https://github.com/paperclipinc/openclaw-operator/commit/2eaaea9dc1f468f3cc1806a2fc4466e297bc4df2))
 
-## [0.26.2](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.26.1...v0.26.2) (2026-04-09)
-
-
-### Bug Fixes
-
-* **backup:** use --skip-links instead of --copy-links in rclone ([#430](https://github.com/openclaw-rocks/openclaw-operator/issues/430)) ([fd7b65e](https://github.com/openclaw-rocks/openclaw-operator/commit/fd7b65ea8f28c2b0cadcedda397be9acef844b1d))
-
-## [0.26.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.26.0...v0.26.1) (2026-04-09)
-
-
-### Bug Fixes
-
-* **helm:** always pass --metrics-secure flag to operator binary ([#440](https://github.com/openclaw-rocks/openclaw-operator/issues/440)) ([b202def](https://github.com/openclaw-rocks/openclaw-operator/commit/b202def1245cd9b5a15732cb61b00eb18fea6d3a))
-
-## [0.26.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.25.2...v0.26.0) (2026-04-09)
+## [0.27.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.26.2...v0.27.0) (2026-04-14)
 
 
 ### Features
 
-* exclude workspace from config-hash to skip unnecessary restarts ([#432](https://github.com/openclaw-rocks/openclaw-operator/issues/432)) ([586e11f](https://github.com/openclaw-rocks/openclaw-operator/commit/586e11fca48cac8edb8a732edcf65a9910dcf64a))
+* **helm:** add logLevel value to control operator log verbosity ([#445](https://github.com/paperclipinc/openclaw-operator/issues/445)) ([4cab3f2](https://github.com/paperclipinc/openclaw-operator/commit/4cab3f274a24e9c4c89e0d19156c56e1e63f0b77))
 
 
 ### Bug Fixes
 
-* remove env token injection in trusted-proxy mode ([#434](https://github.com/openclaw-rocks/openclaw-operator/issues/434)) ([6daae12](https://github.com/openclaw-rocks/openclaw-operator/commit/6daae12a204d6db1ba50a0c2e1660af5e53a281d))
+* preserve third-party annotations and labels when reconciling managed resources ([#447](https://github.com/paperclipinc/openclaw-operator/issues/447)) ([3711bce](https://github.com/paperclipinc/openclaw-operator/commit/3711bce50b6de870d9f36c651bceacf0f044f5f9))
 
-## [0.25.2](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.25.1...v0.25.2) (2026-04-06)
-
-
-### Bug Fixes
-
-* remove token injection in trusted-proxy mode ([#428](https://github.com/openclaw-rocks/openclaw-operator/issues/428)) ([9486685](https://github.com/openclaw-rocks/openclaw-operator/commit/948668545fed95ac010820c2176b680e693689c0))
-
-## [0.25.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.25.0...v0.25.1) (2026-04-01)
+## [0.26.2](https://github.com/paperclipinc/openclaw-operator/compare/v0.26.1...v0.26.2) (2026-04-09)
 
 
 ### Bug Fixes
 
-* **plugins:** set NODE_PATH so OpenClaw discovers installed plugins ([#425](https://github.com/openclaw-rocks/openclaw-operator/issues/425)) ([c43ee12](https://github.com/openclaw-rocks/openclaw-operator/commit/c43ee124839ff49d67ba00441b8074fbac09774e))
+* **backup:** use --skip-links instead of --copy-links in rclone ([#430](https://github.com/paperclipinc/openclaw-operator/issues/430)) ([fd7b65e](https://github.com/paperclipinc/openclaw-operator/commit/fd7b65ea8f28c2b0cadcedda397be9acef844b1d))
 
-## [0.25.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.24.2...v0.25.0) (2026-03-31)
+## [0.26.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.26.0...v0.26.1) (2026-04-09)
+
+
+### Bug Fixes
+
+* **helm:** always pass --metrics-secure flag to operator binary ([#440](https://github.com/paperclipinc/openclaw-operator/issues/440)) ([b202def](https://github.com/paperclipinc/openclaw-operator/commit/b202def1245cd9b5a15732cb61b00eb18fea6d3a))
+
+## [0.26.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.25.2...v0.26.0) (2026-04-09)
 
 
 ### Features
 
-* expose internal scale-to-zero as public spec.suspended API ([#420](https://github.com/openclaw-rocks/openclaw-operator/issues/420)) ([3933d97](https://github.com/openclaw-rocks/openclaw-operator/commit/3933d9794aadae70f67f764195c4cfc8a91db435))
-
-## [0.24.2](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.24.1...v0.24.2) (2026-03-30)
+* exclude workspace from config-hash to skip unnecessary restarts ([#432](https://github.com/paperclipinc/openclaw-operator/issues/432)) ([586e11f](https://github.com/paperclipinc/openclaw-operator/commit/586e11fca48cac8edb8a732edcf65a9910dcf64a))
 
 
 ### Bug Fixes
 
-* remove accidental worktree gitlinks breaking kustomize remote refs ([#417](https://github.com/openclaw-rocks/openclaw-operator/issues/417)) ([9a2b5aa](https://github.com/openclaw-rocks/openclaw-operator/commit/9a2b5aa7b32adf4cd73c27dee1dd15f9c2e0f9d0))
+* remove env token injection in trusted-proxy mode ([#434](https://github.com/paperclipinc/openclaw-operator/issues/434)) ([6daae12](https://github.com/paperclipinc/openclaw-operator/commit/6daae12a204d6db1ba50a0c2e1660af5e53a281d))
 
-## [0.24.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.24.0...v0.24.1) (2026-03-26)
+## [0.25.2](https://github.com/paperclipinc/openclaw-operator/compare/v0.25.1...v0.25.2) (2026-04-06)
 
 
 ### Bug Fixes
 
-* **chromium:** suppress container permission warnings ([#415](https://github.com/openclaw-rocks/openclaw-operator/issues/415)) ([43741dc](https://github.com/openclaw-rocks/openclaw-operator/commit/43741dc48930bb2711f38e3add76fb44e78e4f0e))
+* remove token injection in trusted-proxy mode ([#428](https://github.com/paperclipinc/openclaw-operator/issues/428)) ([9486685](https://github.com/paperclipinc/openclaw-operator/commit/948668545fed95ac010820c2176b680e693689c0))
 
-## [0.24.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.23.2...v0.24.0) (2026-03-25)
+## [0.25.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.25.0...v0.25.1) (2026-04-01)
+
+
+### Bug Fixes
+
+* **plugins:** set NODE_PATH so OpenClaw discovers installed plugins ([#425](https://github.com/paperclipinc/openclaw-operator/issues/425)) ([c43ee12](https://github.com/paperclipinc/openclaw-operator/commit/c43ee124839ff49d67ba00441b8074fbac09774e))
+
+## [0.25.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.24.2...v0.25.0) (2026-03-31)
 
 
 ### Features
 
-* add native OTLP metrics export for the operator ([#410](https://github.com/openclaw-rocks/openclaw-operator/issues/410)) ([94b2a04](https://github.com/openclaw-rocks/openclaw-operator/commit/94b2a04d333ecfaf4a7a008be1f05583088e5abf))
+* expose internal scale-to-zero as public spec.suspended API ([#420](https://github.com/paperclipinc/openclaw-operator/issues/420)) ([3933d97](https://github.com/paperclipinc/openclaw-operator/commit/3933d9794aadae70f67f764195c4cfc8a91db435))
 
-## [0.23.2](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.23.1...v0.23.2) (2026-03-25)
-
-
-### Bug Fixes
-
-* **security:** harden pod security contexts and enforce resource limits ([#408](https://github.com/openclaw-rocks/openclaw-operator/issues/408)) ([3b328a2](https://github.com/openclaw-rocks/openclaw-operator/commit/3b328a2c5b8460d1eb4cc2b644902ee1376a1bf9))
-
-## [0.23.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.23.0...v0.23.1) (2026-03-25)
+## [0.24.2](https://github.com/paperclipinc/openclaw-operator/compare/v0.24.1...v0.24.2) (2026-03-30)
 
 
 ### Bug Fixes
 
-* **chromium:** override entrypoint to fix unquoted $@ in upstream run.sh ([#407](https://github.com/openclaw-rocks/openclaw-operator/issues/407)) ([21b03e5](https://github.com/openclaw-rocks/openclaw-operator/commit/21b03e5dba087f96bf97777ebc365d21d6c0500d))
+* remove accidental worktree gitlinks breaking kustomize remote refs ([#417](https://github.com/paperclipinc/openclaw-operator/issues/417)) ([9a2b5aa](https://github.com/paperclipinc/openclaw-operator/commit/9a2b5aa7b32adf4cd73c27dee1dd15f9c2e0f9d0))
 
-## [0.23.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.22.2...v0.23.0) (2026-03-24)
+## [0.24.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.24.0...v0.24.1) (2026-03-26)
+
+
+### Bug Fixes
+
+* **chromium:** suppress container permission warnings ([#415](https://github.com/paperclipinc/openclaw-operator/issues/415)) ([43741dc](https://github.com/paperclipinc/openclaw-operator/commit/43741dc48930bb2711f38e3add76fb44e78e4f0e))
+
+## [0.24.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.23.2...v0.24.0) (2026-03-25)
 
 
 ### Features
 
-* add spec.workspace.configMapRef and additionalWorkspaces for multi-agent support ([#395](https://github.com/openclaw-rocks/openclaw-operator/issues/395)) ([8fe107a](https://github.com/openclaw-rocks/openclaw-operator/commit/8fe107a8ec6808d0a64580c77e7109187a5cc248))
+* add native OTLP metrics export for the operator ([#410](https://github.com/paperclipinc/openclaw-operator/issues/410)) ([94b2a04](https://github.com/paperclipinc/openclaw-operator/commit/94b2a04d333ecfaf4a7a008be1f05583088e5abf))
+
+## [0.23.2](https://github.com/paperclipinc/openclaw-operator/compare/v0.23.1...v0.23.2) (2026-03-25)
 
 
 ### Bug Fixes
 
-* **backup:** add --copy-links to rclone to include symlinks ([#400](https://github.com/openclaw-rocks/openclaw-operator/issues/400)) ([8ffb8e8](https://github.com/openclaw-rocks/openclaw-operator/commit/8ffb8e8668a178facaffdc215c8029b81c5b35f4))
-* **chromium:** use run.sh entrypoint and migrate deprecated image ([#397](https://github.com/openclaw-rocks/openclaw-operator/issues/397)) ([e74dffd](https://github.com/openclaw-rocks/openclaw-operator/commit/e74dffd6a80a52c7acf6a1b988c4f95e17ccfd65))
-* **controller:** normalize UpdateStrategy.RollingUpdate to stop continuous reconcile loop ([#403](https://github.com/openclaw-rocks/openclaw-operator/issues/403)) ([0df4bcb](https://github.com/openclaw-rocks/openclaw-operator/commit/0df4bcb1e9b410b76ab950d5dc492d62e866cd73))
-* **e2e:** stabilize flaky CDP integration screenshot test ([#405](https://github.com/openclaw-rocks/openclaw-operator/issues/405)) ([2b441af](https://github.com/openclaw-rocks/openclaw-operator/commit/2b441af81304a284ba068b17fe7315b2b85a950d))
-* preserve user-set gateway auth mode in config enrichment ([#404](https://github.com/openclaw-rocks/openclaw-operator/issues/404)) ([337eb72](https://github.com/openclaw-rocks/openclaw-operator/commit/337eb72a3fc889e3ccf38c0247ab2eb34f632772))
+* **security:** harden pod security contexts and enforce resource limits ([#408](https://github.com/paperclipinc/openclaw-operator/issues/408)) ([3b328a2](https://github.com/paperclipinc/openclaw-operator/commit/3b328a2c5b8460d1eb4cc2b644902ee1376a1bf9))
 
-## [0.11.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.30...v0.11.0) (2026-03-10)
+## [0.23.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.23.0...v0.23.1) (2026-03-25)
+
+
+### Bug Fixes
+
+* **chromium:** override entrypoint to fix unquoted $@ in upstream run.sh ([#407](https://github.com/paperclipinc/openclaw-operator/issues/407)) ([21b03e5](https://github.com/paperclipinc/openclaw-operator/commit/21b03e5dba087f96bf97777ebc365d21d6c0500d))
+
+## [0.23.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.22.2...v0.23.0) (2026-03-24)
 
 
 ### Features
 
-* add chromium CDP proxy to inject anti-bot Chrome launch args ([1e30d22](https://github.com/openclaw-rocks/openclaw-operator/commit/1e30d2243fc0efc01de9fbd7281cae3cc3e1bd8f)), closes [#270](https://github.com/openclaw-rocks/openclaw-operator/issues/270)
-* chromium CDP proxy for anti-bot launch args ([e7d9d86](https://github.com/openclaw-rocks/openclaw-operator/commit/e7d9d86d97035cb8bcd4e4331a24f9b9c3c23951))
-* **resources:** add logging and validation for resource quantities ([0dc3508](https://github.com/openclaw-rocks/openclaw-operator/commit/0dc35087c96bebb78c720b9dd803e77e8e64340a))
-* validate existing PVC and improve resource parsing ([351c87a](https://github.com/openclaw-rocks/openclaw-operator/commit/351c87a7b07ebe86338631d7018347ccfee10b2d))
+* add spec.workspace.configMapRef and additionalWorkspaces for multi-agent support ([#395](https://github.com/paperclipinc/openclaw-operator/issues/395)) ([8fe107a](https://github.com/paperclipinc/openclaw-operator/commit/8fe107a8ec6808d0a64580c77e7109187a5cc248))
 
 
 ### Bug Fixes
 
-* handle merge commits in release tag creation step ([370edf6](https://github.com/openclaw-rocks/openclaw-operator/commit/370edf6e2459147e06d6cf69d5e4f225f0e98da0))
-* handle merge commits in release tag creation step ([07b45bf](https://github.com/openclaw-rocks/openclaw-operator/commit/07b45bfb2d1e2ca321e760921862542861c8974e))
-* resolve chromium sidecar startup race and NetworkPolicy gaps ([8579946](https://github.com/openclaw-rocks/openclaw-operator/commit/857994691db3206fd904732f03d6fa677a809253))
-* resolve chromium sidecar startup race and NetworkPolicy gaps ([8e7fc99](https://github.com/openclaw-rocks/openclaw-operator/commit/8e7fc99f6dc4cbedf264587547c07411534eefa5)), closes [#270](https://github.com/openclaw-rocks/openclaw-operator/issues/270)
+* **backup:** add --copy-links to rclone to include symlinks ([#400](https://github.com/paperclipinc/openclaw-operator/issues/400)) ([8ffb8e8](https://github.com/paperclipinc/openclaw-operator/commit/8ffb8e8668a178facaffdc215c8029b81c5b35f4))
+* **chromium:** use run.sh entrypoint and migrate deprecated image ([#397](https://github.com/paperclipinc/openclaw-operator/issues/397)) ([e74dffd](https://github.com/paperclipinc/openclaw-operator/commit/e74dffd6a80a52c7acf6a1b988c4f95e17ccfd65))
+* **controller:** normalize UpdateStrategy.RollingUpdate to stop continuous reconcile loop ([#403](https://github.com/paperclipinc/openclaw-operator/issues/403)) ([0df4bcb](https://github.com/paperclipinc/openclaw-operator/commit/0df4bcb1e9b410b76ab950d5dc492d62e866cd73))
+* **e2e:** stabilize flaky CDP integration screenshot test ([#405](https://github.com/paperclipinc/openclaw-operator/issues/405)) ([2b441af](https://github.com/paperclipinc/openclaw-operator/commit/2b441af81304a284ba068b17fe7315b2b85a950d))
+* preserve user-set gateway auth mode in config enrichment ([#404](https://github.com/paperclipinc/openclaw-operator/issues/404)) ([337eb72](https://github.com/paperclipinc/openclaw-operator/commit/337eb72a3fc889e3ccf38c0247ab2eb34f632772))
 
-## [0.10.30](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.29...v0.10.30) (2026-03-10)
+## [0.11.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.30...v0.11.0) (2026-03-10)
 
 
 ### Features
 
-* idempotent ClawHub skill installs for persistent storage ([b02c5f2](https://github.com/openclaw-rocks/openclaw-operator/commit/b02c5f244315759afb0dfd55f2fd78754af7cd5b))
+* add chromium CDP proxy to inject anti-bot Chrome launch args ([1e30d22](https://github.com/paperclipinc/openclaw-operator/commit/1e30d2243fc0efc01de9fbd7281cae3cc3e1bd8f)), closes [#270](https://github.com/paperclipinc/openclaw-operator/issues/270)
+* chromium CDP proxy for anti-bot launch args ([e7d9d86](https://github.com/paperclipinc/openclaw-operator/commit/e7d9d86d97035cb8bcd4e4331a24f9b9c3c23951))
+* **resources:** add logging and validation for resource quantities ([0dc3508](https://github.com/paperclipinc/openclaw-operator/commit/0dc35087c96bebb78c720b9dd803e77e8e64340a))
+* validate existing PVC and improve resource parsing ([351c87a](https://github.com/paperclipinc/openclaw-operator/commit/351c87a7b07ebe86338631d7018347ccfee10b2d))
 
 
 ### Bug Fixes
 
-* add activeDeadlineSeconds and startingDeadlineSeconds to backup CronJob ([d5a5a0a](https://github.com/openclaw-rocks/openclaw-operator/commit/d5a5a0ad27a6928dce9a5118a89b785df64cfe17)), closes [#286](https://github.com/openclaw-rocks/openclaw-operator/issues/286)
-* add deadline safeguards to backup CronJob ([5f3715d](https://github.com/openclaw-rocks/openclaw-operator/commit/5f3715d77ecdef97f998b18a1ecabb4d15d9a680))
-* add K8s API port 6443 egress when tailscale is enabled ([5968cc1](https://github.com/openclaw-rocks/openclaw-operator/commit/5968cc1cd28706cc811ed695cdeefacd5c6e2784))
-* inject POD_NAMESPACE env via Downward API ([b793c0f](https://github.com/openclaw-rocks/openclaw-operator/commit/b793c0ff352abd1182a7e7d1847f3105a02aad94))
-* inject POD_NAMESPACE env via Downward API in operator deployment ([8b5ae53](https://github.com/openclaw-rocks/openclaw-operator/commit/8b5ae53605cc1a79981ddeb9d95973bc3b5c92cd)), closes [#281](https://github.com/openclaw-rocks/openclaw-operator/issues/281)
+* handle merge commits in release tag creation step ([370edf6](https://github.com/paperclipinc/openclaw-operator/commit/370edf6e2459147e06d6cf69d5e4f225f0e98da0))
+* handle merge commits in release tag creation step ([07b45bf](https://github.com/paperclipinc/openclaw-operator/commit/07b45bfb2d1e2ca321e760921862542861c8974e))
+* resolve chromium sidecar startup race and NetworkPolicy gaps ([8579946](https://github.com/paperclipinc/openclaw-operator/commit/857994691db3206fd904732f03d6fa677a809253))
+* resolve chromium sidecar startup race and NetworkPolicy gaps ([8e7fc99](https://github.com/paperclipinc/openclaw-operator/commit/8e7fc99f6dc4cbedf264587547c07411534eefa5)), closes [#270](https://github.com/paperclipinc/openclaw-operator/issues/270)
 
-## [0.10.29](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.28...v0.10.29) (2026-03-09)
-
-
-### Bug Fixes
-
-* increase chromium startup probe timeout from 2s to 5s ([#279](https://github.com/openclaw-rocks/openclaw-operator/issues/279)) ([2ccf3ec](https://github.com/openclaw-rocks/openclaw-operator/commit/2ccf3ec252daefa846e9c7c027dd40f870b996a6)), closes [#270](https://github.com/openclaw-rocks/openclaw-operator/issues/270)
-
-## [0.10.28](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.27...v0.10.28) (2026-03-09)
-
-
-### Bug Fixes
-
-* auto-inject 127.0.0.0/8 into gateway.trustedProxies ([#276](https://github.com/openclaw-rocks/openclaw-operator/issues/276)) ([e7ecc5c](https://github.com/openclaw-rocks/openclaw-operator/commit/e7ecc5c6f1c50b1b6f26621b9e99d22266dadd34)), closes [#274](https://github.com/openclaw-rocks/openclaw-operator/issues/274)
-* handle OCI pagination in registry tag resolver ([#275](https://github.com/openclaw-rocks/openclaw-operator/issues/275)) ([2fcf3dd](https://github.com/openclaw-rocks/openclaw-operator/commit/2fcf3dd41e2e3c24a440fed155019ae664b36255))
-
-## [0.10.27](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.26...v0.10.27) (2026-03-09)
+## [0.10.30](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.29...v0.10.30) (2026-03-10)
 
 
 ### Features
 
-* support persistent Chromium browser profiles via PVC ([#271](https://github.com/openclaw-rocks/openclaw-operator/issues/271)) ([9d80414](https://github.com/openclaw-rocks/openclaw-operator/commit/9d804148da28ad4ab1640d1da15d7b100ade4347)), closes [#267](https://github.com/openclaw-rocks/openclaw-operator/issues/267)
-
-## [0.10.26](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.25...v0.10.26) (2026-03-09)
-
-
-### Features
-
-* persist Tailscale state across pod restarts via TS_KUBE_SECRET ([#265](https://github.com/openclaw-rocks/openclaw-operator/issues/265)) ([0a9601d](https://github.com/openclaw-rocks/openclaw-operator/commit/0a9601d06972f6d507705c350987d1c12d6c5759)), closes [#262](https://github.com/openclaw-rocks/openclaw-operator/issues/262)
+* idempotent ClawHub skill installs for persistent storage ([b02c5f2](https://github.com/paperclipinc/openclaw-operator/commit/b02c5f244315759afb0dfd55f2fd78754af7cd5b))
 
 
 ### Bug Fixes
 
-* remove invalid llmConfig from webhook validation and docs ([#261](https://github.com/openclaw-rocks/openclaw-operator/issues/261)) ([e8f7399](https://github.com/openclaw-rocks/openclaw-operator/commit/e8f739940e92d2a0a5b2b27ee7cadcab07df6026))
-* respect pod-level runAsNonRoot in container security contexts ([#266](https://github.com/openclaw-rocks/openclaw-operator/issues/266)) ([ad21b4c](https://github.com/openclaw-rocks/openclaw-operator/commit/ad21b4c59260117ed9d2f13ba8278fb4fe7e56d1)), closes [#263](https://github.com/openclaw-rocks/openclaw-operator/issues/263)
+* add activeDeadlineSeconds and startingDeadlineSeconds to backup CronJob ([d5a5a0a](https://github.com/paperclipinc/openclaw-operator/commit/d5a5a0ad27a6928dce9a5118a89b785df64cfe17)), closes [#286](https://github.com/paperclipinc/openclaw-operator/issues/286)
+* add deadline safeguards to backup CronJob ([5f3715d](https://github.com/paperclipinc/openclaw-operator/commit/5f3715d77ecdef97f998b18a1ecabb4d15d9a680))
+* add K8s API port 6443 egress when tailscale is enabled ([5968cc1](https://github.com/paperclipinc/openclaw-operator/commit/5968cc1cd28706cc811ed695cdeefacd5c6e2784))
+* inject POD_NAMESPACE env via Downward API ([b793c0f](https://github.com/paperclipinc/openclaw-operator/commit/b793c0ff352abd1182a7e7d1847f3105a02aad94))
+* inject POD_NAMESPACE env via Downward API in operator deployment ([8b5ae53](https://github.com/paperclipinc/openclaw-operator/commit/8b5ae53605cc1a79981ddeb9d95973bc3b5c92cd)), closes [#281](https://github.com/paperclipinc/openclaw-operator/issues/281)
 
-## [0.10.25](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.24...v0.10.25) (2026-03-07)
-
-
-### Features
-
-* enable writable package installs on read-only root filesystem ([#254](https://github.com/openclaw-rocks/openclaw-operator/issues/254)) ([8d5f4ba](https://github.com/openclaw-rocks/openclaw-operator/commit/8d5f4ba3795980589a566cf2866d3af2bf588987))
-
-## [0.10.24](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.23...v0.10.24) (2026-03-06)
+## [0.10.29](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.28...v0.10.29) (2026-03-09)
 
 
 ### Bug Fixes
 
-* use service DNS for Chromium CDP URL instead of localhost ([#252](https://github.com/openclaw-rocks/openclaw-operator/issues/252)) ([70b9ec4](https://github.com/openclaw-rocks/openclaw-operator/commit/70b9ec48c156cc20d9c9eaf6837e39350f232a40))
+* increase chromium startup probe timeout from 2s to 5s ([#279](https://github.com/paperclipinc/openclaw-operator/issues/279)) ([2ccf3ec](https://github.com/paperclipinc/openclaw-operator/commit/2ccf3ec252daefa846e9c7c027dd40f870b996a6)), closes [#270](https://github.com/paperclipinc/openclaw-operator/issues/270)
 
-## [0.10.23](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.22...v0.10.23) (2026-03-06)
-
-
-### Bug Fixes
-
-* correct attachOnly field placement in browser configuration ([#250](https://github.com/openclaw-rocks/openclaw-operator/issues/250)) ([04d44af](https://github.com/openclaw-rocks/openclaw-operator/commit/04d44af9ff6a0ac9792e9746e23ed2b6d028aa4d))
-
-## [0.10.22](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.21...v0.10.22) (2026-03-05)
-
-
-### Features
-
-* inject default anti-bot-detection flags for Chromium sidecar ([#247](https://github.com/openclaw-rocks/openclaw-operator/issues/247)) ([4a38b4d](https://github.com/openclaw-rocks/openclaw-operator/commit/4a38b4dd7a8b73108448d189561dd565bf10a633))
-
-## [0.10.21](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.20...v0.10.21) (2026-03-05)
+## [0.10.28](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.27...v0.10.28) (2026-03-09)
 
 
 ### Bug Fixes
 
-* disable device auth for Control UI in K8s environments ([#238](https://github.com/openclaw-rocks/openclaw-operator/issues/238)) ([c5c420c](https://github.com/openclaw-rocks/openclaw-operator/commit/c5c420c40d0f01c58e49d5d535f60f5db4b0651d)), closes [#233](https://github.com/openclaw-rocks/openclaw-operator/issues/233)
-* propagate nodeSelector and tolerations to backup CronJob pods ([#245](https://github.com/openclaw-rocks/openclaw-operator/issues/245)) ([98ef456](https://github.com/openclaw-rocks/openclaw-operator/commit/98ef4568d4156f5ce27c9d253dd3da6bf9350c12)), closes [#244](https://github.com/openclaw-rocks/openclaw-operator/issues/244)
-* use localhost for Chromium CDP URL to support IPv6 clusters ([#243](https://github.com/openclaw-rocks/openclaw-operator/issues/243)) ([08dc2c2](https://github.com/openclaw-rocks/openclaw-operator/commit/08dc2c27ce98dc0b54b18a295ec0823d74b90d44)), closes [#228](https://github.com/openclaw-rocks/openclaw-operator/issues/228)
+* auto-inject 127.0.0.0/8 into gateway.trustedProxies ([#276](https://github.com/paperclipinc/openclaw-operator/issues/276)) ([e7ecc5c](https://github.com/paperclipinc/openclaw-operator/commit/e7ecc5c6f1c50b1b6f26621b9e99d22266dadd34)), closes [#274](https://github.com/paperclipinc/openclaw-operator/issues/274)
+* handle OCI pagination in registry tag resolver ([#275](https://github.com/paperclipinc/openclaw-operator/issues/275)) ([2fcf3dd](https://github.com/paperclipinc/openclaw-operator/commit/2fcf3dd41e2e3c24a440fed155019ae664b36255))
 
-## [0.10.20](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.19...v0.10.20) (2026-03-04)
-
-
-### Features
-
-* add attachOnly and disable device auth in browser profiles ([#236](https://github.com/openclaw-rocks/openclaw-operator/issues/236)) ([44dd9ce](https://github.com/openclaw-rocks/openclaw-operator/commit/44dd9cee63c5a442f0dca2e6c1144224489b7ff3))
-
-## [0.10.19](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.18...v0.10.19) (2026-03-04)
+## [0.10.27](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.26...v0.10.27) (2026-03-09)
 
 
 ### Features
 
-* auto-inject gateway.controlUi.allowedOrigins ([#234](https://github.com/openclaw-rocks/openclaw-operator/issues/234)) ([#235](https://github.com/openclaw-rocks/openclaw-operator/issues/235)) ([46b5445](https://github.com/openclaw-rocks/openclaw-operator/commit/46b5445e299e4af252568fcb043bb390373ca12c))
+* support persistent Chromium browser profiles via PVC ([#271](https://github.com/paperclipinc/openclaw-operator/issues/271)) ([9d80414](https://github.com/paperclipinc/openclaw-operator/commit/9d804148da28ad4ab1640d1da15d7b100ade4347)), closes [#267](https://github.com/paperclipinc/openclaw-operator/issues/267)
 
-## [0.10.18](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.17...v0.10.18) (2026-03-03)
+## [0.10.26](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.25...v0.10.26) (2026-03-09)
 
 
 ### Features
 
-* switch probes from exec to httpGet ([#231](https://github.com/openclaw-rocks/openclaw-operator/issues/231)) ([d5b7754](https://github.com/openclaw-rocks/openclaw-operator/commit/d5b7754400e3b1d3e41c57237b03aefc8bc76525))
-
-## [0.10.17](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.16...v0.10.17) (2026-03-02)
+* persist Tailscale state across pod restarts via TS_KUBE_SECRET ([#265](https://github.com/paperclipinc/openclaw-operator/issues/265)) ([0a9601d](https://github.com/paperclipinc/openclaw-operator/commit/0a9601d06972f6d507705c350987d1c12d6c5759)), closes [#262](https://github.com/paperclipinc/openclaw-operator/issues/262)
 
 
 ### Bug Fixes
 
-* add configurable timeout for BackingUp phase to prevent stuck instances ([#226](https://github.com/openclaw-rocks/openclaw-operator/issues/226)) ([778a642](https://github.com/openclaw-rocks/openclaw-operator/commit/778a6426d4f2b26845f110887b3bc41f02ceb0ac)), closes [#224](https://github.com/openclaw-rocks/openclaw-operator/issues/224)
-* make skill pack resolution non-blocking to prevent provisioning failures ([#227](https://github.com/openclaw-rocks/openclaw-operator/issues/227)) ([ffb2485](https://github.com/openclaw-rocks/openclaw-operator/commit/ffb24852190e66844c9fe0f69ba28db8c9fade8f)), closes [#225](https://github.com/openclaw-rocks/openclaw-operator/issues/225)
+* remove invalid llmConfig from webhook validation and docs ([#261](https://github.com/paperclipinc/openclaw-operator/issues/261)) ([e8f7399](https://github.com/paperclipinc/openclaw-operator/commit/e8f739940e92d2a0a5b2b27ee7cadcab07df6026))
+* respect pod-level runAsNonRoot in container security contexts ([#266](https://github.com/paperclipinc/openclaw-operator/issues/266)) ([ad21b4c](https://github.com/paperclipinc/openclaw-operator/commit/ad21b4c59260117ed9d2f13ba8278fb4fe7e56d1)), closes [#263](https://github.com/paperclipinc/openclaw-operator/issues/263)
 
-## [0.10.16](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.15...v0.10.16) (2026-03-01)
-
-
-### Bug Fixes
-
-* propagate nodeSelector and tolerations to backup/restore Jobs ([#221](https://github.com/openclaw-rocks/openclaw-operator/issues/221)) ([342c7ae](https://github.com/openclaw-rocks/openclaw-operator/commit/342c7ae032cad88b5f4e15009c2accca8fd1ddb6))
-
-## [0.10.15](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.14...v0.10.15) (2026-02-27)
+## [0.10.25](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.24...v0.10.25) (2026-03-07)
 
 
 ### Features
 
-* GitHub-based skill pack resolution ([#218](https://github.com/openclaw-rocks/openclaw-operator/issues/218)) ([077dfa6](https://github.com/openclaw-rocks/openclaw-operator/commit/077dfa6b52ec71c312a1e9338788b331d2cfd27a))
+* enable writable package installs on read-only root filesystem ([#254](https://github.com/paperclipinc/openclaw-operator/issues/254)) ([8d5f4ba](https://github.com/paperclipinc/openclaw-operator/commit/8d5f4ba3795980589a566cf2866d3af2bf588987))
 
-## [0.10.14](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.13...v0.10.14) (2026-02-27)
-
-
-### Bug Fixes
-
-* prevent StatefulSet reconciliation loop from server-side defaults ([#217](https://github.com/openclaw-rocks/openclaw-operator/issues/217)) ([0617b46](https://github.com/openclaw-rocks/openclaw-operator/commit/0617b46147cf6221ece0020b613ec8364ec8bc53))
-
-## [0.10.13](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.12...v0.10.13) (2026-02-27)
+## [0.10.24](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.23...v0.10.24) (2026-03-06)
 
 
 ### Bug Fixes
 
-* use Node.js TCP connect for health probes instead of wget ([#215](https://github.com/openclaw-rocks/openclaw-operator/issues/215)) ([ecb7474](https://github.com/openclaw-rocks/openclaw-operator/commit/ecb7474c2ea40775b3a5df5f008b299d319f0d75))
+* use service DNS for Chromium CDP URL instead of localhost ([#252](https://github.com/paperclipinc/openclaw-operator/issues/252)) ([70b9ec4](https://github.com/paperclipinc/openclaw-operator/commit/70b9ec48c156cc20d9c9eaf6837e39350f232a40))
 
-## [0.10.12](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.11...v0.10.12) (2026-02-26)
+## [0.10.23](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.22...v0.10.23) (2026-03-06)
+
+
+### Bug Fixes
+
+* correct attachOnly field placement in browser configuration ([#250](https://github.com/paperclipinc/openclaw-operator/issues/250)) ([04d44af](https://github.com/paperclipinc/openclaw-operator/commit/04d44af9ff6a0ac9792e9746e23ed2b6d028aa4d))
+
+## [0.10.22](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.21...v0.10.22) (2026-03-05)
 
 
 ### Features
 
-* add periodic scheduled backups via CronJob ([#207](https://github.com/openclaw-rocks/openclaw-operator/issues/207)) ([bf29965](https://github.com/openclaw-rocks/openclaw-operator/commit/bf299650b8aad631fdfa6c3427f414bda9b7d511))
+* inject default anti-bot-detection flags for Chromium sidecar ([#247](https://github.com/paperclipinc/openclaw-operator/issues/247)) ([4a38b4d](https://github.com/paperclipinc/openclaw-operator/commit/4a38b4dd7a8b73108448d189561dd565bf10a633))
+
+## [0.10.21](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.20...v0.10.21) (2026-03-05)
 
 
 ### Bug Fixes
 
-* add optional S3_REGION support for MinIO backups ([#212](https://github.com/openclaw-rocks/openclaw-operator/issues/212)) ([c5e96c8](https://github.com/openclaw-rocks/openclaw-operator/commit/c5e96c89660566d5b35a137d8a098ca18cf51234)), closes [#205](https://github.com/openclaw-rocks/openclaw-operator/issues/205)
-* **chromium:** pass extraArgs via DEFAULT_LAUNCH_ARGS env instead of container Args ([#211](https://github.com/openclaw-rocks/openclaw-operator/issues/211)) ([ec79758](https://github.com/openclaw-rocks/openclaw-operator/commit/ec797581aa068ebd48cb55c11de048f41024c826)), closes [#209](https://github.com/openclaw-rocks/openclaw-operator/issues/209)
+* disable device auth for Control UI in K8s environments ([#238](https://github.com/paperclipinc/openclaw-operator/issues/238)) ([c5c420c](https://github.com/paperclipinc/openclaw-operator/commit/c5c420c40d0f01c58e49d5d535f60f5db4b0651d)), closes [#233](https://github.com/paperclipinc/openclaw-operator/issues/233)
+* propagate nodeSelector and tolerations to backup CronJob pods ([#245](https://github.com/paperclipinc/openclaw-operator/issues/245)) ([98ef456](https://github.com/paperclipinc/openclaw-operator/commit/98ef4568d4156f5ce27c9d253dd3da6bf9350c12)), closes [#244](https://github.com/paperclipinc/openclaw-operator/issues/244)
+* use localhost for Chromium CDP URL to support IPv6 clusters ([#243](https://github.com/paperclipinc/openclaw-operator/issues/243)) ([08dc2c2](https://github.com/paperclipinc/openclaw-operator/commit/08dc2c27ce98dc0b54b18a295ec0823d74b90d44)), closes [#228](https://github.com/paperclipinc/openclaw-operator/issues/228)
 
-## [0.10.11](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.10...v0.10.11) (2026-02-26)
+## [0.10.20](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.19...v0.10.20) (2026-03-04)
+
+
+### Features
+
+* add attachOnly and disable device auth in browser profiles ([#236](https://github.com/paperclipinc/openclaw-operator/issues/236)) ([44dd9ce](https://github.com/paperclipinc/openclaw-operator/commit/44dd9cee63c5a442f0dca2e6c1144224489b7ff3))
+
+## [0.10.19](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.18...v0.10.19) (2026-03-04)
+
+
+### Features
+
+* auto-inject gateway.controlUi.allowedOrigins ([#234](https://github.com/paperclipinc/openclaw-operator/issues/234)) ([#235](https://github.com/paperclipinc/openclaw-operator/issues/235)) ([46b5445](https://github.com/paperclipinc/openclaw-operator/commit/46b5445e299e4af252568fcb043bb390373ca12c))
+
+## [0.10.18](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.17...v0.10.18) (2026-03-03)
+
+
+### Features
+
+* switch probes from exec to httpGet ([#231](https://github.com/paperclipinc/openclaw-operator/issues/231)) ([d5b7754](https://github.com/paperclipinc/openclaw-operator/commit/d5b7754400e3b1d3e41c57237b03aefc8bc76525))
+
+## [0.10.17](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.16...v0.10.17) (2026-03-02)
 
 
 ### Bug Fixes
 
-* store plaintext username and password in auto-generated basic auth secret ([#208](https://github.com/openclaw-rocks/openclaw-operator/issues/208)) ([179b4a6](https://github.com/openclaw-rocks/openclaw-operator/commit/179b4a60b94cf2e7fae5ddb293c9bfcc534f40ea)), closes [#201](https://github.com/openclaw-rocks/openclaw-operator/issues/201)
+* add configurable timeout for BackingUp phase to prevent stuck instances ([#226](https://github.com/paperclipinc/openclaw-operator/issues/226)) ([778a642](https://github.com/paperclipinc/openclaw-operator/commit/778a6426d4f2b26845f110887b3bc41f02ceb0ac)), closes [#224](https://github.com/paperclipinc/openclaw-operator/issues/224)
+* make skill pack resolution non-blocking to prevent provisioning failures ([#227](https://github.com/paperclipinc/openclaw-operator/issues/227)) ([ffb2485](https://github.com/paperclipinc/openclaw-operator/commit/ffb24852190e66844c9fe0f69ba28db8c9fade8f)), closes [#225](https://github.com/paperclipinc/openclaw-operator/issues/225)
 
-## [0.10.10](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.9...v0.10.10) (2026-02-26)
-
-
-### Features
-
-* add performance benchmarks for resource builders ([#197](https://github.com/openclaw-rocks/openclaw-operator/issues/197)) ([41efb29](https://github.com/openclaw-rocks/openclaw-operator/commit/41efb29b1de83aa74520f06a6d0dd4483eb08dcc))
-
-## [0.10.9](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.8...v0.10.9) (2026-02-26)
-
-
-### Features
-
-* add Operator SDK scorecard testing ([#198](https://github.com/openclaw-rocks/openclaw-operator/issues/198)) ([3b44d9a](https://github.com/openclaw-rocks/openclaw-operator/commit/3b44d9a4f4533988be44cca2f809ab70a2c93fc7))
-* add topology spread constraints support ([#196](https://github.com/openclaw-rocks/openclaw-operator/issues/196)) ([98ba176](https://github.com/openclaw-rocks/openclaw-operator/commit/98ba176822bc72e1a27497ab66f122715ac024fc))
-
-## [0.10.8](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.7...v0.10.8) (2026-02-26)
-
-
-### Features
-
-* **chromium:** add extraArgs and extraEnv fields to ChromiumSpec ([#187](https://github.com/openclaw-rocks/openclaw-operator/issues/187)) ([2878482](https://github.com/openclaw-rocks/openclaw-operator/commit/2878482029cf0d4f4f4976cacbb594c66bb8a339))
-* **chromium:** add extraArgs/extraEnv to ChromiumSpec, fix issues [#189](https://github.com/openclaw-rocks/openclaw-operator/issues/189)-[#193](https://github.com/openclaw-rocks/openclaw-operator/issues/193) ([#194](https://github.com/openclaw-rocks/openclaw-operator/issues/194)) ([cba8d1a](https://github.com/openclaw-rocks/openclaw-operator/commit/cba8d1a66c972a434d182fd80e815a44e6e79990))
-
-## [0.10.7](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.6...v0.10.7) (2026-02-25)
+## [0.10.16](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.15...v0.10.16) (2026-03-01)
 
 
 ### Bug Fixes
 
-* resolve chromium sidecar port conflict and unreachable CDP ([#183](https://github.com/openclaw-rocks/openclaw-operator/issues/183)) ([2d3d212](https://github.com/openclaw-rocks/openclaw-operator/commit/2d3d2127e6f2ee2566e748e993b5aceae22c80a4)), closes [#180](https://github.com/openclaw-rocks/openclaw-operator/issues/180)
+* propagate nodeSelector and tolerations to backup/restore Jobs ([#221](https://github.com/paperclipinc/openclaw-operator/issues/221)) ([342c7ae](https://github.com/paperclipinc/openclaw-operator/commit/342c7ae032cad88b5f4e15009c2accca8fd1ddb6))
 
-## [0.10.6](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.5...v0.10.6) (2026-02-24)
-
-
-### Bug Fixes
-
-* make Probes a pointer type to accept null/omitted values ([#181](https://github.com/openclaw-rocks/openclaw-operator/issues/181)) ([df42069](https://github.com/openclaw-rocks/openclaw-operator/commit/df42069191e451a756ced3b74faaed3cf44acab0)), closes [#179](https://github.com/openclaw-rocks/openclaw-operator/issues/179)
-
-## [0.10.5](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.4...v0.10.5) (2026-02-24)
+## [0.10.15](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.14...v0.10.15) (2026-02-27)
 
 
 ### Features
 
-* add Tailscale sidecar for working tailnet integration ([#177](https://github.com/openclaw-rocks/openclaw-operator/issues/177)) ([d956925](https://github.com/openclaw-rocks/openclaw-operator/commit/d956925bb60437aa67ff82f961228933e286e0fc))
+* GitHub-based skill pack resolution ([#218](https://github.com/paperclipinc/openclaw-operator/issues/218)) ([077dfa6](https://github.com/paperclipinc/openclaw-operator/commit/077dfa6b52ec71c312a1e9338788b331d2cfd27a))
 
-## [0.10.4](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.3...v0.10.4) (2026-02-24)
-
-
-### Features
-
-* add nginx gateway proxy sidecar for loopback-bound gateway ([#175](https://github.com/openclaw-rocks/openclaw-operator/issues/175)) ([a52383b](https://github.com/openclaw-rocks/openclaw-operator/commit/a52383b121de80229b1ae7b03622cd10561ac5a5))
-
-## [0.10.3](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.2...v0.10.3) (2026-02-23)
+## [0.10.14](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.13...v0.10.14) (2026-02-27)
 
 
 ### Bug Fixes
 
-* auto-set gateway.bind=loopback and use exec probes for Tailscale serve/funnel ([#170](https://github.com/openclaw-rocks/openclaw-operator/issues/170)) ([e26694b](https://github.com/openclaw-rocks/openclaw-operator/commit/e26694b5bd38d7bd4a286f1e6caf5d3438bf6366)), closes [#167](https://github.com/openclaw-rocks/openclaw-operator/issues/167)
-* expose metrics port in Service, StatefulSet, and ServiceMonitor ([#169](https://github.com/openclaw-rocks/openclaw-operator/issues/169)) ([049d097](https://github.com/openclaw-rocks/openclaw-operator/commit/049d097d81a42493a224bf129a243162685b1e5d)), closes [#166](https://github.com/openclaw-rocks/openclaw-operator/issues/166)
-* move CRDs from Helm crds/ to templates/ for upgrade support ([#173](https://github.com/openclaw-rocks/openclaw-operator/issues/173)) ([599b394](https://github.com/openclaw-rocks/openclaw-operator/commit/599b39450a91a858e15d5ccf5f702db0c2c82392)), closes [#168](https://github.com/openclaw-rocks/openclaw-operator/issues/168)
+* prevent StatefulSet reconciliation loop from server-side defaults ([#217](https://github.com/paperclipinc/openclaw-operator/issues/217)) ([0617b46](https://github.com/paperclipinc/openclaw-operator/commit/0617b46147cf6221ece0020b613ec8364ec8bc53))
 
-## [0.10.2](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.1...v0.10.2) (2026-02-23)
+## [0.10.13](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.12...v0.10.13) (2026-02-27)
 
 
 ### Bug Fixes
 
-* break reconciliation tight loop caused by unconditional status writes ([#163](https://github.com/openclaw-rocks/openclaw-operator/issues/163)) ([88921b7](https://github.com/openclaw-rocks/openclaw-operator/commit/88921b7fafe3e703441030d49885dc3277c61213)), closes [#161](https://github.com/openclaw-rocks/openclaw-operator/issues/161)
-* use single-quoted node -e argument in merge mode scripts ([#164](https://github.com/openclaw-rocks/openclaw-operator/issues/164)) ([a661ed8](https://github.com/openclaw-rocks/openclaw-operator/commit/a661ed8d7fbaa91bbedcd9a198dbe74d52c27444)), closes [#162](https://github.com/openclaw-rocks/openclaw-operator/issues/162)
+* use Node.js TCP connect for health probes instead of wget ([#215](https://github.com/paperclipinc/openclaw-operator/issues/215)) ([ecb7474](https://github.com/paperclipinc/openclaw-operator/commit/ecb7474c2ea40775b3a5df5f008b299d319f0d75))
 
-## [0.10.1](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.10.0...v0.10.1) (2026-02-22)
+## [0.10.12](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.11...v0.10.12) (2026-02-26)
 
 
 ### Features
 
-* add ttyd web terminal managed sidecar ([#159](https://github.com/openclaw-rocks/openclaw-operator/issues/159)) ([a9e1bce](https://github.com/openclaw-rocks/openclaw-operator/commit/a9e1bceb9897391cdf75459c6b4beaddce64c201))
+* add periodic scheduled backups via CronJob ([#207](https://github.com/paperclipinc/openclaw-operator/issues/207)) ([bf29965](https://github.com/paperclipinc/openclaw-operator/commit/bf299650b8aad631fdfa6c3427f414bda9b7d511))
 
-## [0.10.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.23...v0.10.0) (2026-02-22)
+
+### Bug Fixes
+
+* add optional S3_REGION support for MinIO backups ([#212](https://github.com/paperclipinc/openclaw-operator/issues/212)) ([c5e96c8](https://github.com/paperclipinc/openclaw-operator/commit/c5e96c89660566d5b35a137d8a098ca18cf51234)), closes [#205](https://github.com/paperclipinc/openclaw-operator/issues/205)
+* **chromium:** pass extraArgs via DEFAULT_LAUNCH_ARGS env instead of container Args ([#211](https://github.com/paperclipinc/openclaw-operator/issues/211)) ([ec79758](https://github.com/paperclipinc/openclaw-operator/commit/ec797581aa068ebd48cb55c11de048f41024c826)), closes [#209](https://github.com/paperclipinc/openclaw-operator/issues/209)
+
+## [0.10.11](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.10...v0.10.11) (2026-02-26)
+
+
+### Bug Fixes
+
+* store plaintext username and password in auto-generated basic auth secret ([#208](https://github.com/paperclipinc/openclaw-operator/issues/208)) ([179b4a6](https://github.com/paperclipinc/openclaw-operator/commit/179b4a60b94cf2e7fae5ddb293c9bfcc534f40ea)), closes [#201](https://github.com/paperclipinc/openclaw-operator/issues/201)
+
+## [0.10.10](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.9...v0.10.10) (2026-02-26)
+
+
+### Features
+
+* add performance benchmarks for resource builders ([#197](https://github.com/paperclipinc/openclaw-operator/issues/197)) ([41efb29](https://github.com/paperclipinc/openclaw-operator/commit/41efb29b1de83aa74520f06a6d0dd4483eb08dcc))
+
+## [0.10.9](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.8...v0.10.9) (2026-02-26)
+
+
+### Features
+
+* add Operator SDK scorecard testing ([#198](https://github.com/paperclipinc/openclaw-operator/issues/198)) ([3b44d9a](https://github.com/paperclipinc/openclaw-operator/commit/3b44d9a4f4533988be44cca2f809ab70a2c93fc7))
+* add topology spread constraints support ([#196](https://github.com/paperclipinc/openclaw-operator/issues/196)) ([98ba176](https://github.com/paperclipinc/openclaw-operator/commit/98ba176822bc72e1a27497ab66f122715ac024fc))
+
+## [0.10.8](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.7...v0.10.8) (2026-02-26)
+
+
+### Features
+
+* **chromium:** add extraArgs and extraEnv fields to ChromiumSpec ([#187](https://github.com/paperclipinc/openclaw-operator/issues/187)) ([2878482](https://github.com/paperclipinc/openclaw-operator/commit/2878482029cf0d4f4f4976cacbb594c66bb8a339))
+* **chromium:** add extraArgs/extraEnv to ChromiumSpec, fix issues [#189](https://github.com/paperclipinc/openclaw-operator/issues/189)-[#193](https://github.com/paperclipinc/openclaw-operator/issues/193) ([#194](https://github.com/paperclipinc/openclaw-operator/issues/194)) ([cba8d1a](https://github.com/paperclipinc/openclaw-operator/commit/cba8d1a66c972a434d182fd80e815a44e6e79990))
+
+## [0.10.7](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.6...v0.10.7) (2026-02-25)
+
+
+### Bug Fixes
+
+* resolve chromium sidecar port conflict and unreachable CDP ([#183](https://github.com/paperclipinc/openclaw-operator/issues/183)) ([2d3d212](https://github.com/paperclipinc/openclaw-operator/commit/2d3d2127e6f2ee2566e748e993b5aceae22c80a4)), closes [#180](https://github.com/paperclipinc/openclaw-operator/issues/180)
+
+## [0.10.6](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.5...v0.10.6) (2026-02-24)
+
+
+### Bug Fixes
+
+* make Probes a pointer type to accept null/omitted values ([#181](https://github.com/paperclipinc/openclaw-operator/issues/181)) ([df42069](https://github.com/paperclipinc/openclaw-operator/commit/df42069191e451a756ced3b74faaed3cf44acab0)), closes [#179](https://github.com/paperclipinc/openclaw-operator/issues/179)
+
+## [0.10.5](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.4...v0.10.5) (2026-02-24)
+
+
+### Features
+
+* add Tailscale sidecar for working tailnet integration ([#177](https://github.com/paperclipinc/openclaw-operator/issues/177)) ([d956925](https://github.com/paperclipinc/openclaw-operator/commit/d956925bb60437aa67ff82f961228933e286e0fc))
+
+## [0.10.4](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.3...v0.10.4) (2026-02-24)
+
+
+### Features
+
+* add nginx gateway proxy sidecar for loopback-bound gateway ([#175](https://github.com/paperclipinc/openclaw-operator/issues/175)) ([a52383b](https://github.com/paperclipinc/openclaw-operator/commit/a52383b121de80229b1ae7b03622cd10561ac5a5))
+
+## [0.10.3](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.2...v0.10.3) (2026-02-23)
+
+
+### Bug Fixes
+
+* auto-set gateway.bind=loopback and use exec probes for Tailscale serve/funnel ([#170](https://github.com/paperclipinc/openclaw-operator/issues/170)) ([e26694b](https://github.com/paperclipinc/openclaw-operator/commit/e26694b5bd38d7bd4a286f1e6caf5d3438bf6366)), closes [#167](https://github.com/paperclipinc/openclaw-operator/issues/167)
+* expose metrics port in Service, StatefulSet, and ServiceMonitor ([#169](https://github.com/paperclipinc/openclaw-operator/issues/169)) ([049d097](https://github.com/paperclipinc/openclaw-operator/commit/049d097d81a42493a224bf129a243162685b1e5d)), closes [#166](https://github.com/paperclipinc/openclaw-operator/issues/166)
+* move CRDs from Helm crds/ to templates/ for upgrade support ([#173](https://github.com/paperclipinc/openclaw-operator/issues/173)) ([599b394](https://github.com/paperclipinc/openclaw-operator/commit/599b39450a91a858e15d5ccf5f702db0c2c82392)), closes [#168](https://github.com/paperclipinc/openclaw-operator/issues/168)
+
+## [0.10.2](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.1...v0.10.2) (2026-02-23)
+
+
+### Bug Fixes
+
+* break reconciliation tight loop caused by unconditional status writes ([#163](https://github.com/paperclipinc/openclaw-operator/issues/163)) ([88921b7](https://github.com/paperclipinc/openclaw-operator/commit/88921b7fafe3e703441030d49885dc3277c61213)), closes [#161](https://github.com/paperclipinc/openclaw-operator/issues/161)
+* use single-quoted node -e argument in merge mode scripts ([#164](https://github.com/paperclipinc/openclaw-operator/issues/164)) ([a661ed8](https://github.com/paperclipinc/openclaw-operator/commit/a661ed8d7fbaa91bbedcd9a198dbe74d52c27444)), closes [#162](https://github.com/paperclipinc/openclaw-operator/issues/162)
+
+## [0.10.1](https://github.com/paperclipinc/openclaw-operator/compare/v0.10.0...v0.10.1) (2026-02-22)
+
+
+### Features
+
+* add ttyd web terminal managed sidecar ([#159](https://github.com/paperclipinc/openclaw-operator/issues/159)) ([a9e1bce](https://github.com/paperclipinc/openclaw-operator/commit/a9e1bceb9897391cdf75459c6b4beaddce64c201))
+
+## [0.10.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.23...v0.10.0) (2026-02-22)
 
 
 ### ⚠ BREAKING CHANGES
@@ -492,179 +492,179 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-* rename B2/Backblaze to generic S3-compatible storage ([#157](https://github.com/openclaw-rocks/openclaw-operator/issues/157)) ([df76683](https://github.com/openclaw-rocks/openclaw-operator/commit/df766839d6fdef920dd85960e46f6a4d2299bc9f))
+* rename B2/Backblaze to generic S3-compatible storage ([#157](https://github.com/paperclipinc/openclaw-operator/issues/157)) ([df76683](https://github.com/paperclipinc/openclaw-operator/commit/df766839d6fdef920dd85960e46f6a4d2299bc9f))
 
-## [0.9.23](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.22...v0.9.23) (2026-02-22)
-
-
-### Features
-
-* add HPA auto-scaling and Auto Pilot capability level ([#155](https://github.com/openclaw-rocks/openclaw-operator/issues/155)) ([024e51a](https://github.com/openclaw-rocks/openclaw-operator/commit/024e51aac294851ae0c9102d89c3ab38e9768d59))
-
-## [0.9.22](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.21...v0.9.22) (2026-02-22)
+## [0.9.23](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.22...v0.9.23) (2026-02-22)
 
 
 ### Features
 
-* add OpenClawSelfConfig CRD for agent self-modification ([#146](https://github.com/openclaw-rocks/openclaw-operator/issues/146)) ([2351737](https://github.com/openclaw-rocks/openclaw-operator/commit/235173750618afd32e64c571604c3bf753add2ef))
+* add HPA auto-scaling and Auto Pilot capability level ([#155](https://github.com/paperclipinc/openclaw-operator/issues/155)) ([024e51a](https://github.com/paperclipinc/openclaw-operator/commit/024e51aac294851ae0c9102d89c3ab38e9768d59))
 
-## [0.9.21](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.20...v0.9.21) (2026-02-21)
-
-
-### Bug Fixes
-
-* set CSV capabilities to Deep Insights (Level 4) ([#152](https://github.com/openclaw-rocks/openclaw-operator/issues/152)) ([1fe72ed](https://github.com/openclaw-rocks/openclaw-operator/commit/1fe72ed7369e3cc73255c7a6cde2dfb6ac841b39))
-
-## [0.9.20](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.19...v0.9.20) (2026-02-21)
+## [0.9.22](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.21...v0.9.22) (2026-02-22)
 
 
 ### Features
 
-* add Level 4 Deep Insights - auto-provisioned PrometheusRule and Grafana dashboards ([#149](https://github.com/openclaw-rocks/openclaw-operator/issues/149)) ([3c46765](https://github.com/openclaw-rocks/openclaw-operator/commit/3c46765f5e86a24ca904b58be1fce863cfdce4ff))
+* add OpenClawSelfConfig CRD for agent self-modification ([#146](https://github.com/paperclipinc/openclaw-operator/issues/146)) ([2351737](https://github.com/paperclipinc/openclaw-operator/commit/235173750618afd32e64c571604c3bf753add2ef))
 
-## [0.9.19](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.18...v0.9.19) (2026-02-21)
+## [0.9.21](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.20...v0.9.21) (2026-02-21)
+
+
+### Bug Fixes
+
+* set CSV capabilities to Deep Insights (Level 4) ([#152](https://github.com/paperclipinc/openclaw-operator/issues/152)) ([1fe72ed](https://github.com/paperclipinc/openclaw-operator/commit/1fe72ed7369e3cc73255c7a6cde2dfb6ac841b39))
+
+## [0.9.20](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.19...v0.9.20) (2026-02-21)
 
 
 ### Features
 
-* add custom service ports and ingress backend port support ([#144](https://github.com/openclaw-rocks/openclaw-operator/issues/144)) ([#145](https://github.com/openclaw-rocks/openclaw-operator/issues/145)) ([d0604c1](https://github.com/openclaw-rocks/openclaw-operator/commit/d0604c141889c37fb957c002ef7aeca7cecee10c))
+* add Level 4 Deep Insights - auto-provisioned PrometheusRule and Grafana dashboards ([#149](https://github.com/paperclipinc/openclaw-operator/issues/149)) ([3c46765](https://github.com/paperclipinc/openclaw-operator/commit/3c46765f5e86a24ca904b58be1fce863cfdce4ff))
 
-## [0.9.18](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.17...v0.9.18) (2026-02-20)
-
-
-### Features
-
-* improve OperatorHub and ArtifactHub listing quality ([#142](https://github.com/openclaw-rocks/openclaw-operator/issues/142)) ([b15937c](https://github.com/openclaw-rocks/openclaw-operator/commit/b15937c87da175cf72f1b7981c6bcef1b8330bfe))
-
-## [0.9.17](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.16...v0.9.17) (2026-02-20)
-
-
-### Bug Fixes
-
-* configMapRef bypasses gateway auth enrichment ([#138](https://github.com/openclaw-rocks/openclaw-operator/issues/138)) ([1322d5e](https://github.com/openclaw-rocks/openclaw-operator/commit/1322d5e8e3141a9c5a4ea7298ddc0149d2a1d11c))
-
-## [0.9.16](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.15...v0.9.16) (2026-02-20)
+## [0.9.19](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.18...v0.9.19) (2026-02-21)
 
 
 ### Features
 
-* support npm packages in skills field and disable lifecycle scripts ([#137](https://github.com/openclaw-rocks/openclaw-operator/issues/137)) ([a9db9d0](https://github.com/openclaw-rocks/openclaw-operator/commit/a9db9d091a357bca07b260ed6e7f9560917f9e9d)), closes [#131](https://github.com/openclaw-rocks/openclaw-operator/issues/131) [#91](https://github.com/openclaw-rocks/openclaw-operator/issues/91)
+* add custom service ports and ingress backend port support ([#144](https://github.com/paperclipinc/openclaw-operator/issues/144)) ([#145](https://github.com/paperclipinc/openclaw-operator/issues/145)) ([d0604c1](https://github.com/paperclipinc/openclaw-operator/commit/d0604c141889c37fb957c002ef7aeca7cecee10c))
 
-## [0.9.15](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.14...v0.9.15) (2026-02-19)
-
-
-### Bug Fixes
-
-* prevent StatefulSet spec drift on every reconcile ([#133](https://github.com/openclaw-rocks/openclaw-operator/issues/133)) ([b6fa7b3](https://github.com/openclaw-rocks/openclaw-operator/commit/b6fa7b3f257e51593fb01aaa42a8e4b89e9de50b))
-
-## [0.9.14](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.13...v0.9.14) (2026-02-19)
-
-
-### Bug Fixes
-
-* restore config on container restart via postStart hook ([#128](https://github.com/openclaw-rocks/openclaw-operator/issues/128)) ([38ea2c5](https://github.com/openclaw-rocks/openclaw-operator/commit/38ea2c53adc1a4ba71bf307780b8c415d18fad6d))
-
-## [0.9.13](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.12...v0.9.13) (2026-02-19)
-
-
-### Bug Fixes
-
-* inject browser config for Chromium sidecar ([#126](https://github.com/openclaw-rocks/openclaw-operator/issues/126)) ([570344e](https://github.com/openclaw-rocks/openclaw-operator/commit/570344e167702092bd7e5640d7c1aff0340e01e1))
-* use copyFileSync instead of renameSync in merge mode init container ([#121](https://github.com/openclaw-rocks/openclaw-operator/issues/121)) ([72bd962](https://github.com/openclaw-rocks/openclaw-operator/commit/72bd962d492fdfd3ccc525523e3bb6f12de3ac70)), closes [#120](https://github.com/openclaw-rocks/openclaw-operator/issues/120)
-
-## [0.9.12](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.11...v0.9.12) (2026-02-18)
+## [0.9.18](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.17...v0.9.18) (2026-02-20)
 
 
 ### Features
 
-* add first-class Ollama sidecar support ([860225e](https://github.com/openclaw-rocks/openclaw-operator/commit/860225e8e656d228218056ed6be8937f897ba582))
-* add native Tailscale integration via CRD fields ([#115](https://github.com/openclaw-rocks/openclaw-operator/issues/115)) ([c3a2ae4](https://github.com/openclaw-rocks/openclaw-operator/commit/c3a2ae49b73836780aebb192fdfe931d445a1751))
+* improve OperatorHub and ArtifactHub listing quality ([#142](https://github.com/paperclipinc/openclaw-operator/issues/142)) ([b15937c](https://github.com/paperclipinc/openclaw-operator/commit/b15937c87da175cf72f1b7981c6bcef1b8330bfe))
 
-## [0.9.11](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.10...v0.9.11) (2026-02-18)
-
-
-### Bug Fixes
-
-* resolve flaky backup/restore tests and autorelease label API ([#117](https://github.com/openclaw-rocks/openclaw-operator/issues/117)) ([da7a2a5](https://github.com/openclaw-rocks/openclaw-operator/commit/da7a2a58f0cb82bac091e954179efdd4827d2b78))
-
-## [0.9.10](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.9...v0.9.10) (2026-02-18)
+## [0.9.17](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.16...v0.9.17) (2026-02-20)
 
 
 ### Bug Fixes
 
-* emit provider-aware ingress annotations based on className ([#109](https://github.com/openclaw-rocks/openclaw-operator/issues/109)) ([#110](https://github.com/openclaw-rocks/openclaw-operator/issues/110)) ([c040df6](https://github.com/openclaw-rocks/openclaw-operator/commit/c040df69f77e95ea8e284e84ad7bf86cd03df1ed))
-* graceful deletion when B2 backup credentials are not configured ([#112](https://github.com/openclaw-rocks/openclaw-operator/issues/112)) ([10b59be](https://github.com/openclaw-rocks/openclaw-operator/commit/10b59be0368d2f4c2ad5069621ecf62609d924eb)), closes [#111](https://github.com/openclaw-rocks/openclaw-operator/issues/111)
-* use shell-capable images for distroless init containers ([#108](https://github.com/openclaw-rocks/openclaw-operator/issues/108)) ([2c87e68](https://github.com/openclaw-rocks/openclaw-operator/commit/2c87e68e2e8b6bb94c95fb2ae751084843ecf2af))
+* configMapRef bypasses gateway auth enrichment ([#138](https://github.com/paperclipinc/openclaw-operator/issues/138)) ([1322d5e](https://github.com/paperclipinc/openclaw-operator/commit/1322d5e8e3141a9c5a4ea7298ddc0149d2a1d11c))
 
-## [0.9.9](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.8...v0.9.9) (2026-02-17)
-
-
-### Bug Fixes
-
-* inject gateway.bind=lan so vanilla deployments pass health probes ([#102](https://github.com/openclaw-rocks/openclaw-operator/issues/102)) ([7c63d86](https://github.com/openclaw-rocks/openclaw-operator/commit/7c63d862b7e09c1d44368205c915064d4dbe25e1)), closes [#101](https://github.com/openclaw-rocks/openclaw-operator/issues/101)
-
-## [0.9.8](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.7...v0.9.8) (2026-02-17)
-
-
-### Bug Fixes
-
-* sync Helm RBAC and add gateway.existingSecret ([#98](https://github.com/openclaw-rocks/openclaw-operator/issues/98)) ([33dbc2c](https://github.com/openclaw-rocks/openclaw-operator/commit/33dbc2c15344ef857ec8e5d70f15544f9f5a12a0))
-
-## [0.9.7](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.6...v0.9.7) (2026-02-17)
-
-
-### Bug Fixes
-
-* use server-side apply for CRD installation and update README ([#94](https://github.com/openclaw-rocks/openclaw-operator/issues/94)) ([73b0677](https://github.com/openclaw-rocks/openclaw-operator/commit/73b0677d577ada187af7298e0b685cf25161ba12))
-
-## [0.9.6](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.5...v0.9.6) (2026-02-16)
+## [0.9.16](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.15...v0.9.16) (2026-02-20)
 
 
 ### Features
 
-* add runtime dependency init containers for pnpm and Python/uv ([#89](https://github.com/openclaw-rocks/openclaw-operator/issues/89)) ([#90](https://github.com/openclaw-rocks/openclaw-operator/issues/90)) ([b6a583c](https://github.com/openclaw-rocks/openclaw-operator/commit/b6a583cfa368a49d0054943b5f055e925c2c2e5e))
+* support npm packages in skills field and disable lifecycle scripts ([#137](https://github.com/paperclipinc/openclaw-operator/issues/137)) ([a9db9d0](https://github.com/paperclipinc/openclaw-operator/commit/a9db9d091a357bca07b260ed6e7f9560917f9e9d)), closes [#131](https://github.com/paperclipinc/openclaw-operator/issues/131) [#91](https://github.com/paperclipinc/openclaw-operator/issues/91)
 
-## [0.9.5](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.4...v0.9.5) (2026-02-16)
-
-
-### Features
-
-* add Phase 2+3 features and CVE-2025-22868 fix ([#84](https://github.com/openclaw-rocks/openclaw-operator/issues/84)) ([94d4273](https://github.com/openclaw-rocks/openclaw-operator/commit/94d427300aece52946929d3360e612ebbdba8441))
-* add read-only rootfs, config merge mode, skill installation, and secret rotation detection ([#82](https://github.com/openclaw-rocks/openclaw-operator/issues/82)) ([abd7911](https://github.com/openclaw-rocks/openclaw-operator/commit/abd7911b76c829127c133d251927f5862f3cdeda))
-* auto-generate gateway token auth for OpenClaw instances ([#85](https://github.com/openclaw-rocks/openclaw-operator/issues/85)) ([6ee7eca](https://github.com/openclaw-rocks/openclaw-operator/commit/6ee7eca5002b7035f15e1042a18d6199e50823c1)), closes [#83](https://github.com/openclaw-rocks/openclaw-operator/issues/83)
-
-## [0.9.4](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.3...v0.9.4) (2026-02-16)
+## [0.9.15](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.14...v0.9.15) (2026-02-19)
 
 
 ### Bug Fixes
 
-* auto-label release PRs to prevent release-please stalling ([#80](https://github.com/openclaw-rocks/openclaw-operator/issues/80)) ([c1bce0a](https://github.com/openclaw-rocks/openclaw-operator/commit/c1bce0add378e1917c086c6c6e7f4779ac7f45af))
+* prevent StatefulSet spec drift on every reconcile ([#133](https://github.com/paperclipinc/openclaw-operator/issues/133)) ([b6fa7b3](https://github.com/paperclipinc/openclaw-operator/commit/b6fa7b3f257e51593fb01aaa42a8e4b89e9de50b))
 
-## [0.9.3](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.2...v0.9.3) (2026-02-16)
-
-
-### Features
-
-* add auto-rollback on failed update with health check monitoring ([#75](https://github.com/openclaw-rocks/openclaw-operator/issues/75)) ([1dff347](https://github.com/openclaw-rocks/openclaw-operator/commit/1dff347ce46c8608be6a92640b9a5bf1bee53f28))
-
-## [0.9.2](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.9.1...v0.9.2) (2026-02-16)
-
-
-### Features
-
-* add opt-in auto-update for OCI registry version tracking ([#71](https://github.com/openclaw-rocks/openclaw-operator/issues/71)) ([5ce624e](https://github.com/openclaw-rocks/openclaw-operator/commit/5ce624e72e70a185700fced9b4cc6c2461d74b91))
-* add webhook warning for latest image tag ([#67](https://github.com/openclaw-rocks/openclaw-operator/issues/67)) ([6791624](https://github.com/openclaw-rocks/openclaw-operator/commit/6791624d8ec5e46fc95b02f125ac38b1578a30c7))
+## [0.9.14](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.13...v0.9.14) (2026-02-19)
 
 
 ### Bug Fixes
 
-* add skip-backup annotation to E2E test instance ([#69](https://github.com/openclaw-rocks/openclaw-operator/issues/69)) ([33ab056](https://github.com/openclaw-rocks/openclaw-operator/commit/33ab0563ebfdfb4817a8cd4627400af35ae3a699))
-* extract imageTagLatest constant to satisfy goconst linter ([#68](https://github.com/openclaw-rocks/openclaw-operator/issues/68)) ([fc14d1a](https://github.com/openclaw-rocks/openclaw-operator/commit/fc14d1a12406373cf0fd5a6cf779e64594577841))
-* suppress gosec false positive and handle existing releases ([aef5468](https://github.com/openclaw-rocks/openclaw-operator/commit/aef5468b57b3e787b9dbff82470362f5918d4bd0))
-* suppress gosec G101 false positive and handle existing releases ([182fafb](https://github.com/openclaw-rocks/openclaw-operator/commit/182fafb026d7733b4f6c9c5e918366fab71da79c))
-* sync release-please manifest to v0.9.1 ([#72](https://github.com/openclaw-rocks/openclaw-operator/issues/72)) ([88f50a9](https://github.com/openclaw-rocks/openclaw-operator/commit/88f50a9a2492d20922d7dfe2781e1d8c0fcdb1dd))
+* restore config on container restart via postStart hook ([#128](https://github.com/paperclipinc/openclaw-operator/issues/128)) ([38ea2c5](https://github.com/paperclipinc/openclaw-operator/commit/38ea2c53adc1a4ba71bf307780b8c415d18fad6d))
 
-## [0.6.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.5.0...v0.6.0) (2026-02-13)
+## [0.9.13](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.12...v0.9.13) (2026-02-19)
+
+
+### Bug Fixes
+
+* inject browser config for Chromium sidecar ([#126](https://github.com/paperclipinc/openclaw-operator/issues/126)) ([570344e](https://github.com/paperclipinc/openclaw-operator/commit/570344e167702092bd7e5640d7c1aff0340e01e1))
+* use copyFileSync instead of renameSync in merge mode init container ([#121](https://github.com/paperclipinc/openclaw-operator/issues/121)) ([72bd962](https://github.com/paperclipinc/openclaw-operator/commit/72bd962d492fdfd3ccc525523e3bb6f12de3ac70)), closes [#120](https://github.com/paperclipinc/openclaw-operator/issues/120)
+
+## [0.9.12](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.11...v0.9.12) (2026-02-18)
+
+
+### Features
+
+* add first-class Ollama sidecar support ([860225e](https://github.com/paperclipinc/openclaw-operator/commit/860225e8e656d228218056ed6be8937f897ba582))
+* add native Tailscale integration via CRD fields ([#115](https://github.com/paperclipinc/openclaw-operator/issues/115)) ([c3a2ae4](https://github.com/paperclipinc/openclaw-operator/commit/c3a2ae49b73836780aebb192fdfe931d445a1751))
+
+## [0.9.11](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.10...v0.9.11) (2026-02-18)
+
+
+### Bug Fixes
+
+* resolve flaky backup/restore tests and autorelease label API ([#117](https://github.com/paperclipinc/openclaw-operator/issues/117)) ([da7a2a5](https://github.com/paperclipinc/openclaw-operator/commit/da7a2a58f0cb82bac091e954179efdd4827d2b78))
+
+## [0.9.10](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.9...v0.9.10) (2026-02-18)
+
+
+### Bug Fixes
+
+* emit provider-aware ingress annotations based on className ([#109](https://github.com/paperclipinc/openclaw-operator/issues/109)) ([#110](https://github.com/paperclipinc/openclaw-operator/issues/110)) ([c040df6](https://github.com/paperclipinc/openclaw-operator/commit/c040df69f77e95ea8e284e84ad7bf86cd03df1ed))
+* graceful deletion when B2 backup credentials are not configured ([#112](https://github.com/paperclipinc/openclaw-operator/issues/112)) ([10b59be](https://github.com/paperclipinc/openclaw-operator/commit/10b59be0368d2f4c2ad5069621ecf62609d924eb)), closes [#111](https://github.com/paperclipinc/openclaw-operator/issues/111)
+* use shell-capable images for distroless init containers ([#108](https://github.com/paperclipinc/openclaw-operator/issues/108)) ([2c87e68](https://github.com/paperclipinc/openclaw-operator/commit/2c87e68e2e8b6bb94c95fb2ae751084843ecf2af))
+
+## [0.9.9](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.8...v0.9.9) (2026-02-17)
+
+
+### Bug Fixes
+
+* inject gateway.bind=lan so vanilla deployments pass health probes ([#102](https://github.com/paperclipinc/openclaw-operator/issues/102)) ([7c63d86](https://github.com/paperclipinc/openclaw-operator/commit/7c63d862b7e09c1d44368205c915064d4dbe25e1)), closes [#101](https://github.com/paperclipinc/openclaw-operator/issues/101)
+
+## [0.9.8](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.7...v0.9.8) (2026-02-17)
+
+
+### Bug Fixes
+
+* sync Helm RBAC and add gateway.existingSecret ([#98](https://github.com/paperclipinc/openclaw-operator/issues/98)) ([33dbc2c](https://github.com/paperclipinc/openclaw-operator/commit/33dbc2c15344ef857ec8e5d70f15544f9f5a12a0))
+
+## [0.9.7](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.6...v0.9.7) (2026-02-17)
+
+
+### Bug Fixes
+
+* use server-side apply for CRD installation and update README ([#94](https://github.com/paperclipinc/openclaw-operator/issues/94)) ([73b0677](https://github.com/paperclipinc/openclaw-operator/commit/73b0677d577ada187af7298e0b685cf25161ba12))
+
+## [0.9.6](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.5...v0.9.6) (2026-02-16)
+
+
+### Features
+
+* add runtime dependency init containers for pnpm and Python/uv ([#89](https://github.com/paperclipinc/openclaw-operator/issues/89)) ([#90](https://github.com/paperclipinc/openclaw-operator/issues/90)) ([b6a583c](https://github.com/paperclipinc/openclaw-operator/commit/b6a583cfa368a49d0054943b5f055e925c2c2e5e))
+
+## [0.9.5](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.4...v0.9.5) (2026-02-16)
+
+
+### Features
+
+* add Phase 2+3 features and CVE-2025-22868 fix ([#84](https://github.com/paperclipinc/openclaw-operator/issues/84)) ([94d4273](https://github.com/paperclipinc/openclaw-operator/commit/94d427300aece52946929d3360e612ebbdba8441))
+* add read-only rootfs, config merge mode, skill installation, and secret rotation detection ([#82](https://github.com/paperclipinc/openclaw-operator/issues/82)) ([abd7911](https://github.com/paperclipinc/openclaw-operator/commit/abd7911b76c829127c133d251927f5862f3cdeda))
+* auto-generate gateway token auth for OpenClaw instances ([#85](https://github.com/paperclipinc/openclaw-operator/issues/85)) ([6ee7eca](https://github.com/paperclipinc/openclaw-operator/commit/6ee7eca5002b7035f15e1042a18d6199e50823c1)), closes [#83](https://github.com/paperclipinc/openclaw-operator/issues/83)
+
+## [0.9.4](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.3...v0.9.4) (2026-02-16)
+
+
+### Bug Fixes
+
+* auto-label release PRs to prevent release-please stalling ([#80](https://github.com/paperclipinc/openclaw-operator/issues/80)) ([c1bce0a](https://github.com/paperclipinc/openclaw-operator/commit/c1bce0add378e1917c086c6c6e7f4779ac7f45af))
+
+## [0.9.3](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.2...v0.9.3) (2026-02-16)
+
+
+### Features
+
+* add auto-rollback on failed update with health check monitoring ([#75](https://github.com/paperclipinc/openclaw-operator/issues/75)) ([1dff347](https://github.com/paperclipinc/openclaw-operator/commit/1dff347ce46c8608be6a92640b9a5bf1bee53f28))
+
+## [0.9.2](https://github.com/paperclipinc/openclaw-operator/compare/v0.9.1...v0.9.2) (2026-02-16)
+
+
+### Features
+
+* add opt-in auto-update for OCI registry version tracking ([#71](https://github.com/paperclipinc/openclaw-operator/issues/71)) ([5ce624e](https://github.com/paperclipinc/openclaw-operator/commit/5ce624e72e70a185700fced9b4cc6c2461d74b91))
+* add webhook warning for latest image tag ([#67](https://github.com/paperclipinc/openclaw-operator/issues/67)) ([6791624](https://github.com/paperclipinc/openclaw-operator/commit/6791624d8ec5e46fc95b02f125ac38b1578a30c7))
+
+
+### Bug Fixes
+
+* add skip-backup annotation to E2E test instance ([#69](https://github.com/paperclipinc/openclaw-operator/issues/69)) ([33ab056](https://github.com/paperclipinc/openclaw-operator/commit/33ab0563ebfdfb4817a8cd4627400af35ae3a699))
+* extract imageTagLatest constant to satisfy goconst linter ([#68](https://github.com/paperclipinc/openclaw-operator/issues/68)) ([fc14d1a](https://github.com/paperclipinc/openclaw-operator/commit/fc14d1a12406373cf0fd5a6cf779e64594577841))
+* suppress gosec false positive and handle existing releases ([aef5468](https://github.com/paperclipinc/openclaw-operator/commit/aef5468b57b3e787b9dbff82470362f5918d4bd0))
+* suppress gosec G101 false positive and handle existing releases ([182fafb](https://github.com/paperclipinc/openclaw-operator/commit/182fafb026d7733b4f6c9c5e918366fab71da79c))
+* sync release-please manifest to v0.9.1 ([#72](https://github.com/paperclipinc/openclaw-operator/issues/72)) ([88f50a9](https://github.com/paperclipinc/openclaw-operator/commit/88f50a9a2492d20922d7dfe2781e1d8c0fcdb1dd))
+
+## [0.6.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.5.0...v0.6.0) (2026-02-13)
 
 
 ### ⚠ BREAKING CHANGES
@@ -673,54 +673,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-* Add nautical banner image with crab captain at Kubernetes helm ([84d1854](https://github.com/openclaw-rocks/openclaw-operator/commit/84d1854cb7200587d6745c9ae3dc29c049fc3b8e))
-* Add observability, testing, docs, and dev tooling ([5af27e1](https://github.com/openclaw-rocks/openclaw-operator/commit/5af27e1884285d385356ee548f32a62dc8608a95))
-* Add observability, testing, docs, and dev tooling for production readiness ([a8c063b](https://github.com/openclaw-rocks/openclaw-operator/commit/a8c063b1e06143e06eacf84419ecbc31a9435684))
-* Add support for custom sidecar containers ([#27](https://github.com/openclaw-rocks/openclaw-operator/issues/27)) ([f0071f7](https://github.com/openclaw-rocks/openclaw-operator/commit/f0071f72dd92b248223f53b7af9b2f3eb9a184be)), closes [#24](https://github.com/openclaw-rocks/openclaw-operator/issues/24)
-* Initial OpenClaw Kubernetes Operator implementation ([6d873ff](https://github.com/openclaw-rocks/openclaw-operator/commit/6d873ff855273c9e51337181e657ced2b82af711))
-* Inject CHROMIUM_URL env var into main container when sidecar is enabled ([8553cc7](https://github.com/openclaw-rocks/openclaw-operator/commit/8553cc7ec0b41675bd815a0f8febd0622bbf068c))
-* Inject CHROMIUM_URL env var when sidecar is enabled ([b80dabe](https://github.com/openclaw-rocks/openclaw-operator/commit/b80dabe32dbf2ff0f755c92f4e83e2467050bd89))
-* Replace manual release steps with GoReleaser ([#2](https://github.com/openclaw-rocks/openclaw-operator/issues/2)) ([fedc497](https://github.com/openclaw-rocks/openclaw-operator/commit/fedc49766d414e0a2d96bc9c080abcb82b2b2202))
-* Support custom egress rules in NetworkPolicy ([#15](https://github.com/openclaw-rocks/openclaw-operator/issues/15)) ([#16](https://github.com/openclaw-rocks/openclaw-operator/issues/16)) ([c62dc09](https://github.com/openclaw-rocks/openclaw-operator/commit/c62dc09cec6112cf4625175423d033310ce50dc3))
-* update banner with real OpenClaw logo and Kubernetes logo ([#37](https://github.com/openclaw-rocks/openclaw-operator/issues/37)) ([840adb9](https://github.com/openclaw-rocks/openclaw-operator/commit/840adb9e285c14dffe1bfed17e9b9411b05f4538))
+* Add nautical banner image with crab captain at Kubernetes helm ([84d1854](https://github.com/paperclipinc/openclaw-operator/commit/84d1854cb7200587d6745c9ae3dc29c049fc3b8e))
+* Add observability, testing, docs, and dev tooling ([5af27e1](https://github.com/paperclipinc/openclaw-operator/commit/5af27e1884285d385356ee548f32a62dc8608a95))
+* Add observability, testing, docs, and dev tooling for production readiness ([a8c063b](https://github.com/paperclipinc/openclaw-operator/commit/a8c063b1e06143e06eacf84419ecbc31a9435684))
+* Add support for custom sidecar containers ([#27](https://github.com/paperclipinc/openclaw-operator/issues/27)) ([f0071f7](https://github.com/paperclipinc/openclaw-operator/commit/f0071f72dd92b248223f53b7af9b2f3eb9a184be)), closes [#24](https://github.com/paperclipinc/openclaw-operator/issues/24)
+* Initial OpenClaw Kubernetes Operator implementation ([6d873ff](https://github.com/paperclipinc/openclaw-operator/commit/6d873ff855273c9e51337181e657ced2b82af711))
+* Inject CHROMIUM_URL env var into main container when sidecar is enabled ([8553cc7](https://github.com/paperclipinc/openclaw-operator/commit/8553cc7ec0b41675bd815a0f8febd0622bbf068c))
+* Inject CHROMIUM_URL env var when sidecar is enabled ([b80dabe](https://github.com/paperclipinc/openclaw-operator/commit/b80dabe32dbf2ff0f755c92f4e83e2467050bd89))
+* Replace manual release steps with GoReleaser ([#2](https://github.com/paperclipinc/openclaw-operator/issues/2)) ([fedc497](https://github.com/paperclipinc/openclaw-operator/commit/fedc49766d414e0a2d96bc9c080abcb82b2b2202))
+* Support custom egress rules in NetworkPolicy ([#15](https://github.com/paperclipinc/openclaw-operator/issues/15)) ([#16](https://github.com/paperclipinc/openclaw-operator/issues/16)) ([c62dc09](https://github.com/paperclipinc/openclaw-operator/commit/c62dc09cec6112cf4625175423d033310ce50dc3))
+* update banner with real OpenClaw logo and Kubernetes logo ([#37](https://github.com/paperclipinc/openclaw-operator/issues/37)) ([840adb9](https://github.com/paperclipinc/openclaw-operator/commit/840adb9e285c14dffe1bfed17e9b9411b05f4538))
 
 
 ### Bug Fixes
 
-* Add leader election RBAC and E2E test infrastructure ([4eb6019](https://github.com/openclaw-rocks/openclaw-operator/commit/4eb601994f3b87bde07f4c28a51f1dd010f045d4))
-* Apply same CreateOrUpdate pattern to ServiceMonitor reconciler ([#30](https://github.com/openclaw-rocks/openclaw-operator/issues/30)) ([c1aaa36](https://github.com/openclaw-rocks/openclaw-operator/commit/c1aaa3639b7cb82eb95696bbe06b98817d46a55e))
-* Bump chromium /dev/shm from 256Mi to 1Gi ([925d7b8](https://github.com/openclaw-rocks/openclaw-operator/commit/925d7b84c0630b73f581fca32d8da68ca582cd19))
-* Bump chromium /dev/shm sizeLimit from 256Mi to 1Gi ([a4b3fbb](https://github.com/openclaw-rocks/openclaw-operator/commit/a4b3fbb005fd40a743a54dcb8ce42c0db9ef7b27))
-* change CRD API group domain from openclaw.io to openclaw.rocks ([#41](https://github.com/openclaw-rocks/openclaw-operator/issues/41)) ([5bae852](https://github.com/openclaw-rocks/openclaw-operator/commit/5bae852810d249358fad1453694503298851208c))
-* Chromium sidecar crash (UID mismatch + read-only rootfs) and lint ([#14](https://github.com/openclaw-rocks/openclaw-operator/issues/14)) ([febe1d3](https://github.com/openclaw-rocks/openclaw-operator/commit/febe1d323bb80e4ffc0e36721fa1cd75a949b023))
-* Disable SBOM upload-release-assets to avoid race condition ([d909808](https://github.com/openclaw-rocks/openclaw-operator/commit/d909808d5aecde367748691604be1fbc152a6619))
-* Downgrade to Go 1.23 for golangci-lint compatibility ([dd33c08](https://github.com/openclaw-rocks/openclaw-operator/commit/dd33c08d1ffe962f358c14a6ae0a7b3105799d44))
-* Increase golangci-lint timeout and update to v1.63.4 ([1d982ca](https://github.com/openclaw-rocks/openclaw-operator/commit/1d982ca114f3316ad656bf873ad0fc6694f71cc5))
-* Link OpenClaw to openclaw.ai, not openclaw.rocks ([679b043](https://github.com/openclaw-rocks/openclaw-operator/commit/679b04340afc6835284f2e9e13e7aef02e69ed14))
-* Link OpenClaw to openclaw.ai, not openclaw.rocks ([#22](https://github.com/openclaw-rocks/openclaw-operator/issues/22)) ([9bfdbd8](https://github.com/openclaw-rocks/openclaw-operator/commit/9bfdbd86b29ed43f043a16bdbd126f6960df32a2))
-* Polish README copy and diagram alignment ([#19](https://github.com/openclaw-rocks/openclaw-operator/issues/19)) ([ef6a8d1](https://github.com/openclaw-rocks/openclaw-operator/commit/ef6a8d1f0973f36d3c790d34529f86e1c1d7343c))
-* Pre-enable channel modules in config to prevent EBUSY on startup ([#13](https://github.com/openclaw-rocks/openclaw-operator/issues/13)) ([21ee585](https://github.com/openclaw-rocks/openclaw-operator/commit/21ee585fb4bef4f77afed0b0a8d730c0975af0e3)), closes [#11](https://github.com/openclaw-rocks/openclaw-operator/issues/11)
-* Prevent endless Deployment reconciliation loop ([#29](https://github.com/openclaw-rocks/openclaw-operator/issues/29)) ([db942b9](https://github.com/openclaw-rocks/openclaw-operator/commit/db942b945586e6c3b49db7f0d3ca242f5fac7b44)), closes [#28](https://github.com/openclaw-rocks/openclaw-operator/issues/28)
-* Remove chart-releaser, keep OCI-only Helm distribution ([#3](https://github.com/openclaw-rocks/openclaw-operator/issues/3)) ([99e3cdb](https://github.com/openclaw-rocks/openclaw-operator/commit/99e3cdba598ac46e5cd3cab2dc7dad00b456a0e8))
-* Replace config subPath mount with init container to avoid EBUSY ([#10](https://github.com/openclaw-rocks/openclaw-operator/issues/10)) ([38b60d3](https://github.com/openclaw-rocks/openclaw-operator/commit/38b60d39b835fb1eca459f6c4d612d0304873c3e)), closes [#9](https://github.com/openclaw-rocks/openclaw-operator/issues/9)
-* Resolve variable shadowing of err in PVC reconciliation ([a9ea85b](https://github.com/openclaw-rocks/openclaw-operator/commit/a9ea85b05770ba4123b4c0325e551ba93e90d103))
-* Set HOME env var to match config mount path ([#5](https://github.com/openclaw-rocks/openclaw-operator/issues/5)) ([175ff92](https://github.com/openclaw-rocks/openclaw-operator/commit/175ff9219b5af8d80e37579627f8ebccce71cb1b)), closes [#4](https://github.com/openclaw-rocks/openclaw-operator/issues/4)
-* skip GitHub release creation in release-please ([#47](https://github.com/openclaw-rocks/openclaw-operator/issues/47)) ([96a5be9](https://github.com/openclaw-rocks/openclaw-operator/commit/96a5be93020ef61d6a37f804e1a741b3a229e86d))
-* Specify kind cluster name for image loading ([7ac2116](https://github.com/openclaw-rocks/openclaw-operator/commit/7ac21166b36e79fb0d93c23eb24de8c420dd8446))
-* update banner alt text ([#38](https://github.com/openclaw-rocks/openclaw-operator/issues/38)) ([d00dc23](https://github.com/openclaw-rocks/openclaw-operator/commit/d00dc23516d79e6a95b6aeca9d5d29c1a777e0e6))
-* Update Chart.yaml version/appVersion to match latest release v0.2.4 ([#26](https://github.com/openclaw-rocks/openclaw-operator/issues/26)) ([c475ffc](https://github.com/openclaw-rocks/openclaw-operator/commit/c475ffcd145b5109befb784a1a92672377be8936))
-* Update copyright to 2026 OpenClaw.rocks ([bca1f0f](https://github.com/openclaw-rocks/openclaw-operator/commit/bca1f0f626ebd8c7c1285882d20b87483380fba4))
-* Update copyright to 2026 OpenClaw.rocks ([4d462f9](https://github.com/openclaw-rocks/openclaw-operator/commit/4d462f97799865f48c13525074702f4b1163e54f))
-* Update Go version to 1.24 for CI compatibility ([5c13d06](https://github.com/openclaw-rocks/openclaw-operator/commit/5c13d068f3cba6d19609a3ea78b237d4b0b311ff))
-* Use correct GitHub org name (OpenClaw-rocks) in all references ([#20](https://github.com/openclaw-rocks/openclaw-operator/issues/20)) ([c157899](https://github.com/openclaw-rocks/openclaw-operator/commit/c1578998cb7bfb4824eae64ce390fba4e508e6ca))
-* Use direct append instead of loop for image pull secrets ([187477c](https://github.com/openclaw-rocks/openclaw-operator/commit/187477c3e205ddf332bd9f2831936d141b1e4088))
-* Use Go 1.24 with goinstall mode for golangci-lint ([3dd40c8](https://github.com/openclaw-rocks/openclaw-operator/commit/3dd40c8fc02e964c9edd98407ae44a7d94634b2b))
-* Use govet enable list for shadow analyzer ([3f04b1b](https://github.com/openclaw-rocks/openclaw-operator/commit/3f04b1bd705f33df5c438e3ae9b22fd5e2cd7975))
-* Use lowercase image names for OCI registry compatibility ([2d3c87e](https://github.com/openclaw-rocks/openclaw-operator/commit/2d3c87ea562800a98b5be6c63b71bafe1fbae1e8))
-* Use lowercase owner name for Helm OCI registry ([67bc33e](https://github.com/openclaw-rocks/openclaw-operator/commit/67bc33e503a6f1329908dd437731b3bf96be2ea5))
-* use PAT for release-please to trigger downstream workflows ([#45](https://github.com/openclaw-rocks/openclaw-operator/issues/45)) ([21191ed](https://github.com/openclaw-rocks/openclaw-operator/commit/21191ed3e29ff2d4aeb4c0aa269eca1fb7f6284a))
+* Add leader election RBAC and E2E test infrastructure ([4eb6019](https://github.com/paperclipinc/openclaw-operator/commit/4eb601994f3b87bde07f4c28a51f1dd010f045d4))
+* Apply same CreateOrUpdate pattern to ServiceMonitor reconciler ([#30](https://github.com/paperclipinc/openclaw-operator/issues/30)) ([c1aaa36](https://github.com/paperclipinc/openclaw-operator/commit/c1aaa3639b7cb82eb95696bbe06b98817d46a55e))
+* Bump chromium /dev/shm from 256Mi to 1Gi ([925d7b8](https://github.com/paperclipinc/openclaw-operator/commit/925d7b84c0630b73f581fca32d8da68ca582cd19))
+* Bump chromium /dev/shm sizeLimit from 256Mi to 1Gi ([a4b3fbb](https://github.com/paperclipinc/openclaw-operator/commit/a4b3fbb005fd40a743a54dcb8ce42c0db9ef7b27))
+* change CRD API group domain from openclaw.io to openclaw.rocks ([#41](https://github.com/paperclipinc/openclaw-operator/issues/41)) ([5bae852](https://github.com/paperclipinc/openclaw-operator/commit/5bae852810d249358fad1453694503298851208c))
+* Chromium sidecar crash (UID mismatch + read-only rootfs) and lint ([#14](https://github.com/paperclipinc/openclaw-operator/issues/14)) ([febe1d3](https://github.com/paperclipinc/openclaw-operator/commit/febe1d323bb80e4ffc0e36721fa1cd75a949b023))
+* Disable SBOM upload-release-assets to avoid race condition ([d909808](https://github.com/paperclipinc/openclaw-operator/commit/d909808d5aecde367748691604be1fbc152a6619))
+* Downgrade to Go 1.23 for golangci-lint compatibility ([dd33c08](https://github.com/paperclipinc/openclaw-operator/commit/dd33c08d1ffe962f358c14a6ae0a7b3105799d44))
+* Increase golangci-lint timeout and update to v1.63.4 ([1d982ca](https://github.com/paperclipinc/openclaw-operator/commit/1d982ca114f3316ad656bf873ad0fc6694f71cc5))
+* Link OpenClaw to openclaw.ai, not openclaw.rocks ([679b043](https://github.com/paperclipinc/openclaw-operator/commit/679b04340afc6835284f2e9e13e7aef02e69ed14))
+* Link OpenClaw to openclaw.ai, not openclaw.rocks ([#22](https://github.com/paperclipinc/openclaw-operator/issues/22)) ([9bfdbd8](https://github.com/paperclipinc/openclaw-operator/commit/9bfdbd86b29ed43f043a16bdbd126f6960df32a2))
+* Polish README copy and diagram alignment ([#19](https://github.com/paperclipinc/openclaw-operator/issues/19)) ([ef6a8d1](https://github.com/paperclipinc/openclaw-operator/commit/ef6a8d1f0973f36d3c790d34529f86e1c1d7343c))
+* Pre-enable channel modules in config to prevent EBUSY on startup ([#13](https://github.com/paperclipinc/openclaw-operator/issues/13)) ([21ee585](https://github.com/paperclipinc/openclaw-operator/commit/21ee585fb4bef4f77afed0b0a8d730c0975af0e3)), closes [#11](https://github.com/paperclipinc/openclaw-operator/issues/11)
+* Prevent endless Deployment reconciliation loop ([#29](https://github.com/paperclipinc/openclaw-operator/issues/29)) ([db942b9](https://github.com/paperclipinc/openclaw-operator/commit/db942b945586e6c3b49db7f0d3ca242f5fac7b44)), closes [#28](https://github.com/paperclipinc/openclaw-operator/issues/28)
+* Remove chart-releaser, keep OCI-only Helm distribution ([#3](https://github.com/paperclipinc/openclaw-operator/issues/3)) ([99e3cdb](https://github.com/paperclipinc/openclaw-operator/commit/99e3cdba598ac46e5cd3cab2dc7dad00b456a0e8))
+* Replace config subPath mount with init container to avoid EBUSY ([#10](https://github.com/paperclipinc/openclaw-operator/issues/10)) ([38b60d3](https://github.com/paperclipinc/openclaw-operator/commit/38b60d39b835fb1eca459f6c4d612d0304873c3e)), closes [#9](https://github.com/paperclipinc/openclaw-operator/issues/9)
+* Resolve variable shadowing of err in PVC reconciliation ([a9ea85b](https://github.com/paperclipinc/openclaw-operator/commit/a9ea85b05770ba4123b4c0325e551ba93e90d103))
+* Set HOME env var to match config mount path ([#5](https://github.com/paperclipinc/openclaw-operator/issues/5)) ([175ff92](https://github.com/paperclipinc/openclaw-operator/commit/175ff9219b5af8d80e37579627f8ebccce71cb1b)), closes [#4](https://github.com/paperclipinc/openclaw-operator/issues/4)
+* skip GitHub release creation in release-please ([#47](https://github.com/paperclipinc/openclaw-operator/issues/47)) ([96a5be9](https://github.com/paperclipinc/openclaw-operator/commit/96a5be93020ef61d6a37f804e1a741b3a229e86d))
+* Specify kind cluster name for image loading ([7ac2116](https://github.com/paperclipinc/openclaw-operator/commit/7ac21166b36e79fb0d93c23eb24de8c420dd8446))
+* update banner alt text ([#38](https://github.com/paperclipinc/openclaw-operator/issues/38)) ([d00dc23](https://github.com/paperclipinc/openclaw-operator/commit/d00dc23516d79e6a95b6aeca9d5d29c1a777e0e6))
+* Update Chart.yaml version/appVersion to match latest release v0.2.4 ([#26](https://github.com/paperclipinc/openclaw-operator/issues/26)) ([c475ffc](https://github.com/paperclipinc/openclaw-operator/commit/c475ffcd145b5109befb784a1a92672377be8936))
+* Update copyright to 2026 OpenClaw.rocks ([bca1f0f](https://github.com/paperclipinc/openclaw-operator/commit/bca1f0f626ebd8c7c1285882d20b87483380fba4))
+* Update copyright to 2026 OpenClaw.rocks ([4d462f9](https://github.com/paperclipinc/openclaw-operator/commit/4d462f97799865f48c13525074702f4b1163e54f))
+* Update Go version to 1.24 for CI compatibility ([5c13d06](https://github.com/paperclipinc/openclaw-operator/commit/5c13d068f3cba6d19609a3ea78b237d4b0b311ff))
+* Use correct GitHub org name (OpenClaw-rocks) in all references ([#20](https://github.com/paperclipinc/openclaw-operator/issues/20)) ([c157899](https://github.com/paperclipinc/openclaw-operator/commit/c1578998cb7bfb4824eae64ce390fba4e508e6ca))
+* Use direct append instead of loop for image pull secrets ([187477c](https://github.com/paperclipinc/openclaw-operator/commit/187477c3e205ddf332bd9f2831936d141b1e4088))
+* Use Go 1.24 with goinstall mode for golangci-lint ([3dd40c8](https://github.com/paperclipinc/openclaw-operator/commit/3dd40c8fc02e964c9edd98407ae44a7d94634b2b))
+* Use govet enable list for shadow analyzer ([3f04b1b](https://github.com/paperclipinc/openclaw-operator/commit/3f04b1bd705f33df5c438e3ae9b22fd5e2cd7975))
+* Use lowercase image names for OCI registry compatibility ([2d3c87e](https://github.com/paperclipinc/openclaw-operator/commit/2d3c87ea562800a98b5be6c63b71bafe1fbae1e8))
+* Use lowercase owner name for Helm OCI registry ([67bc33e](https://github.com/paperclipinc/openclaw-operator/commit/67bc33e503a6f1329908dd437731b3bf96be2ea5))
+* use PAT for release-please to trigger downstream workflows ([#45](https://github.com/paperclipinc/openclaw-operator/issues/45)) ([21191ed](https://github.com/paperclipinc/openclaw-operator/commit/21191ed3e29ff2d4aeb4c0aa269eca1fb7f6284a))
 
-## [0.5.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.4.0...v0.5.0) (2026-02-13)
+## [0.5.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.4.0...v0.5.0) (2026-02-13)
 
 
 ### ⚠ BREAKING CHANGES
@@ -729,53 +729,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-* Add nautical banner image with crab captain at Kubernetes helm ([84d1854](https://github.com/openclaw-rocks/openclaw-operator/commit/84d1854cb7200587d6745c9ae3dc29c049fc3b8e))
-* Add observability, testing, docs, and dev tooling ([5af27e1](https://github.com/openclaw-rocks/openclaw-operator/commit/5af27e1884285d385356ee548f32a62dc8608a95))
-* Add observability, testing, docs, and dev tooling for production readiness ([a8c063b](https://github.com/openclaw-rocks/openclaw-operator/commit/a8c063b1e06143e06eacf84419ecbc31a9435684))
-* Add support for custom sidecar containers ([#27](https://github.com/openclaw-rocks/openclaw-operator/issues/27)) ([f0071f7](https://github.com/openclaw-rocks/openclaw-operator/commit/f0071f72dd92b248223f53b7af9b2f3eb9a184be)), closes [#24](https://github.com/openclaw-rocks/openclaw-operator/issues/24)
-* Initial OpenClaw Kubernetes Operator implementation ([6d873ff](https://github.com/openclaw-rocks/openclaw-operator/commit/6d873ff855273c9e51337181e657ced2b82af711))
-* Inject CHROMIUM_URL env var into main container when sidecar is enabled ([8553cc7](https://github.com/openclaw-rocks/openclaw-operator/commit/8553cc7ec0b41675bd815a0f8febd0622bbf068c))
-* Inject CHROMIUM_URL env var when sidecar is enabled ([b80dabe](https://github.com/openclaw-rocks/openclaw-operator/commit/b80dabe32dbf2ff0f755c92f4e83e2467050bd89))
-* Replace manual release steps with GoReleaser ([#2](https://github.com/openclaw-rocks/openclaw-operator/issues/2)) ([fedc497](https://github.com/openclaw-rocks/openclaw-operator/commit/fedc49766d414e0a2d96bc9c080abcb82b2b2202))
-* Support custom egress rules in NetworkPolicy ([#15](https://github.com/openclaw-rocks/openclaw-operator/issues/15)) ([#16](https://github.com/openclaw-rocks/openclaw-operator/issues/16)) ([c62dc09](https://github.com/openclaw-rocks/openclaw-operator/commit/c62dc09cec6112cf4625175423d033310ce50dc3))
-* update banner with real OpenClaw logo and Kubernetes logo ([#37](https://github.com/openclaw-rocks/openclaw-operator/issues/37)) ([840adb9](https://github.com/openclaw-rocks/openclaw-operator/commit/840adb9e285c14dffe1bfed17e9b9411b05f4538))
+* Add nautical banner image with crab captain at Kubernetes helm ([84d1854](https://github.com/paperclipinc/openclaw-operator/commit/84d1854cb7200587d6745c9ae3dc29c049fc3b8e))
+* Add observability, testing, docs, and dev tooling ([5af27e1](https://github.com/paperclipinc/openclaw-operator/commit/5af27e1884285d385356ee548f32a62dc8608a95))
+* Add observability, testing, docs, and dev tooling for production readiness ([a8c063b](https://github.com/paperclipinc/openclaw-operator/commit/a8c063b1e06143e06eacf84419ecbc31a9435684))
+* Add support for custom sidecar containers ([#27](https://github.com/paperclipinc/openclaw-operator/issues/27)) ([f0071f7](https://github.com/paperclipinc/openclaw-operator/commit/f0071f72dd92b248223f53b7af9b2f3eb9a184be)), closes [#24](https://github.com/paperclipinc/openclaw-operator/issues/24)
+* Initial OpenClaw Kubernetes Operator implementation ([6d873ff](https://github.com/paperclipinc/openclaw-operator/commit/6d873ff855273c9e51337181e657ced2b82af711))
+* Inject CHROMIUM_URL env var into main container when sidecar is enabled ([8553cc7](https://github.com/paperclipinc/openclaw-operator/commit/8553cc7ec0b41675bd815a0f8febd0622bbf068c))
+* Inject CHROMIUM_URL env var when sidecar is enabled ([b80dabe](https://github.com/paperclipinc/openclaw-operator/commit/b80dabe32dbf2ff0f755c92f4e83e2467050bd89))
+* Replace manual release steps with GoReleaser ([#2](https://github.com/paperclipinc/openclaw-operator/issues/2)) ([fedc497](https://github.com/paperclipinc/openclaw-operator/commit/fedc49766d414e0a2d96bc9c080abcb82b2b2202))
+* Support custom egress rules in NetworkPolicy ([#15](https://github.com/paperclipinc/openclaw-operator/issues/15)) ([#16](https://github.com/paperclipinc/openclaw-operator/issues/16)) ([c62dc09](https://github.com/paperclipinc/openclaw-operator/commit/c62dc09cec6112cf4625175423d033310ce50dc3))
+* update banner with real OpenClaw logo and Kubernetes logo ([#37](https://github.com/paperclipinc/openclaw-operator/issues/37)) ([840adb9](https://github.com/paperclipinc/openclaw-operator/commit/840adb9e285c14dffe1bfed17e9b9411b05f4538))
 
 
 ### Bug Fixes
 
-* Add leader election RBAC and E2E test infrastructure ([4eb6019](https://github.com/openclaw-rocks/openclaw-operator/commit/4eb601994f3b87bde07f4c28a51f1dd010f045d4))
-* Apply same CreateOrUpdate pattern to ServiceMonitor reconciler ([#30](https://github.com/openclaw-rocks/openclaw-operator/issues/30)) ([c1aaa36](https://github.com/openclaw-rocks/openclaw-operator/commit/c1aaa3639b7cb82eb95696bbe06b98817d46a55e))
-* Bump chromium /dev/shm from 256Mi to 1Gi ([925d7b8](https://github.com/openclaw-rocks/openclaw-operator/commit/925d7b84c0630b73f581fca32d8da68ca582cd19))
-* Bump chromium /dev/shm sizeLimit from 256Mi to 1Gi ([a4b3fbb](https://github.com/openclaw-rocks/openclaw-operator/commit/a4b3fbb005fd40a743a54dcb8ce42c0db9ef7b27))
-* change CRD API group domain from openclaw.io to openclaw.rocks ([#41](https://github.com/openclaw-rocks/openclaw-operator/issues/41)) ([5bae852](https://github.com/openclaw-rocks/openclaw-operator/commit/5bae852810d249358fad1453694503298851208c))
-* Chromium sidecar crash (UID mismatch + read-only rootfs) and lint ([#14](https://github.com/openclaw-rocks/openclaw-operator/issues/14)) ([febe1d3](https://github.com/openclaw-rocks/openclaw-operator/commit/febe1d323bb80e4ffc0e36721fa1cd75a949b023))
-* Disable SBOM upload-release-assets to avoid race condition ([d909808](https://github.com/openclaw-rocks/openclaw-operator/commit/d909808d5aecde367748691604be1fbc152a6619))
-* Downgrade to Go 1.23 for golangci-lint compatibility ([dd33c08](https://github.com/openclaw-rocks/openclaw-operator/commit/dd33c08d1ffe962f358c14a6ae0a7b3105799d44))
-* Increase golangci-lint timeout and update to v1.63.4 ([1d982ca](https://github.com/openclaw-rocks/openclaw-operator/commit/1d982ca114f3316ad656bf873ad0fc6694f71cc5))
-* Link OpenClaw to openclaw.ai, not openclaw.rocks ([679b043](https://github.com/openclaw-rocks/openclaw-operator/commit/679b04340afc6835284f2e9e13e7aef02e69ed14))
-* Link OpenClaw to openclaw.ai, not openclaw.rocks ([#22](https://github.com/openclaw-rocks/openclaw-operator/issues/22)) ([9bfdbd8](https://github.com/openclaw-rocks/openclaw-operator/commit/9bfdbd86b29ed43f043a16bdbd126f6960df32a2))
-* Polish README copy and diagram alignment ([#19](https://github.com/openclaw-rocks/openclaw-operator/issues/19)) ([ef6a8d1](https://github.com/openclaw-rocks/openclaw-operator/commit/ef6a8d1f0973f36d3c790d34529f86e1c1d7343c))
-* Pre-enable channel modules in config to prevent EBUSY on startup ([#13](https://github.com/openclaw-rocks/openclaw-operator/issues/13)) ([21ee585](https://github.com/openclaw-rocks/openclaw-operator/commit/21ee585fb4bef4f77afed0b0a8d730c0975af0e3)), closes [#11](https://github.com/openclaw-rocks/openclaw-operator/issues/11)
-* Prevent endless Deployment reconciliation loop ([#29](https://github.com/openclaw-rocks/openclaw-operator/issues/29)) ([db942b9](https://github.com/openclaw-rocks/openclaw-operator/commit/db942b945586e6c3b49db7f0d3ca242f5fac7b44)), closes [#28](https://github.com/openclaw-rocks/openclaw-operator/issues/28)
-* Remove chart-releaser, keep OCI-only Helm distribution ([#3](https://github.com/openclaw-rocks/openclaw-operator/issues/3)) ([99e3cdb](https://github.com/openclaw-rocks/openclaw-operator/commit/99e3cdba598ac46e5cd3cab2dc7dad00b456a0e8))
-* Replace config subPath mount with init container to avoid EBUSY ([#10](https://github.com/openclaw-rocks/openclaw-operator/issues/10)) ([38b60d3](https://github.com/openclaw-rocks/openclaw-operator/commit/38b60d39b835fb1eca459f6c4d612d0304873c3e)), closes [#9](https://github.com/openclaw-rocks/openclaw-operator/issues/9)
-* Resolve variable shadowing of err in PVC reconciliation ([a9ea85b](https://github.com/openclaw-rocks/openclaw-operator/commit/a9ea85b05770ba4123b4c0325e551ba93e90d103))
-* Set HOME env var to match config mount path ([#5](https://github.com/openclaw-rocks/openclaw-operator/issues/5)) ([175ff92](https://github.com/openclaw-rocks/openclaw-operator/commit/175ff9219b5af8d80e37579627f8ebccce71cb1b)), closes [#4](https://github.com/openclaw-rocks/openclaw-operator/issues/4)
-* Specify kind cluster name for image loading ([7ac2116](https://github.com/openclaw-rocks/openclaw-operator/commit/7ac21166b36e79fb0d93c23eb24de8c420dd8446))
-* update banner alt text ([#38](https://github.com/openclaw-rocks/openclaw-operator/issues/38)) ([d00dc23](https://github.com/openclaw-rocks/openclaw-operator/commit/d00dc23516d79e6a95b6aeca9d5d29c1a777e0e6))
-* Update Chart.yaml version/appVersion to match latest release v0.2.4 ([#26](https://github.com/openclaw-rocks/openclaw-operator/issues/26)) ([c475ffc](https://github.com/openclaw-rocks/openclaw-operator/commit/c475ffcd145b5109befb784a1a92672377be8936))
-* Update copyright to 2026 OpenClaw.rocks ([bca1f0f](https://github.com/openclaw-rocks/openclaw-operator/commit/bca1f0f626ebd8c7c1285882d20b87483380fba4))
-* Update copyright to 2026 OpenClaw.rocks ([4d462f9](https://github.com/openclaw-rocks/openclaw-operator/commit/4d462f97799865f48c13525074702f4b1163e54f))
-* Update Go version to 1.24 for CI compatibility ([5c13d06](https://github.com/openclaw-rocks/openclaw-operator/commit/5c13d068f3cba6d19609a3ea78b237d4b0b311ff))
-* Use correct GitHub org name (OpenClaw-rocks) in all references ([#20](https://github.com/openclaw-rocks/openclaw-operator/issues/20)) ([c157899](https://github.com/openclaw-rocks/openclaw-operator/commit/c1578998cb7bfb4824eae64ce390fba4e508e6ca))
-* Use direct append instead of loop for image pull secrets ([187477c](https://github.com/openclaw-rocks/openclaw-operator/commit/187477c3e205ddf332bd9f2831936d141b1e4088))
-* Use Go 1.24 with goinstall mode for golangci-lint ([3dd40c8](https://github.com/openclaw-rocks/openclaw-operator/commit/3dd40c8fc02e964c9edd98407ae44a7d94634b2b))
-* Use govet enable list for shadow analyzer ([3f04b1b](https://github.com/openclaw-rocks/openclaw-operator/commit/3f04b1bd705f33df5c438e3ae9b22fd5e2cd7975))
-* Use lowercase image names for OCI registry compatibility ([2d3c87e](https://github.com/openclaw-rocks/openclaw-operator/commit/2d3c87ea562800a98b5be6c63b71bafe1fbae1e8))
-* Use lowercase owner name for Helm OCI registry ([67bc33e](https://github.com/openclaw-rocks/openclaw-operator/commit/67bc33e503a6f1329908dd437731b3bf96be2ea5))
-* use PAT for release-please to trigger downstream workflows ([#45](https://github.com/openclaw-rocks/openclaw-operator/issues/45)) ([21191ed](https://github.com/openclaw-rocks/openclaw-operator/commit/21191ed3e29ff2d4aeb4c0aa269eca1fb7f6284a))
+* Add leader election RBAC and E2E test infrastructure ([4eb6019](https://github.com/paperclipinc/openclaw-operator/commit/4eb601994f3b87bde07f4c28a51f1dd010f045d4))
+* Apply same CreateOrUpdate pattern to ServiceMonitor reconciler ([#30](https://github.com/paperclipinc/openclaw-operator/issues/30)) ([c1aaa36](https://github.com/paperclipinc/openclaw-operator/commit/c1aaa3639b7cb82eb95696bbe06b98817d46a55e))
+* Bump chromium /dev/shm from 256Mi to 1Gi ([925d7b8](https://github.com/paperclipinc/openclaw-operator/commit/925d7b84c0630b73f581fca32d8da68ca582cd19))
+* Bump chromium /dev/shm sizeLimit from 256Mi to 1Gi ([a4b3fbb](https://github.com/paperclipinc/openclaw-operator/commit/a4b3fbb005fd40a743a54dcb8ce42c0db9ef7b27))
+* change CRD API group domain from openclaw.io to openclaw.rocks ([#41](https://github.com/paperclipinc/openclaw-operator/issues/41)) ([5bae852](https://github.com/paperclipinc/openclaw-operator/commit/5bae852810d249358fad1453694503298851208c))
+* Chromium sidecar crash (UID mismatch + read-only rootfs) and lint ([#14](https://github.com/paperclipinc/openclaw-operator/issues/14)) ([febe1d3](https://github.com/paperclipinc/openclaw-operator/commit/febe1d323bb80e4ffc0e36721fa1cd75a949b023))
+* Disable SBOM upload-release-assets to avoid race condition ([d909808](https://github.com/paperclipinc/openclaw-operator/commit/d909808d5aecde367748691604be1fbc152a6619))
+* Downgrade to Go 1.23 for golangci-lint compatibility ([dd33c08](https://github.com/paperclipinc/openclaw-operator/commit/dd33c08d1ffe962f358c14a6ae0a7b3105799d44))
+* Increase golangci-lint timeout and update to v1.63.4 ([1d982ca](https://github.com/paperclipinc/openclaw-operator/commit/1d982ca114f3316ad656bf873ad0fc6694f71cc5))
+* Link OpenClaw to openclaw.ai, not openclaw.rocks ([679b043](https://github.com/paperclipinc/openclaw-operator/commit/679b04340afc6835284f2e9e13e7aef02e69ed14))
+* Link OpenClaw to openclaw.ai, not openclaw.rocks ([#22](https://github.com/paperclipinc/openclaw-operator/issues/22)) ([9bfdbd8](https://github.com/paperclipinc/openclaw-operator/commit/9bfdbd86b29ed43f043a16bdbd126f6960df32a2))
+* Polish README copy and diagram alignment ([#19](https://github.com/paperclipinc/openclaw-operator/issues/19)) ([ef6a8d1](https://github.com/paperclipinc/openclaw-operator/commit/ef6a8d1f0973f36d3c790d34529f86e1c1d7343c))
+* Pre-enable channel modules in config to prevent EBUSY on startup ([#13](https://github.com/paperclipinc/openclaw-operator/issues/13)) ([21ee585](https://github.com/paperclipinc/openclaw-operator/commit/21ee585fb4bef4f77afed0b0a8d730c0975af0e3)), closes [#11](https://github.com/paperclipinc/openclaw-operator/issues/11)
+* Prevent endless Deployment reconciliation loop ([#29](https://github.com/paperclipinc/openclaw-operator/issues/29)) ([db942b9](https://github.com/paperclipinc/openclaw-operator/commit/db942b945586e6c3b49db7f0d3ca242f5fac7b44)), closes [#28](https://github.com/paperclipinc/openclaw-operator/issues/28)
+* Remove chart-releaser, keep OCI-only Helm distribution ([#3](https://github.com/paperclipinc/openclaw-operator/issues/3)) ([99e3cdb](https://github.com/paperclipinc/openclaw-operator/commit/99e3cdba598ac46e5cd3cab2dc7dad00b456a0e8))
+* Replace config subPath mount with init container to avoid EBUSY ([#10](https://github.com/paperclipinc/openclaw-operator/issues/10)) ([38b60d3](https://github.com/paperclipinc/openclaw-operator/commit/38b60d39b835fb1eca459f6c4d612d0304873c3e)), closes [#9](https://github.com/paperclipinc/openclaw-operator/issues/9)
+* Resolve variable shadowing of err in PVC reconciliation ([a9ea85b](https://github.com/paperclipinc/openclaw-operator/commit/a9ea85b05770ba4123b4c0325e551ba93e90d103))
+* Set HOME env var to match config mount path ([#5](https://github.com/paperclipinc/openclaw-operator/issues/5)) ([175ff92](https://github.com/paperclipinc/openclaw-operator/commit/175ff9219b5af8d80e37579627f8ebccce71cb1b)), closes [#4](https://github.com/paperclipinc/openclaw-operator/issues/4)
+* Specify kind cluster name for image loading ([7ac2116](https://github.com/paperclipinc/openclaw-operator/commit/7ac21166b36e79fb0d93c23eb24de8c420dd8446))
+* update banner alt text ([#38](https://github.com/paperclipinc/openclaw-operator/issues/38)) ([d00dc23](https://github.com/paperclipinc/openclaw-operator/commit/d00dc23516d79e6a95b6aeca9d5d29c1a777e0e6))
+* Update Chart.yaml version/appVersion to match latest release v0.2.4 ([#26](https://github.com/paperclipinc/openclaw-operator/issues/26)) ([c475ffc](https://github.com/paperclipinc/openclaw-operator/commit/c475ffcd145b5109befb784a1a92672377be8936))
+* Update copyright to 2026 OpenClaw.rocks ([bca1f0f](https://github.com/paperclipinc/openclaw-operator/commit/bca1f0f626ebd8c7c1285882d20b87483380fba4))
+* Update copyright to 2026 OpenClaw.rocks ([4d462f9](https://github.com/paperclipinc/openclaw-operator/commit/4d462f97799865f48c13525074702f4b1163e54f))
+* Update Go version to 1.24 for CI compatibility ([5c13d06](https://github.com/paperclipinc/openclaw-operator/commit/5c13d068f3cba6d19609a3ea78b237d4b0b311ff))
+* Use correct GitHub org name (OpenClaw-rocks) in all references ([#20](https://github.com/paperclipinc/openclaw-operator/issues/20)) ([c157899](https://github.com/paperclipinc/openclaw-operator/commit/c1578998cb7bfb4824eae64ce390fba4e508e6ca))
+* Use direct append instead of loop for image pull secrets ([187477c](https://github.com/paperclipinc/openclaw-operator/commit/187477c3e205ddf332bd9f2831936d141b1e4088))
+* Use Go 1.24 with goinstall mode for golangci-lint ([3dd40c8](https://github.com/paperclipinc/openclaw-operator/commit/3dd40c8fc02e964c9edd98407ae44a7d94634b2b))
+* Use govet enable list for shadow analyzer ([3f04b1b](https://github.com/paperclipinc/openclaw-operator/commit/3f04b1bd705f33df5c438e3ae9b22fd5e2cd7975))
+* Use lowercase image names for OCI registry compatibility ([2d3c87e](https://github.com/paperclipinc/openclaw-operator/commit/2d3c87ea562800a98b5be6c63b71bafe1fbae1e8))
+* Use lowercase owner name for Helm OCI registry ([67bc33e](https://github.com/paperclipinc/openclaw-operator/commit/67bc33e503a6f1329908dd437731b3bf96be2ea5))
+* use PAT for release-please to trigger downstream workflows ([#45](https://github.com/paperclipinc/openclaw-operator/issues/45)) ([21191ed](https://github.com/paperclipinc/openclaw-operator/commit/21191ed3e29ff2d4aeb4c0aa269eca1fb7f6284a))
 
-## [0.4.0](https://github.com/openclaw-rocks/openclaw-operator/compare/v0.3.0...v0.4.0) (2026-02-13)
+## [0.4.0](https://github.com/paperclipinc/openclaw-operator/compare/v0.3.0...v0.4.0) (2026-02-13)
 
 
 ### ⚠ BREAKING CHANGES
@@ -784,16 +784,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-* Add nautical banner image with crab captain at Kubernetes helm ([84d1854](https://github.com/openclaw-rocks/openclaw-operator/commit/84d1854cb7200587d6745c9ae3dc29c049fc3b8e))
-* update banner with real OpenClaw logo and Kubernetes logo ([#37](https://github.com/openclaw-rocks/openclaw-operator/issues/37)) ([840adb9](https://github.com/openclaw-rocks/openclaw-operator/commit/840adb9e285c14dffe1bfed17e9b9411b05f4538))
+* Add nautical banner image with crab captain at Kubernetes helm ([84d1854](https://github.com/paperclipinc/openclaw-operator/commit/84d1854cb7200587d6745c9ae3dc29c049fc3b8e))
+* update banner with real OpenClaw logo and Kubernetes logo ([#37](https://github.com/paperclipinc/openclaw-operator/issues/37)) ([840adb9](https://github.com/paperclipinc/openclaw-operator/commit/840adb9e285c14dffe1bfed17e9b9411b05f4538))
 
 
 ### Bug Fixes
 
-* Apply same CreateOrUpdate pattern to ServiceMonitor reconciler ([#30](https://github.com/openclaw-rocks/openclaw-operator/issues/30)) ([c1aaa36](https://github.com/openclaw-rocks/openclaw-operator/commit/c1aaa3639b7cb82eb95696bbe06b98817d46a55e))
-* change CRD API group domain from openclaw.io to openclaw.rocks ([#41](https://github.com/openclaw-rocks/openclaw-operator/issues/41)) ([5bae852](https://github.com/openclaw-rocks/openclaw-operator/commit/5bae852810d249358fad1453694503298851208c))
-* Prevent endless Deployment reconciliation loop ([#29](https://github.com/openclaw-rocks/openclaw-operator/issues/29)) ([db942b9](https://github.com/openclaw-rocks/openclaw-operator/commit/db942b945586e6c3b49db7f0d3ca242f5fac7b44)), closes [#28](https://github.com/openclaw-rocks/openclaw-operator/issues/28)
-* update banner alt text ([#38](https://github.com/openclaw-rocks/openclaw-operator/issues/38)) ([d00dc23](https://github.com/openclaw-rocks/openclaw-operator/commit/d00dc23516d79e6a95b6aeca9d5d29c1a777e0e6))
+* Apply same CreateOrUpdate pattern to ServiceMonitor reconciler ([#30](https://github.com/paperclipinc/openclaw-operator/issues/30)) ([c1aaa36](https://github.com/paperclipinc/openclaw-operator/commit/c1aaa3639b7cb82eb95696bbe06b98817d46a55e))
+* change CRD API group domain from openclaw.io to openclaw.rocks ([#41](https://github.com/paperclipinc/openclaw-operator/issues/41)) ([5bae852](https://github.com/paperclipinc/openclaw-operator/commit/5bae852810d249358fad1453694503298851208c))
+* Prevent endless Deployment reconciliation loop ([#29](https://github.com/paperclipinc/openclaw-operator/issues/29)) ([db942b9](https://github.com/paperclipinc/openclaw-operator/commit/db942b945586e6c3b49db7f0d3ca242f5fac7b44)), closes [#28](https://github.com/paperclipinc/openclaw-operator/issues/28)
+* update banner alt text ([#38](https://github.com/paperclipinc/openclaw-operator/issues/38)) ([d00dc23](https://github.com/paperclipinc/openclaw-operator/commit/d00dc23516d79e6a95b6aeca9d5d29c1a777e0e6))
 
 ## [Unreleased]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@
 
 Go-based Kubernetes operator for managing OpenClaw instances, built with controller-runtime (kubebuilder). CRD API group is `openclaw.rocks`, version `v1alpha1`.
 
-- **Module:** `github.com/openclawrocks/openclaw-operator`
+- **Module:** `github.com/paperclipinc/openclaw-operator`
 - **Go version:** 1.25
-- **GitHub:** `openclaw-rocks/openclaw-operator` (GHCR org: `openclaw-rocks`)
+- **GitHub:** `paperclipinc/openclaw-operator` (GHCR org: `paperclipinc`)
 
 ## Commands
 
@@ -202,7 +202,7 @@ Automated via release-please + GoReleaser:
 5. Cosign signs images, SBOM is generated and attested
 6. SBOM uploaded to draft release, then release is published (using PAT)
 7. Published release triggers `operatorhub.yaml`: auto-submits bundle PR to `k8s-operatorhub/community-operators`
-8. Helm chart is packaged and pushed to `oci://ghcr.io/openclaw-rocks/charts`
+8. Helm chart is packaged and pushed to `oci://ghcr.io/paperclipinc/charts`
 
 **Key config files:**
 - `release-please-config.json` — `skip-github-release: true` (GoReleaser manages the release lifecycle)
@@ -214,4 +214,4 @@ Automated via release-please + GoReleaser:
 
 **Manual trigger:** `gh workflow run "OperatorHub Submission" -f tag=vX.Y.Z`
 
-Image: `ghcr.io/openclaw-rocks/openclaw-operator`
+Image: `ghcr.io/paperclipinc/openclaw-operator`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ git clone https://github.com/YOUR_USERNAME/openclaw-operator.git
 cd openclaw-operator
 
 # Add upstream remote
-git remote add upstream https://github.com/OpenClaw-rocks/openclaw-operator.git
+git remote add upstream https://github.com/paperclipinc/openclaw-operator.git
 
 # Install dependencies
 go mod download

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 OpenClaw.rocks
+   Copyright 2026 Paperclip.inc
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/openclaw-rocks/openclaw-operator:latest
+IMG ?= ghcr.io/paperclipinc/openclaw-operator:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0

--- a/PROJECT
+++ b/PROJECT
@@ -5,7 +5,7 @@ domain: openclaw.rocks
 layout:
 - go.kubebuilder.io/v4
 projectName: openclaw-operator
-repo: github.com/openclawrocks/openclaw-operator
+repo: github.com/paperclipinc/openclaw-operator
 resources:
 - api:
     crdVersion: v1
@@ -14,7 +14,7 @@ resources:
   domain: openclaw.rocks
   group: ""
   kind: OpenClawInstance
-  path: github.com/openclawrocks/openclaw-operator/api/v1alpha1
+  path: github.com/paperclipinc/openclaw-operator/api/v1alpha1
   version: v1alpha1
   webhooks:
     validation: true
@@ -25,6 +25,6 @@ resources:
   domain: openclaw.rocks
   group: ""
   kind: OpenClawSelfConfig
-  path: github.com/openclawrocks/openclaw-operator/api/v1alpha1
+  path: github.com/paperclipinc/openclaw-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Every request is validated against the instance's allowlist policy. Protected co
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-operator-system \
   --create-namespace
 ```
@@ -156,7 +156,7 @@ helm install openclaw-operator \
 make install
 
 # Deploy the operator
-make deploy IMG=ghcr.io/openclaw-rocks/openclaw-operator:latest
+make deploy IMG=ghcr.io/paperclipinc/openclaw-operator:latest
 ```
 
 </details>
@@ -172,7 +172,7 @@ to that list (plus the operator's own namespace, for backup credentials).
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-operator-system \
   --create-namespace \
   --set 'watchNamespaces={team-a,team-b}'
@@ -185,7 +185,7 @@ SecurityCenter policy), disable chart-managed RBAC:
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-operator-system \
   --create-namespace \
   --set rbac.create=false
@@ -483,8 +483,8 @@ Skill packs bundle multiple files (SKILL.md, scripts, config) into a single inst
 ```yaml
 spec:
   skills:
-    - "pack:openclaw-rocks/skills/image-gen"            # latest from default branch
-    - "pack:openclaw-rocks/skills/image-gen@v1.0.0"     # pinned to tag
+    - "pack:paperclipinc/skills/image-gen"            # latest from default branch
+    - "pack:paperclipinc/skills/image-gen@v1.0.0"     # pinned to tag
     - "pack:myorg/private-skills/custom-tool@main"       # private repo (requires GITHUB_TOKEN)
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 # OpenClaw Kubernetes Operator
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Go Report Card](https://goreportcard.com/badge/github.com/OpenClaw-rocks/openclaw-operator)](https://goreportcard.com/report/github.com/OpenClaw-rocks/openclaw-operator)
-[![CI](https://github.com/OpenClaw-rocks/openclaw-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/OpenClaw-rocks/openclaw-operator/actions/workflows/ci.yaml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/paperclipinc/openclaw-operator)](https://goreportcard.com/report/github.com/paperclipinc/openclaw-operator)
+[![CI](https://github.com/paperclipinc/openclaw-operator/actions/workflows/ci.yaml/badge.svg)](https://github.com/paperclipinc/openclaw-operator/actions/workflows/ci.yaml)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-1.28%2B-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io)
 [![Go](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go&logoColor=white)](https://go.dev)
 
@@ -1248,7 +1248,7 @@ Platform-specific deployment guides are available for:
 
 ```bash
 # Clone and set up
-git clone https://github.com/OpenClaw-rocks/openclaw-operator.git
+git clone https://github.com/paperclipinc/openclaw-operator.git
 cd openclaw-operator
 go mod download
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ If you discover a security vulnerability in the OpenClaw Kubernetes Operator, pl
 ### How to Report
 
 1. Email: Send a detailed report to **security@openclaw.rocks**
-2. GitHub: Use [GitHub's private vulnerability reporting](https://github.com/OpenClaw-rocks/openclaw-operator/security/advisories/new)
+2. GitHub: Use [GitHub's private vulnerability reporting](https://github.com/paperclipinc/openclaw-operator/security/advisories/new)
 
 ### What to Include
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
 repositoryID: 0ee43d67-67cc-4efb-8b56-ee4fc577cb6c
 owners:
   - name: Jannes Stubbemann
-    email: jannes@openclaw.rocks
+    email: jannes@paperclip.inc

--- a/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
+++ b/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     containerImage: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
     createdAt: "2026-02-11T00:00:00Z"
     support: OpenClaw.rocks
-    repository: https://github.com/OpenClaw-rocks/openclaw-operator
+    repository: https://github.com/paperclipinc/openclaw-operator
     description: "A production-grade Kubernetes operator for deploying and managing OpenClaw AI agent instances with auto-updates, backup/restore, and security hardening."
     alm-examples: |-
       [
@@ -205,11 +205,11 @@ spec:
     - name: Operator Documentation
       url: https://openclaw.rocks/docs/operator/0.10
     - name: API Reference
-      url: https://github.com/OpenClaw-rocks/openclaw-operator/blob/main/docs/api-reference.md
+      url: https://github.com/paperclipinc/openclaw-operator/blob/main/docs/api-reference.md
     - name: GitHub Repository
-      url: https://github.com/OpenClaw-rocks/openclaw-operator
+      url: https://github.com/paperclipinc/openclaw-operator
     - name: Changelog
-      url: https://github.com/OpenClaw-rocks/openclaw-operator/blob/main/CHANGELOG.md
+      url: https://github.com/paperclipinc/openclaw-operator/blob/main/CHANGELOG.md
   icon:
     - base64data: PHN2ZyB2aWV3Qm94PSIwIDAgMTIwIDEyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNNjAgMTAgQzMwIDEwIDE1IDM1IDE1IDU1IEMxNSA3NSAzMCA5NSA0NSAxMDAgTDQ1IDExMCBMNTUgMTEwIEw1NSAxMDAgQzU1IDEwMCA2MCAxMDIgNjUgMTAwIEw2NSAxMTAgTDc1IDExMCBMNzUgMTAwIEM5MCA5NSAxMDUgNzUgMTA1IDU1IEMxMDUgMzUgOTAgMTAgNjAgMTBaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+CiAgPHBhdGggZD0iTTIwIDQ1IEM1IDQwIDAgNTAgNSA2MCBDMTAgNzAgMjAgNjUgMjUgNTUgQzI4IDQ4IDI1IDQ1IDIwIDQ1WiIgZmlsbD0idXJsKCNsb2JzdGVyLWdyYWRpZW50KSIvPgogIDxwYXRoIGQ9Ik0xMDAgNDUgQzExNSA0MCAxMjAgNTAgMTE1IDYwIEMxMTAgNzAgMTAwIDY1IDk1IDU1IEM5MiA0OCA5NSA0NSAxMDAgNDVaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+CiAgPHBhdGggZD0iTTQ1IDE1IFEzNSA1IDMwIDgiIHN0cm9rZT0iI2Y4NzE3MSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8cGF0aCBkPSJNNzUgMTUgUTg1IDUgOTAgOCIgc3Ryb2tlPSIjZjg3MTcxIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogIDxwYXRoIGQ9Ik0zMCAzMiBMNTIgMzIgTDUyIDQyIFE1MiA0NiA0OCA0NiBMMzQgNDYgUTMwIDQ2IDMwIDQyIFoiIGZpbGw9IiMwYTBhMGIiLz4KICA8cGF0aCBkPSJNNjggMzIgTDkwIDMyIEw5MCA0MiBROTAgNDYgODYgNDYgTDcyIDQ2IFE2OCA0NiA2OCA0MiBaIiBmaWxsPSIjMGEwYTBiIi8+CiAgPHBhdGggZD0iTTUyIDM2IEw2OCAzNiIgc3Ryb2tlPSIjMGEwYTBiIiBzdHJva2Utd2lkdGg9IjMiLz4KICA8cmVjdCB4PSIzMiIgeT0iMzQiIHdpZHRoPSI2IiBoZWlnaHQ9IjIiIGZpbGw9IiNmYWZhZmEiIG9wYWNpdHk9IjAuMyIgcng9IjEiLz4KICA8cmVjdCB4PSI3MCIgeT0iMzQiIHdpZHRoPSI2IiBoZWlnaHQ9IjIiIGZpbGw9IiNmYWZhZmEiIG9wYWNpdHk9IjAuMyIgcng9IjEiLz4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0ibG9ic3Rlci1ncmFkaWVudCIgeDE9IjAlIiB5MT0iMCUiIHgyPSIxMDAlIiB5Mj0iMTAwJSI+CiAgICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiNmODcxNzEiLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjZGMyNjI2Ii8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogIDwvZGVmcz4KPC9zdmc+Cg==
       mediatype: image/svg+xml

--- a/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
+++ b/bundle/manifests/openclaw-operator.v0.9.0.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     capabilities: "Auto Pilot"
     categories: "AI/Machine Learning, Developer Tools, Application Runtime"
-    containerImage: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+    containerImage: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
     createdAt: "2026-02-11T00:00:00Z"
     support: OpenClaw.rocks
     repository: https://github.com/OpenClaw-rocks/openclaw-operator
@@ -224,7 +224,7 @@ spec:
       supported: true
   relatedImages:
     - name: openclaw-operator
-      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+      image: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
     - name: openclaw
       image: ghcr.io/openclaw/openclaw:latest
     - name: chromium-sidecar
@@ -588,7 +588,7 @@ spec:
                 terminationGracePeriodSeconds: 10
                 containers:
                   - name: manager
-                    image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+                    image: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
                     command:
                       - /manager
                     args:

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -67,7 +67,7 @@ annotations:
             size: 10Gi
   artifacthub.io/images: |
     - name: openclaw-operator
-      image: ghcr.io/openclaw-rocks/openclaw-operator:v0.9.0
+      image: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
   artifacthub.io/changes: |
     - kind: added
       description: PVC backup-on-delete and restore-from-backup via rclone/S3

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -18,7 +18,7 @@ keywords:
 home: https://openclaw.rocks
 icon: https://openclaw.rocks/favicon.svg
 sources:
-  - https://github.com/OpenClaw-rocks/openclaw-operator
+  - https://github.com/paperclipinc/openclaw-operator
 maintainers:
   - name: Jannes Stubbemann
     email: jannes@openclaw.rocks
@@ -40,7 +40,7 @@ annotations:
     - name: Artifact Hub
       url: https://artifacthub.io/packages/olm/community-operators/openclaw-operator
     - name: support
-      url: https://github.com/OpenClaw-rocks/openclaw-operator/issues
+      url: https://github.com/paperclipinc/openclaw-operator/issues
   artifacthub.io/crds: |
     - kind: OpenClawInstance
       version: v1alpha1

--- a/charts/openclaw-operator/templates/NOTES.txt
+++ b/charts/openclaw-operator/templates/NOTES.txt
@@ -53,9 +53,9 @@ on every `helm upgrade`.
 ## Documentation
 
 For more information, visit:
-https://github.com/OpenClaw-rocks/openclaw-operator
+https://github.com/paperclipinc/openclaw-operator
 
 ## Getting Help
 
 If you encounter any issues, please file an issue at:
-https://github.com/OpenClaw-rocks/openclaw-operator/issues
+https://github.com/paperclipinc/openclaw-operator/issues

--- a/charts/openclaw-operator/values.yaml
+++ b/charts/openclaw-operator/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 # Operator image configuration
 image:
-  repository: ghcr.io/openclaw-rocks/openclaw-operator
+  repository: ghcr.io/paperclipinc/openclaw-operator
   pullPolicy: IfNotPresent
   tag: ""  # Defaults to chart appVersion
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,10 +48,10 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/controller"
-	"github.com/openclawrocks/openclaw-operator/internal/registry"
-	"github.com/openclawrocks/openclaw-operator/internal/skillpacks"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/controller"
+	"github.com/paperclipinc/openclaw-operator/internal/registry"
+	"github.com/paperclipinc/openclaw-operator/internal/skillpacks"
 )
 
 // version is set at build time via ldflags (see .goreleaser.yaml).

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: controller
-    newName: ghcr.io/openclaw-rocks/openclaw-operator
+    newName: ghcr.io/paperclipinc/openclaw-operator
     newTag: latest

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,7 +1,7 @@
 # Docs site for openclaw-operator
 
 This directory contains the mkdocs-material project that publishes
-[openclaw.rocks/docs/operator/](https://openclaw.rocks/docs/operator/latest/).
+[paperclipinc.github.io/openclaw-operator/](https://paperclipinc.github.io/openclaw-operator/latest/).
 
 ## Local preview
 
@@ -42,7 +42,7 @@ run `make api-docs` and commit the result in the same PR.
 out the released tag, runs `mike deploy <minor> latest`, and pushes to
 `gh-pages`. GH Pages serves the result at
 `docs-operator.openclaw.rocks`, and Caddy on the openclaw.rocks box
-reverse-proxies `openclaw.rocks/docs/operator/*` to it.
+reverse-proxies `paperclipinc.github.io/openclaw-operator/*` to it.
 
 ## Republishing a specific tag manually
 

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -2,8 +2,8 @@ site_name: OpenClaw Operator
 site_url: https://openclaw.rocks/docs/operator/
 site_description: Kubernetes operator for managing OpenClaw AI agent instances with production-grade security, observability, and lifecycle management.
 site_author: OpenClaw.rocks
-repo_url: https://github.com/openclaw-rocks/openclaw-operator
-repo_name: openclaw-rocks/openclaw-operator
+repo_url: https://github.com/paperclipinc/openclaw-operator
+repo_name: paperclipinc/openclaw-operator
 edit_uri: edit/main/docs/
 copyright: Copyright &copy; OpenClaw.rocks
 
@@ -108,4 +108,4 @@ extra:
     posthog: !ENV [POSTHOG_KEY, '']
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/openclaw-rocks/openclaw-operator
+      link: https://github.com/paperclipinc/openclaw-operator

--- a/docs-site/overrides/404.html
+++ b/docs-site/overrides/404.html
@@ -11,7 +11,7 @@
       <li>Search using the bar at the top of the page.</li>
       <li>Jump to the <a href="/docs/operator/latest/">latest docs</a>.</li>
       <li>Browse the <a href="/docs/operator/latest/api-reference/">API reference</a>.</li>
-      <li>Open a question on <a href="https://github.com/openclaw-rocks/openclaw-operator/issues/new/choose">GitHub Issues</a>.</li>
+      <li>Open a question on <a href="https://github.com/paperclipinc/openclaw-operator/issues/new/choose">GitHub Issues</a>.</li>
     </ul>
   </article>
 </div>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,7 +1,7 @@
 # API Reference
 
 ## Packages
-- [openclaw.rocks/v1alpha1](#openclawrocksv1alpha1)
+- [openclaw.rocks/v1alpha1](#paperclipincv1alpha1)
 
 
 ## openclaw.rocks/v1alpha1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,7 +1,7 @@
 # API Reference
 
 ## Packages
-- [openclaw.rocks/v1alpha1](#paperclipincv1alpha1)
+- [openclaw.rocks/v1alpha1](#openclawrocksv1alpha1)
 
 
 ## openclaw.rocks/v1alpha1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -467,7 +467,7 @@ helm install openclaw-operator \
 
 ```bash
 # Clone the repository
-git clone https://github.com/OpenClaw-rocks/openclaw-operator.git
+git clone https://github.com/paperclipinc/openclaw-operator.git
 cd openclaw-operator
 
 # Install CRDs

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -146,7 +146,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -263,7 +263,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -383,7 +383,7 @@ EOF
 
 ```bash
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -458,7 +458,7 @@ kubectl get storageclass
 ```bash
 # Add the OCI registry (no separate repo add needed for OCI)
 helm install openclaw-operator \
-  oci://ghcr.io/openclaw-rocks/charts/openclaw-operator \
+  oci://ghcr.io/paperclipinc/charts/openclaw-operator \
   --namespace openclaw-system --create-namespace \
   --set leaderElection.enabled=true
 ```
@@ -474,7 +474,7 @@ cd openclaw-operator
 make install
 
 # Deploy the operator
-make deploy IMG=ghcr.io/openclaw-rocks/openclaw-operator:v0.1.0
+make deploy IMG=ghcr.io/paperclipinc/openclaw-operator:v0.1.0
 ```
 
 ### 4. Create an Instance

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Ingress, and ServiceMonitor. The operator reconciles that resource into
 a hardened, monitored, self-healing deployment.
 
 For the project pitch and a feature overview, see the
-[README](https://github.com/openclaw-rocks/openclaw-operator).
+[README](https://github.com/paperclipinc/openclaw-operator).
 
 ## Where to start
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openclawrocks/openclaw-operator
+module github.com/paperclipinc/openclaw-operator
 
 go 1.25.0
 

--- a/internal/controller/autoupdate.go
+++ b/internal/controller/autoupdate.go
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 const (

--- a/internal/controller/backup.go
+++ b/internal/controller/backup.go
@@ -33,8 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 const (

--- a/internal/controller/backup_test.go
+++ b/internal/controller/backup_test.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("Backup on Delete", func() {

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -49,10 +49,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/registry"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
-	"github.com/openclawrocks/openclaw-operator/internal/skillpacks"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/registry"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
+	"github.com/paperclipinc/openclaw-operator/internal/skillpacks"
 )
 
 const (

--- a/internal/controller/openclawinstance_controller_test.go
+++ b/internal/controller/openclawinstance_controller_test.go
@@ -31,8 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("OpenClawInstance Controller", func() {

--- a/internal/controller/openclawselfconfig_controller.go
+++ b/internal/controller/openclawselfconfig_controller.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 const (

--- a/internal/controller/openclawselfconfig_controller_test.go
+++ b/internal/controller/openclawselfconfig_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 var _ = Describe("OpenClawSelfConfig Controller", func() {

--- a/internal/controller/restore.go
+++ b/internal/controller/restore.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // reconcileRestore handles restoring PVC data from an S3 backup before StatefulSet creation.

--- a/internal/controller/restore_test.go
+++ b/internal/controller/restore_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 var _ = Describe("Restore from Backup", func() {

--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 const (

--- a/internal/controller/s3_test.go
+++ b/internal/controller/s3_test.go
@@ -24,8 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("S3 Helpers", func() {

--- a/internal/controller/selfconfig_apply.go
+++ b/internal/controller/selfconfig_apply.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // SelfConfigFieldManager is the SSA field manager name for SelfConfig changes.

--- a/internal/controller/selfconfig_apply_test.go
+++ b/internal/controller/selfconfig_apply_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 func newTestInstance() *openclawv1alpha1.OpenClawInstance {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 var (

--- a/internal/resources/bootstrap_skill.go
+++ b/internal/resources/bootstrap_skill.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resources
 
 import (
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // bootstrapEnabled reports whether the operator should inject BOOTSTRAP.md

--- a/internal/resources/cluster_defaults.go
+++ b/internal/resources/cluster_defaults.go
@@ -19,7 +19,7 @@ package resources
 import (
 	corev1 "k8s.io/api/core/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // ApplyClusterDefaults returns a deep copy of instance with unset fields filled

--- a/internal/resources/cluster_defaults_test.go
+++ b/internal/resources/cluster_defaults_test.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 func newClusterDefaults(spec *openclawv1alpha1.OpenClawClusterDefaultsSpec) *openclawv1alpha1.OpenClawClusterDefaults {

--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 var rLog = ctrl.Log.WithName("resources")

--- a/internal/resources/common_test.go
+++ b/internal/resources/common_test.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 func TestParseQuantity(t *testing.T) {

--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // BuildConfigMap creates a ConfigMap for the OpenClawInstance configuration.

--- a/internal/resources/grafana_dashboard.go
+++ b/internal/resources/grafana_dashboard.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 const defaultGrafanaFolder = "OpenClaw"

--- a/internal/resources/hpa.go
+++ b/internal/resources/hpa.go
@@ -21,7 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // HPAName returns the name of the HorizontalPodAutoscaler

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -23,7 +23,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // IngressProvider represents the detected ingress controller type

--- a/internal/resources/networkpolicy.go
+++ b/internal/resources/networkpolicy.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // BuildNetworkPolicy creates a NetworkPolicy for the OpenClawInstance

--- a/internal/resources/pdb.go
+++ b/internal/resources/pdb.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // BuildPDB creates a PodDisruptionBudget for the OpenClawInstance

--- a/internal/resources/prometheusrule.go
+++ b/internal/resources/prometheusrule.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 const defaultRunbookBaseURL = "https://openclaw.rocks/docs/runbooks"

--- a/internal/resources/pvc.go
+++ b/internal/resources/pvc.go
@@ -20,7 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // BuildPVC creates a PersistentVolumeClaim for the OpenClawInstance

--- a/internal/resources/rbac.go
+++ b/internal/resources/rbac.go
@@ -23,7 +23,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // BuildServiceAccount creates a ServiceAccount for the OpenClawInstance

--- a/internal/resources/resources_bench_test.go
+++ b/internal/resources/resources_bench_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // newBenchInstance creates a minimal instance for benchmarking.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // newTestInstance creates a minimal OpenClawInstance for testing.
@@ -5326,7 +5326,7 @@ func TestBuildStatefulSet_WritablePVCSubPaths(t *testing.T) {
 	// ~/.local and ~/.cache cover pip/npm/uv package installs; ~/.config is
 	// required for tools (e.g. Codex CLI, ACP runtimes) that write config to
 	// ~/.config/<tool>/ on startup under readOnlyRootFilesystem: true.
-	// See https://github.com/openclaw-rocks/openclaw-operator/issues/456.
+	// See https://github.com/paperclipinc/openclaw-operator/issues/456.
 	wantMounts := []struct {
 		mountPath string
 		subPath   string
@@ -5358,7 +5358,7 @@ func TestBuildStatefulSet_WritablePVCSubPaths(t *testing.T) {
 // the init containers create .local, .cache, and skills subdirectories with
 // the pod UID as owner. Every downstream container that mounts these paths via
 // SubPath inherits the correct ownership from the pre-created directory.
-// See https://github.com/openclaw-rocks/openclaw-operator/issues/448.
+// See https://github.com/paperclipinc/openclaw-operator/issues/448.
 func TestBuildStatefulSet_InitUvPipMountFullDataVolume(t *testing.T) {
 	instance := newTestInstance("init-uv-hostpath")
 	sts := BuildStatefulSet(instance, "", nil, nil, nil)
@@ -5435,7 +5435,7 @@ func TestBuildStatefulSet_InitUvPipMountFullDataVolume(t *testing.T) {
 // openclaw import at the current container image. Without this symlink, bundled
 // plugins (e.g. discord) crash loop after an image upgrade because they resolve
 // "openclaw" against the stale npm-cached package on the PVC.
-// See https://github.com/openclaw-rocks/openclaw-operator/issues/462.
+// See https://github.com/paperclipinc/openclaw-operator/issues/462.
 func TestBuildStatefulSet_PluginRuntimeDepsSymlink(t *testing.T) {
 	instance := newTestInstance("plugin-runtime-deps")
 	sts := BuildStatefulSet(instance, "", nil, nil, nil)
@@ -5682,7 +5682,7 @@ func TestNormalizeClawHubSlug(t *testing.T) {
 		{"@slug (no owner)", "@mcp-server-fetch", "mcp-server-fetch"},
 		{"nested path", "@org/sub/skill-name", "skill-name"},
 		{"npm: passthrough", "npm:@openclaw/matrix", "npm:@openclaw/matrix"},
-		{"pack: passthrough", "pack:openclaw-rocks/skills/image-gen", "pack:openclaw-rocks/skills/image-gen"},
+		{"pack: passthrough", "pack:paperclipinc/skills/image-gen", "pack:paperclipinc/skills/image-gen"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/resources/secret.go
+++ b/internal/resources/secret.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // HtpasswdEntry returns a single htpasswd line in {SHA} format for the given username and password.

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // BuildService creates a Service for the OpenClawInstance

--- a/internal/resources/servicemonitor.go
+++ b/internal/resources/servicemonitor.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // ServiceMonitorGVK returns the GroupVersionKind for ServiceMonitor

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -32,7 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // BuildStatefulSet creates a StatefulSet for the OpenClawInstance.

--- a/internal/resources/workspace_configmap.go
+++ b/internal/resources/workspace_configmap.go
@@ -23,7 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 const additionalWorkspaceKeySep = "--ws--"

--- a/internal/skillpacks/resolver.go
+++ b/internal/skillpacks/resolver.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 const defaultBaseURL = "https://api.github.com"

--- a/internal/skillpacks/resolver_test.go
+++ b/internal/skillpacks/resolver_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // ghFile returns a GitHub Contents API JSON response for a file.
@@ -53,10 +53,10 @@ func TestParsePackRef(t *testing.T) {
 		ref     string
 		wantErr bool
 	}{
-		{"openclaw-rocks/skills/image-gen", "openclaw-rocks", "skills", "image-gen", "", false},
-		{"openclaw-rocks/skills/image-gen@v1.0.0", "openclaw-rocks", "skills", "image-gen", "v1.0.0", false},
+		{"paperclipinc/skills/image-gen", "paperclipinc", "skills", "image-gen", "", false},
+		{"paperclipinc/skills/image-gen@v1.0.0", "paperclipinc", "skills", "image-gen", "v1.0.0", false},
 		{"myorg/private-skills/custom-tool@main", "myorg", "private-skills", "custom-tool", "main", false},
-		{"openclaw-rocks/skills/nested/deep/path@abc123", "openclaw-rocks", "skills", "nested/deep/path", "abc123", false},
+		{"paperclipinc/skills/nested/deep/path@abc123", "paperclipinc", "skills", "nested/deep/path", "abc123", false},
 		{"owner/repo", "", "", "", "", true},
 		{"invalid", "", "", "", "", true},
 	}

--- a/internal/webhook/openclawinstance_webhook.go
+++ b/internal/webhook/openclawinstance_webhook.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 const imageTagLatest = "latest"

--- a/internal/webhook/openclawinstance_webhook_test.go
+++ b/internal/webhook/openclawinstance_webhook_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 // ptr returns a pointer to the given value.

--- a/test/e2e/e2e_backup_cronjob_test.go
+++ b/test/e2e/e2e_backup_cronjob_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
 )
 
 var _ = Describe("Periodic Backup CronJob", func() {

--- a/test/e2e/e2e_chromium_cdp_test.go
+++ b/test/e2e/e2e_chromium_cdp_test.go
@@ -38,8 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // cdpCommand represents a Chrome DevTools Protocol command sent over WebSocket.

--- a/test/e2e/e2e_cluster_defaults_test.go
+++ b/test/e2e/e2e_cluster_defaults_test.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // This suite verifies #457 - cluster-wide defaults applied at reconcile time.

--- a/test/e2e/e2e_init_uv_hostpath_test.go
+++ b/test/e2e/e2e_init_uv_hostpath_test.go
@@ -28,8 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // This suite verifies the regression fix for #448: init-uv failing with

--- a/test/e2e/e2e_observability_test.go
+++ b/test/e2e/e2e_observability_test.go
@@ -32,8 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // prometheusRuleCRDAvailable checks if the PrometheusRule CRD is installed in the cluster.

--- a/test/e2e/e2e_plugin_runtime_deps_test.go
+++ b/test/e2e/e2e_plugin_runtime_deps_test.go
@@ -28,8 +28,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // This suite verifies the regression fix for #462: bundled plugin extensions

--- a/test/e2e/e2e_selfconfig_test.go
+++ b/test/e2e/e2e_selfconfig_test.go
@@ -29,8 +29,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("OpenClawSelfConfig Controller", func() {

--- a/test/e2e/e2e_skillpacks_test.go
+++ b/test/e2e/e2e_skillpacks_test.go
@@ -29,8 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("Skill Pack Resolution", func() {
@@ -65,7 +65,7 @@ var _ = Describe("Skill Pack Resolution", func() {
 				ref = "main"
 			}
 
-			packRef := "pack:openclaw-rocks/openclaw-operator/test/testdata/skill-packs/test-skill@" + ref
+			packRef := "pack:paperclipinc/openclaw-operator/test/testdata/skill-packs/test-skill@" + ref
 
 			instanceName := "skillpack-test"
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -42,8 +42,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var (

--- a/test/e2e/e2e_suspended_test.go
+++ b/test/e2e/e2e_suspended_test.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("Instance Suspension", func() {

--- a/test/e2e/e2e_workspace_additional_test.go
+++ b/test/e2e/e2e_workspace_additional_test.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("Additional Workspaces", func() {

--- a/test/e2e/e2e_workspace_bootstrap_disable_test.go
+++ b/test/e2e/e2e_workspace_bootstrap_disable_test.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // This suite verifies the opt-out behavior for operator-managed BOOTSTRAP.md

--- a/test/e2e/e2e_workspace_configmapref_test.go
+++ b/test/e2e/e2e_workspace_configmapref_test.go
@@ -27,8 +27,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 var _ = Describe("Workspace ConfigMapRef", func() {

--- a/test/e2e/e2e_workspace_nested_files_test.go
+++ b/test/e2e/e2e_workspace_nested_files_test.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	openclawv1alpha1 "github.com/openclawrocks/openclaw-operator/api/v1alpha1"
-	"github.com/openclawrocks/openclaw-operator/internal/resources"
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
 )
 
 // Regression for #482: nested paths in spec.workspace.initialFiles must


### PR DESCRIPTION
## Why

Org rename from openclaw-rocks → paperclipinc happened earlier. The repo + image + chart all migrated to the new org, but in-tree references still point at the old URL. Artifact Hub is failing to scan the chart's image because the old `ghcr.io/openclaw-rocks/openclaw-operator` URL now returns DENIED (since the package belongs to the renamed org).

## What changes

- **Go module path:** `github.com/openclaw-rocks/openclaw-operator` (as `openclawrocks` in go.mod) → `github.com/paperclipinc/openclaw-operator` (`go.mod` + every import statement across 72 files).
- **Image references in Helm chart:** `charts/openclaw-operator/values.yaml`, `Chart.yaml`.
- **OLM bundle CSV:** `bundle/manifests/openclaw-operator.v*.clusterserviceversion.yaml`.
- **CI workflows:** `.github/workflows/ci.yaml`, `operatorhub.yaml`.
- **Release tooling:** `Makefile`, `.goreleaser.yaml`, `config/manager/kustomization.yaml`.
- **Docs + README:** every `github.com/openclaw-rocks/...` and `ghcr.io/openclaw-rocks/...` URL.

`go build ./...` passes. Unit/webhook/resources/skillpacks tests pass. Controller integration tests and e2e tests require kubebuilder binaries and a live cluster respectively — those failures are pre-existing infrastructure constraints, not caused by this rename.

## After merge

Cut a new release. Once the new image publishes at `ghcr.io/paperclipinc/openclaw-operator:vN` and the chart at `ghcr.io/paperclipinc/charts/openclaw-operator:vN`, Artifact Hub re-scans against the new URL and the error emails stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)