### PR TITLE
fix(ci): operatorhub workflow gh repo fork CLI syntax

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -63,7 +63,7 @@ jobs:
           gh auth setup-git
 
           # Clone the community-operators repo (fork is auto-created by gh)
-          gh repo fork k8s-operatorhub/community-operators --clone=true --remote=true -- community-operators
+          gh repo fork k8s-operatorhub/community-operators --clone -- community-operators
           cd community-operators
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Fork and submit to community-operators
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.OPERATORHUB_FORK_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="openclaw-operator-v${VERSION}"


### PR DESCRIPTION
## Problem

`gh repo fork` has been failing every release since v0.34.1 with:

> the `--remote` flag is unsupported when a repository argument is provided

Newer gh CLI rejects `--remote=true` when a repository positional arg is also passed. The OperatorHub submission step never ran, so v0.34.0 is the last version on community-operators.

## Fix

Drop `--remote=true`. `gh repo fork --clone` already sets up `upstream` pointing at the original repo, which is all the next `git fetch upstream main` step needs.

After this merges, re-run "OperatorHub" workflow against v0.34.5 to submit the first paperclipinc-flavored bundle to community-operators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)