### PR TITLE
fix: disable metric_expiration on otel-collector prometheus exporter

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -243,6 +243,7 @@ func otelCollectorConfig(instance *openclawv1alpha1.OpenClawInstance) string {
 exporters:
   prometheus:
     endpoint: 0.0.0.0:%d
+    metric_expiration: 0s
 
 service:
   pipelines:

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2493,6 +2493,9 @@ func TestBuildConfigMap_OTelCollectorConfig(t *testing.T) {
 		t.Error("OTel config should contain OTLP receiver")
 	}
 	if !strings.Contains(config, "prometheus:") {
+		t.Error("OTel Collector config should contain prometheus exporter")
+	}
+	if !strings.Contains(config, "metric_expiration: 0s") {
 		t.Error("OTel config should contain Prometheus exporter")
 	}
 	if !strings.Contains(config, fmt.Sprintf("0.0.0.0:%d", DefaultMetricsPort)) {


### PR DESCRIPTION
The otel-collector sidecar's prometheus exporter uses a default metric_expiration of 5 minutes.
When the gateway has no activity for that period, counters (tokens_total, model_call_duration, etc.) are evicted from the /metrics endpoint. Prometheus/GMP scrapes see the series disappear and reappear, treating each reappearance as a new series rather than a continuation of a monotonic counter. This breaks rate() and increase() queries.

Set metric_expiration: 0s so counters persist for the lifetime of the otel-collector process. Memory impact is negligible — label cardinality is bounded by models × token_types × channels.