### PR TITLE
fix: keep otel-collector metrics alive (metric_expiration 8760h + directory-mount)

### DIFF
--- a/internal/resources/configmap.go
+++ b/internal/resources/configmap.go
@@ -243,6 +243,7 @@ func otelCollectorConfig(instance *openclawv1alpha1.OpenClawInstance) string {
 exporters:
   prometheus:
     endpoint: 0.0.0.0:%d
+    metric_expiration: 8760h
 
 service:
   pipelines:

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -2493,6 +2493,9 @@ func TestBuildConfigMap_OTelCollectorConfig(t *testing.T) {
 		t.Error("OTel config should contain OTLP receiver")
 	}
 	if !strings.Contains(config, "prometheus:") {
+		t.Error("OTel Collector config should contain prometheus exporter")
+	}
+	if !strings.Contains(config, "metric_expiration: 8760h") {
 		t.Error("OTel config should contain Prometheus exporter")
 	}
 	if !strings.Contains(config, fmt.Sprintf("0.0.0.0:%d", DefaultMetricsPort)) {
@@ -2523,10 +2526,10 @@ func TestBuildStatefulSet_OTelCollectorContainer(t *testing.T) {
 		found = true
 		// Verify metrics port is on the collector
 		assertContainerPort(t, c.Ports, "metrics", DefaultMetricsPort)
-		// Verify config volume mount
+		// Verify config volume mount (directory mount, no SubPath)
 		var hasConfigMount bool
 		for _, vm := range c.VolumeMounts {
-			if vm.SubPath == OTelCollectorConfigKey {
+			if vm.Name == "otel-collector-config" && vm.MountPath == "/etc/otel-collector" {
 				hasConfigMount = true
 			}
 		}

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -2181,7 +2181,7 @@ func buildVolumes(instance *openclawv1alpha1.OpenClawInstance, skillPacks *Resol
 		},
 	})
 
-	// OTel Collector config — directory mount (no subPath) so the kubelet
+	// OTel Collector config - directory mount (no subPath) so the kubelet
 	// uses an atomic symlink that tolerates ConfigMap/pod creation races.
 	if IsMetricsEnabled(instance) {
 		volumes = append(volumes, corev1.Volume{

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -2016,7 +2016,7 @@ func buildOTelCollectorContainer(instance *openclawv1alpha1.OpenClawInstance) co
 		Name:                     "otel-collector",
 		Image:                    image,
 		ImagePullPolicy:          corev1.PullIfNotPresent,
-		Args:                     []string{"--config=/etc/otel-collector/config.yaml"},
+		Args:                     []string{"--config=/etc/otel-collector/" + OTelCollectorConfigKey},
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 		SecurityContext: &corev1.SecurityContext{
@@ -2049,9 +2049,8 @@ func buildOTelCollectorContainer(instance *openclawv1alpha1.OpenClawInstance) co
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      "config",
-				MountPath: "/etc/otel-collector/config.yaml",
-				SubPath:   OTelCollectorConfigKey,
+				Name:      "otel-collector-config",
+				MountPath: "/etc/otel-collector",
 				ReadOnly:  true,
 			},
 		},
@@ -2181,6 +2180,28 @@ func buildVolumes(instance *openclawv1alpha1.OpenClawInstance, skillPacks *Resol
 			},
 		},
 	})
+
+	// OTel Collector config — directory mount (no subPath) so the kubelet
+	// uses an atomic symlink that tolerates ConfigMap/pod creation races.
+	if IsMetricsEnabled(instance) {
+		volumes = append(volumes, corev1.Volume{
+			Name: "otel-collector-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: ConfigMapName(instance),
+					},
+					DefaultMode: &defaultMode,
+					Items: []corev1.KeyToPath{
+						{
+							Key:  OTelCollectorConfigKey,
+							Path: OTelCollectorConfigKey,
+						},
+					},
+				},
+			},
+		})
+	}
 
 	// Workspace init volume (ConfigMap with seed files)
 	if hasWorkspaceFiles(instance, skillPacks) {


### PR DESCRIPTION
Supersedes #537.

The prometheus exporter defaulted to metric_expiration: 5m, evicting counters (`tokens_total`, `model_call_duration`, etc.) from `/metrics` after the gateway goes idle that long. Since the gateway only pushes OTLP during model calls, idle gaps routinely exceed 5m, so GMP saw series disappear and reappear and treated each reappearance as a new series, breaking `rate()/increase()`.

A prior attempt (#537) set 0s intending "never expire", but in this exporter 0s means expire immediately, so /metrics was always empty. Set it to 8760h, longer than any expected idle gap, so counters persist for the pod's lifetime. Counter resets on pod restart remain handled by PromQL reset detection.

Also mount the collector config as a directory (no subPath) so the kubelet uses an atomic symlink that tolerates ConfigMap/pod creation races, instead of a subPath bind-mount that could resolve to an empty file when ConfigMap and pod are created in the same instant.