### PR TITLE
Phase 1: world-class Artifact Hub presence (chart signing + image annotation)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,6 +120,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write  # keyless cosign signing of the chart artifact
 
     steps:
       - name: Checkout
@@ -132,6 +133,9 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
       - name: Extract version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
@@ -143,8 +147,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Package and push Helm chart to OCI registry
+      - name: Package, push, and sign Helm chart
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          OWNER="${{ steps.owner.outputs.name }}"
           helm package charts/openclaw-operator --version "${VERSION}" --app-version "${VERSION}"
-          helm push "openclaw-operator-${VERSION}.tgz" oci://ghcr.io/${{ steps.owner.outputs.name }}/charts
+          PUSH_OUT=$(helm push "openclaw-operator-${VERSION}.tgz" "oci://ghcr.io/${OWNER}/charts" 2>&1)
+          echo "${PUSH_OUT}"
+          DIGEST=$(echo "${PUSH_OUT}" | awk '/Digest:/ {print $2}')
+          if [ -z "${DIGEST}" ]; then echo "::error::could not parse chart digest"; exit 1; fi
+          cosign sign --yes "ghcr.io/${OWNER}/charts/openclaw-operator@${DIGEST}"

--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -65,9 +65,13 @@ annotations:
           persistence:
             enabled: true
             size: 10Gi
+  # The trailing "# x-release-please-version" below is intentional and must stay
+  # inline on the image line: release-please's generic updater bumps the tag on
+  # that line, and Artifact Hub parses this block as YAML so it treats the marker
+  # as a comment. Do not move it to its own line — that breaks the auto-bump.
   artifacthub.io/images: |
     - name: openclaw-operator
-      image: ghcr.io/paperclipinc/openclaw-operator:v0.9.0
+      image: ghcr.io/paperclipinc/openclaw-operator:v0.36.1 # x-release-please-version
   artifacthub.io/changes: |
     - kind: added
       description: PVC backup-on-delete and restore-from-backup via rclone/S3

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,10 @@
           "type": "yaml",
           "path": "charts/openclaw-operator/Chart.yaml",
           "jsonpath": "$.appVersion"
+        },
+        {
+          "type": "generic",
+          "path": "charts/openclaw-operator/Chart.yaml"
         }
       ]
     }


### PR DESCRIPTION
Phase 1 of the Artifact Hub / OperatorHub world-class effort (spec & plan in `paperclip-operator/docs/superpowers/`).

## Changes
- **fix(chart):** `artifacthub.io/images` was stale at `v0.9.0`; now matches the rendered image tag (`v0.36.1`) and auto-bumps on release via a `# x-release-please-version` marker + release-please `generic` updater.
- **ci(release):** the `helm-release` job now keyless-cosign-signs the pushed Helm chart artifact (mirrors the existing image signing), adding supply-chain trust to the chart on Artifact Hub.

## Verification
- `helm lint` passes; annotation parses to a clean `ghcr.io/paperclipinc/openclaw-operator:v0.36.1`.
- Chart-signing step captures the push digest and signs `@<digest>`, failing loudly if the digest can't be parsed.

## Notes
- No `artifacthub.io/signKey` annotation added — that is for GPG `.prov` provenance, not keyless cosign.
- Follow-ups (separate, gated): cut the release, retire/clean dead pre-migration chart tags, stand up the verified `paperclipinc` Artifact Hub org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)