### PR TITLE
ci: guard chart image.repository against namespace drift

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,15 @@ jobs:
           fi
           echo "No unconditional Update calls on managed resources found."
 
+  chart-image-repository:
+    name: Chart Image Repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check chart image.repository uses the canonical namespace
+        run: bash hack/check-chart-image-repository.sh
+
   helm-rbac-sync:
     name: Helm RBAC Sync
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ All checks run on every push to main and every PR:
 | **Test** | `make test` (unit + envtest integration) |
 | **Security Scan** | gosec + Trivy (CRITICAL/HIGH) |
 | **Reconcile Guard** | Grep check preventing bare `r.Update()` on managed resources |
+| **Chart Image Repository** | Verifies the chart `image.repository` default points at the canonical `ghcr.io/paperclipinc` namespace (guards against the #536 stale-namespace regression) |
 | **Helm RBAC Sync** | Verifies Helm chart ClusterRole contains all kubebuilder RBAC permissions |
 | **Docs Build** | `mkdocs build --strict` against `docs-site/`; uploads preview artifact on PRs |
 | **API Docs Sync** | Verifies `docs/api-reference.md` matches output of `make api-docs` |

--- a/hack/check-chart-image-repository.sh
+++ b/hack/check-chart-image-repository.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# hack/check-chart-image-repository.sh
+#
+# Verifies that the Helm chart's default image.repository points at the
+# canonical paperclipinc GHCR namespace.
+#
+# Background: chart releases 0.32.0 to 0.34.4 shipped with a stale
+# 'ghcr.io/openclaw-rocks/openclaw-operator' default left over from the
+# openclaw-rocks -> paperclipinc org rename. The old namespace returns 403 on
+# anonymous pull, so deploying those charts failed silently with
+# ImagePullBackOff. See: https://github.com/paperclipinc/openclaw-operator/issues/536
+#
+# This guard fails the build if the default ever drifts away from the
+# canonical namespace again.
+
+set -euo pipefail
+
+VALUES="charts/openclaw-operator/values.yaml"
+EXPECTED="ghcr.io/paperclipinc/openclaw-operator"
+
+if [ ! -f "$VALUES" ]; then
+  echo "::error::Chart values not found at $VALUES"
+  exit 1
+fi
+
+# Extract the first 'repository:' under the top-level 'image:' block.
+ACTUAL=$(awk '
+  /^image:/ { in_image = 1; next }
+  in_image && /^[^[:space:]]/ { in_image = 0 }
+  in_image && /^[[:space:]]+repository:/ {
+    sub(/^[[:space:]]+repository:[[:space:]]*/, "")
+    gsub(/["'"'"']/, "")
+    print
+    exit
+  }
+' "$VALUES")
+
+if [ -z "$ACTUAL" ]; then
+  echo "::error::Could not find image.repository in $VALUES"
+  exit 1
+fi
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  echo "::error::Chart image.repository is '$ACTUAL', expected '$EXPECTED'."
+  echo "The chart must default to the canonical paperclipinc GHCR namespace so"
+  echo "published charts pull successfully. See issue #536."
+  exit 1
+fi
+
+echo "Chart image.repository is correct: $ACTUAL"


### PR DESCRIPTION
## Summary

Adds a CI guard (`Chart Image Repository` job) that fails the build if the Helm chart default `image.repository` in `charts/openclaw-operator/values.yaml` drifts away from the canonical `ghcr.io/paperclipinc/openclaw-operator` namespace.

## Why

Chart releases 0.32.0 to 0.34.4 shipped with a stale `ghcr.io/openclaw-rocks/openclaw-operator` default left over from the org rename. The old namespace returns 403 on anonymous pull, so those charts failed silently with `ImagePullBackOff` (#536). The affected charts have been re-published in place; this guard prevents the regression from recurring.

## Changes

- `hack/check-chart-image-repository.sh`: parses the `image.repository` default and asserts it equals the canonical namespace (mirrors the existing `check-helm-rbac-sync.sh` style).
- `.github/workflows/ci.yaml`: new `chart-image-repository` job.
- `CLAUDE.md`: documents the new job in the CI pipeline table.

## Validation

Verified locally: passes on the current correct values, exits 1 with a clear `::error::` on a simulated stale namespace.

Closes #540