### PR TITLE
fix(chart): refresh changelog for signed-chart release (0.36.2)

### DIFF
--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -74,4 +74,6 @@ annotations:
       image: ghcr.io/paperclipinc/openclaw-operator:v0.36.1 # x-release-please-version
   artifacthub.io/changes: |
     - kind: added
-      description: PVC backup-on-delete and restore-from-backup via rclone/S3
+      description: Helm chart OCI artifact is now cosign-signed (keyless)
+    - kind: fixed
+      description: artifacthub.io/images annotation now tracks the released operator image tag


### PR DESCRIPTION
Forces a release (`Release-As: 0.36.2`) to ship the two Phase-1 fixes already merged in #544:
- Helm chart OCI artifact is now cosign-signed (keyless).
- `artifacthub.io/images` annotation now tracks the released operator image tag (and auto-bumps).

On merge, release-please cuts `v0.36.2`; the release pipeline publishes a **signed** chart + image and auto-files a fresh `paperclipinc` OLM bundle PR to `k8s-operatorhub/community-operators` (refreshing the operatorhub.io listing off the stale `openclaw-rocks` `0.2.4` bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)