### PR TITLE
fix(helm): grant cluster-scoped OpenClawClusterDefaults RBAC under watchNamespaces

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,6 +71,17 @@ jobs:
       - name: Check Helm chart CRD templates match generated CRDs
         run: bash hack/sync-chart-crds.sh --check
 
+  helm-cluster-rbac:
+    name: Helm Cluster RBAC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Check cluster-scoped RBAC is granted in all watch modes
+        run: bash hack/check-helm-cluster-rbac.sh
+
   docs-build:
     name: Docs Build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -166,10 +166,14 @@ make deploy IMG=ghcr.io/paperclipinc/openclaw-operator:latest
 <summary>Restrict the operator to specific namespaces</summary>
 
 To run the operator with namespaced RBAC instead of cluster-wide permissions,
-list the namespaces it should watch. The chart switches from
-`ClusterRole`/`ClusterRoleBinding` to per-namespace `Role`/`RoleBinding`, and
-passes `--watch-namespaces` to the operator so its informer cache is scoped
-to that list (plus the operator's own namespace, for backup credentials).
+list the namespaces it should watch. The chart switches the namespace-scoped
+permissions from a `ClusterRole`/`ClusterRoleBinding` to per-namespace
+`Role`/`RoleBinding`, and passes `--watch-namespaces` to the operator so its
+informer cache is scoped to that list (plus the operator's own namespace, for
+backup credentials). A small `ClusterRole`/`ClusterRoleBinding` is still created
+for the cluster-scoped `OpenClawClusterDefaults` resource, which the operator
+watches regardless of namespace scoping -- a namespaced `Role` cannot grant
+access to a cluster-scoped resource.
 
 ```bash
 helm install openclaw-operator \

--- a/charts/openclaw-operator/templates/_helpers.tpl
+++ b/charts/openclaw-operator/templates/_helpers.tpl
@@ -142,6 +142,19 @@ kubebuilder-generated config/rbac/role.yaml.
 - apiGroups: ["openclaw.rocks"]
   resources: ["openclawselfconfigs/finalizers"]
   verbs: ["update"]
+{{- end }}
+
+{{/*
+Cluster-scoped manager rules. OpenClawClusterDefaults is a cluster-scoped
+singleton (#457), so the operator needs these permissions via a ClusterRole
+even when it watches only specific namespaces -- a namespaced Role cannot grant
+access to a cluster-scoped resource (#529). Kept separate from managerRules so
+the namespaced-mode per-namespace Roles do not carry an ineffective rule, while
+the cluster-wide ClusterRole renders both sets.
+hack/check-helm-rbac-sync.sh parses this define alongside managerRules so the
+union is asserted to be a superset of config/rbac/role.yaml.
+*/}}
+{{- define "openclaw-operator.clusterScopedRules" -}}
 # OpenClawClusterDefaults singleton (#457)
 - apiGroups: ["openclaw.rocks"]
   resources: ["openclawclusterdefaults"]

--- a/charts/openclaw-operator/templates/rbac.yaml
+++ b/charts/openclaw-operator/templates/rbac.yaml
@@ -35,6 +35,34 @@ subjects:
     name: {{ $saName }}
     namespace: {{ $saNamespace }}
 {{- end }}
+---
+# OpenClawClusterDefaults is cluster-scoped (#457). Even when watching specific
+# namespaces, the operator must be granted access via a ClusterRole -- a
+# namespaced Role cannot grant access to a cluster-scoped resource, so without
+# this the manager cache fails to sync and the operator shuts down (#529).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $managerName }}-cluster
+  labels:
+    {{- $labels | nindent 4 }}
+rules:
+  {{- include "openclaw-operator.clusterScopedRules" . | nindent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $managerBinding }}-cluster
+  labels:
+    {{- $labels | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $managerName }}-cluster
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $saNamespace }}
 {{- else }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -44,6 +72,7 @@ metadata:
     {{- $labels | nindent 4 }}
 rules:
   {{- include "openclaw-operator.managerRules" . | nindent 2 }}
+  {{- include "openclaw-operator.clusterScopedRules" . | nindent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/hack/check-helm-cluster-rbac.sh
+++ b/hack/check-helm-cluster-rbac.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# hack/check-helm-cluster-rbac.sh
+#
+# Regression guard for #529: OpenClawClusterDefaults is a cluster-scoped
+# resource, so the operator must always be granted access to it via a
+# ClusterRole -- including when it is configured to watch only specific
+# namespaces. A namespaced Role cannot grant access to a cluster-scoped
+# resource; without a ClusterRole the manager cache fails to sync and the
+# operator shuts down.
+#
+# This renders the chart with `helm template` in both modes and asserts:
+#   1. namespaced mode (watchNamespaces set) renders a ClusterRole that grants
+#      openclawclusterdefaults, and the per-namespace Roles do NOT carry it;
+#   2. cluster-wide mode (no watchNamespaces) keeps openclawclusterdefaults in
+#      the manager ClusterRole.
+
+set -euo pipefail
+
+CHART="charts/openclaw-operator"
+RESOURCE="openclawclusterdefaults"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "::error::helm is required to run this check"
+  exit 1
+fi
+
+fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+# Emit "<kind>|<name>" for every Role/ClusterRole document whose rules mention
+# $RESOURCE. Splits the rendered manifest into YAML documents and uses a plain
+# substring check, so it is robust to flow- vs block-style rule arrays and quoting.
+roles_granting_resource() {
+  awk -v res="$RESOURCE" '
+    BEGIN { RS = "\n---\n" }
+    {
+      kind = ""; name = ""
+      n = split($0, lines, "\n")
+      for (i = 1; i <= n; i++) {
+        if (lines[i] ~ /^kind:/)                       { sub(/^kind:[ ]*/, "", lines[i]); kind = lines[i] }
+        else if (lines[i] ~ /^  name:/ && name == "")  { sub(/^  name:[ ]*/, "", lines[i]); name = lines[i] }
+      }
+      if ((kind == "Role" || kind == "ClusterRole") && index($0, res) > 0)
+        print kind "|" name
+    }
+  '
+}
+
+echo "==> Rendering chart in namespaced mode (watchNamespaces={openclaw,team-a})"
+NS_RENDER=$(helm template oc "$CHART" --namespace openclaw --set 'watchNamespaces={openclaw,team-a}')
+NS_GRANTS=$(echo "$NS_RENDER" | roles_granting_resource)
+
+if ! echo "$NS_GRANTS" | grep -q "^ClusterRole|"; then
+  echo "Rendered roles granting $RESOURCE:"
+  echo "${NS_GRANTS:-<none>}"
+  fail "namespaced mode does not grant $RESOURCE via a ClusterRole (#529)"
+fi
+if echo "$NS_GRANTS" | grep -q "^Role|"; then
+  echo "$NS_GRANTS"
+  fail "namespaced mode grants $RESOURCE via a namespaced Role, which is ineffective for a cluster-scoped resource (#529)"
+fi
+echo "    OK: ClusterRole grants $RESOURCE; no namespaced Role does."
+
+echo "==> Rendering chart in cluster-wide mode (no watchNamespaces)"
+CW_RENDER=$(helm template oc "$CHART" --namespace openclaw)
+CW_GRANTS=$(echo "$CW_RENDER" | roles_granting_resource)
+
+if ! echo "$CW_GRANTS" | grep -q "^ClusterRole|"; then
+  echo "Rendered roles granting $RESOURCE:"
+  echo "${CW_GRANTS:-<none>}"
+  fail "cluster-wide mode does not grant $RESOURCE via a ClusterRole"
+fi
+echo "    OK: ClusterRole grants $RESOURCE."
+
+echo "Helm chart grants cluster-scoped $RESOURCE access in both watch modes."

--- a/hack/check-helm-rbac-sync.sh
+++ b/hack/check-helm-rbac-sync.sh
@@ -63,14 +63,16 @@ parse_generated() {
 }
 
 # Parse the manager rules block out of _helpers.tpl. The block lives between
-# `{{- define "openclaw-operator.managerRules" -}}` and the matching `{{- end }}`.
-# rbac.yaml renders these rules into either a ClusterRole or per-namespace Roles
-# via `{{ include "openclaw-operator.managerRules" . | nindent 2 }}`, so the
-# helper is the single source of truth for what permissions the operator gets.
+# `{{- define "openclaw-operator.managerRules" -}}` and the matching `{{- end }}`,
+# plus the cluster-scoped split `openclaw-operator.clusterScopedRules` (#529).
+# rbac.yaml renders these rules into ClusterRoles and/or per-namespace Roles via
+# `{{ include "openclaw-operator.managerRules" . | nindent 2 }}` (and the
+# clusterScopedRules include), so the union of both helpers is the single source
+# of truth for what permissions the operator gets.
 parse_helm() {
   awk '
-    /\{\{-? *define .openclaw-operator\.managerRules. *-?\}\}/ { in_rules = 1; next }
-    in_rules && /\{\{-? *end *-?\}\}/ { exit }
+    /\{\{-? *define .openclaw-operator\.(managerRules|clusterScopedRules). *-?\}\}/ { in_rules = 1; next }
+    in_rules && /\{\{-? *end *-?\}\}/ { in_rules = 0; next }
     !in_rules { next }
     /^\s*#/ { next }
 
@@ -110,6 +112,10 @@ parse_helm() {
 # matching helper rules that no template references.
 if ! grep -q 'openclaw-operator\.managerRules' "$HELM"; then
   echo "::error::$HELM does not include the openclaw-operator.managerRules helper"
+  exit 1
+fi
+if ! grep -q 'openclaw-operator\.clusterScopedRules' "$HELM"; then
+  echo "::error::$HELM does not include the openclaw-operator.clusterScopedRules helper (cluster-scoped RBAC, #529)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes #529. When the operator is installed with `watchNamespaces` set, it fails to start with:

```
openclawclusterdefaults.openclaw.rocks is forbidden: User "system:serviceaccount:openclaw:openclaw-operator" cannot list resource "openclawclusterdefaults" in API group "openclaw.rocks" at the cluster scope
```

## Root cause

`OpenClawClusterDefaults` is a **cluster-scoped** singleton (#457). In namespaced mode the chart rendered *all* of `openclaw-operator.managerRules` -- including the cluster-scoped `openclawclusterdefaults` rule -- into per-namespace `Role`s (`templates/rbac.yaml`). A namespaced `Role` cannot grant access to a cluster-scoped resource, so the manager's informer cache never syncs and the operator shuts down. Exactly the diagnosis in the issue.

## Fix

- Split the cluster-scoped rule out of `managerRules` into a new `openclaw-operator.clusterScopedRules` helper.
- **Namespaced mode** (`watchNamespaces` set): per-namespace `Role`/`RoleBinding` for namespaced resources (as before, minus the dead rule) **plus** a `ClusterRole`/`ClusterRoleBinding` (`<name>-manager-role-cluster`) granting `get;list;watch` on `openclawclusterdefaults`.
- **Cluster-wide mode** (default): the manager `ClusterRole` renders both rule sets -- effective permissions unchanged.
- Per-namespace `Role`s no longer carry the ineffective cluster-scoped rule.

This matches the issue's suggested fix (keep namespaced Roles for namespaced resources; always create cluster-scoped RBAC for cluster-scoped CRs).

## Tests

- `hack/check-helm-rbac-sync.sh` now parses both helpers, so the union stays a verified superset of the kubebuilder-generated `config/rbac/role.yaml`.
- New `hack/check-helm-cluster-rbac.sh` + **Helm Cluster RBAC** CI job render the chart in both watch modes and assert `openclawclusterdefaults` is granted via a `ClusterRole` (and *not* via a namespaced `Role`). Verified the guard fails against the pre-fix behavior.
- `helm lint` clean; rendered manifests parse as valid YAML in both modes.

## Verification

```
# namespaced mode
$ helm template oc charts/openclaw-operator --set 'watchNamespaces={openclaw,team-a}'
  ClusterRole oc-...-manager-role-cluster: openclawclusterdefaults=True  (+ ClusterRoleBinding)
  Role oc-...-manager-role: leaks-clusterdefaults=False   (x2 namespaces)

# cluster-wide mode (unchanged)
  ClusterRole oc-...-manager-role: openclawclusterdefaults=True, #resources=26
```

No Go/CRD/marker changes, so `config/crd/` and `config/rbac/role.yaml` are untouched.
