### PR TITLE
fix: idempotent plugin install in init-plugins container

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -6317,7 +6317,7 @@ func TestBuildStatefulSet_SkillsOnly_HasBothInitContainers(t *testing.T) {
 
 func TestParsePluginEntry_Basic(t *testing.T) {
 	got := parsePluginEntry("@martian-engineering/lossless-claw")
-	want := "openclaw plugins install 'clawhub:@martian-engineering/lossless-claw'"
+	want := "openclaw plugins install --force 'clawhub:@martian-engineering/lossless-claw'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -6325,7 +6325,7 @@ func TestParsePluginEntry_Basic(t *testing.T) {
 
 func TestParsePluginEntry_WithNpmPrefix(t *testing.T) {
 	got := parsePluginEntry("npm:@openclaw/some-plugin")
-	want := "openclaw plugins install 'npm:@openclaw/some-plugin'"
+	want := "openclaw plugins install --force 'npm:@openclaw/some-plugin'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -6333,7 +6333,7 @@ func TestParsePluginEntry_WithNpmPrefix(t *testing.T) {
 
 func TestParsePluginEntry_Unscoped(t *testing.T) {
 	got := parsePluginEntry("some-plugin")
-	want := "openclaw plugins install 'clawhub:some-plugin'"
+	want := "openclaw plugins install --force 'clawhub:some-plugin'"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -6343,9 +6343,9 @@ func TestParsePluginEntry_Versioned(t *testing.T) {
 	cases := []struct {
 		entry, want string
 	}{
-		{"brave-plugin@1.2.3", "openclaw plugins install 'clawhub:brave-plugin@1.2.3'"},
-		{"@openclaw/brave-plugin@1.2.3", "openclaw plugins install 'clawhub:@openclaw/brave-plugin@1.2.3'"},
-		{"npm:@openclaw/brave-plugin@1.2.3", "openclaw plugins install 'npm:@openclaw/brave-plugin@1.2.3'"},
+		{"brave-plugin@1.2.3", "openclaw plugins install --force 'clawhub:brave-plugin@1.2.3'"},
+		{"@openclaw/brave-plugin@1.2.3", "openclaw plugins install --force 'clawhub:@openclaw/brave-plugin@1.2.3'"},
+		{"npm:@openclaw/brave-plugin@1.2.3", "openclaw plugins install --force 'npm:@openclaw/brave-plugin@1.2.3'"},
 	}
 	for _, c := range cases {
 		if got := parsePluginEntry(c.entry); got != c.want {
@@ -6375,10 +6375,10 @@ func TestBuildPluginsScript_WithPlugins(t *testing.T) {
 	if !strings.Contains(script, "mkdir -p /home/openclaw/.openclaw/extensions") {
 		t.Error("script should ensure ~/.openclaw/extensions exists")
 	}
-	if !strings.Contains(script, "openclaw plugins install 'clawhub:@martian-engineering/lossless-claw'") {
+	if !strings.Contains(script, "openclaw plugins install --force 'clawhub:@martian-engineering/lossless-claw'") {
 		t.Errorf("script should install lossless-claw via openclaw CLI, got:\n%s", script)
 	}
-	if !strings.Contains(script, "openclaw plugins install 'clawhub:another-plugin'") {
+	if !strings.Contains(script, "openclaw plugins install --force 'clawhub:another-plugin'") {
 		t.Errorf("script should install another-plugin via openclaw CLI, got:\n%s", script)
 	}
 	// Regression guard: don't emit the old broken layout
@@ -6400,7 +6400,7 @@ func TestBuildPluginsScript_UsesClawhubCLI(t *testing.T) {
 
 	// The CLI handles workspace:* dependency markers correctly, whereas raw
 	// `npm install` rejects them with EUNSUPPORTEDPROTOCOL (#505).
-	want := "openclaw plugins install 'clawhub:@openclaw/matrix'"
+	want := "openclaw plugins install --force 'clawhub:@openclaw/matrix'"
 	if !strings.Contains(script, want) {
 		t.Errorf("expected %q in script, got:\n%s", want, script)
 	}
@@ -6524,8 +6524,8 @@ func TestBuildStatefulSet_WithPlugins_InitPluginsContainer(t *testing.T) {
 
 	// Script should invoke the openclaw CLI (#505)
 	script := pluginsContainer.Command[2]
-	if !strings.Contains(script, "openclaw plugins install") {
-		t.Errorf("expected openclaw plugins install in script, got: %q", script)
+	if !strings.Contains(script, "openclaw plugins install --force") {
+		t.Errorf("expected openclaw plugins install --force in script, got: %q", script)
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -1116,9 +1116,9 @@ func buildSkillsInitContainer(instance *openclawv1alpha1.OpenClawInstance) *core
 // raw npm rejects with EUNSUPPORTEDPROTOCOL (#505).
 func parsePluginEntry(entry string) string {
 	if pkg, ok := strings.CutPrefix(entry, "npm:"); ok {
-		return fmt.Sprintf("openclaw plugins install %s", shellQuote("npm:"+pkg))
+		return fmt.Sprintf("openclaw plugins install --force %s", shellQuote("npm:"+pkg))
 	}
-	return fmt.Sprintf("openclaw plugins install %s", shellQuote("clawhub:"+entry))
+	return fmt.Sprintf("openclaw plugins install --force %s", shellQuote("clawhub:"+entry))
 }
 
 // BuildPluginsScript generates the shell script for the plugins init container.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -2114,9 +2114,9 @@ var _ = Describe("OpenClawInstance Controller", func() {
 			script := pluginsContainer.Command[2]
 			Expect(script).To(ContainSubstring("mkdir -p /home/openclaw/.openclaw/extensions"),
 				"init-plugins must ensure the extensions directory exists")
-			Expect(script).To(ContainSubstring("openclaw plugins install 'clawhub:@openclaw/matrix'"),
+			Expect(script).To(ContainSubstring("openclaw plugins install --force 'clawhub:@openclaw/matrix'"),
 				"matrix must be installed via the openclaw CLI (issue #505)")
-			Expect(script).To(ContainSubstring("openclaw plugins install 'clawhub:@martian-engineering/lossless-claw'"),
+			Expect(script).To(ContainSubstring("openclaw plugins install --force 'clawhub:@martian-engineering/lossless-claw'"),
 				"third-party plugins must also go through the openclaw CLI")
 			// Regression guards: previous layouts that fail for workspace:*-publishing plugins.
 			Expect(script).NotTo(ContainSubstring("cd /home/openclaw/.openclaw && npm install"),


### PR DESCRIPTION
init-plugins runs on every pod start. With persistence enabled, the plugin already exists on the PVC from the previous run. `openclaw plugins install` exits non-zero with "plugin already exists", crashing the init container in a loop.

`--force` overwrites the existing install target, making the init container idempotent across pod restarts.