### PR TITLE
fix(ci): sync OperatorHub fork to avoid workflow-scope push rejection

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -78,11 +78,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Sync fork with upstream to avoid stale-branch CI failures
-          git fetch upstream main
-          git reset --hard upstream/main
+          FORK_OWNER=$(gh api user --jq '.login')
 
-          git checkout -b "${BRANCH}"
+          # Sync the fork's main with upstream SERVER-SIDE. gh repo sync performs a
+          # fast-forward via the GitHub API and is exempt from the PAT 'workflow'
+          # scope restriction. Previously we reset --hard to upstream/main and pushed
+          # the branch, which carried upstream's .github/workflows changes; a PAT
+          # without 'workflow' scope is refused that push (broke v0.36.1/v0.36.2).
+          gh repo sync "${FORK_OWNER}/community-operators" --branch main --force
+
+          # Branch from the now-synced fork main, so the bundle branch's push delta
+          # is ONLY the bundle commit (workflow-file commits are already on the fork
+          # via the server-side sync and are not re-introduced by the push).
+          git fetch origin main
+          git checkout -B "${BRANCH}" origin/main
 
           # Copy prepared bundle (mkdir for first-time submissions)
           mkdir -p operators/openclaw-operator
@@ -187,11 +196,20 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Sync fork with upstream to avoid stale-branch CI failures
-          git fetch upstream main
-          git reset --hard upstream/main
+          FORK_OWNER=$(gh api user --jq '.login')
 
-          git checkout -b "${BRANCH}"
+          # Sync the fork's main with upstream SERVER-SIDE. gh repo sync performs a
+          # fast-forward via the GitHub API and is exempt from the PAT 'workflow'
+          # scope restriction. Previously we reset --hard to upstream/main and pushed
+          # the branch, which carried upstream's .github/workflows changes; a PAT
+          # without 'workflow' scope is refused that push (broke v0.36.1/v0.36.2).
+          gh repo sync "${FORK_OWNER}/community-operators-prod" --branch main --force
+
+          # Branch from the now-synced fork main, so the bundle branch's push delta
+          # is ONLY the bundle commit (workflow-file commits are already on the fork
+          # via the server-side sync and are not re-introduced by the push).
+          git fetch origin main
+          git checkout -B "${BRANCH}" origin/main
 
           # Copy prepared bundle (mkdir for first-time submissions)
           mkdir -p operators/openclaw-operator


### PR DESCRIPTION
The OperatorHub submission to `k8s-operatorhub/community-operators` has failed since **v0.36.1** (and again v0.36.2):

```
! [remote rejected] (refusing to allow a Personal Access Token to create or update
workflow `.github/workflows/command_merge.yaml` without `workflow` scope)
```

**Cause:** both submit jobs did `git reset --hard upstream/main` then pushed the bundle branch. Because the fork was stale, the pushed branch carried upstream's `.github/workflows` changes, and `OPERATORHUB_FORK_TOKEN` lacks the `workflow` scope, so GitHub rejected the push.

**Fix:** sync the fork's `main` **server-side** via `gh repo sync` (a fast-forward through the API, exempt from the workflow-scope restriction), then branch from the synced `main` so the push delta is only the bundle commit — no workflow files. Applied to both the `community-operators` and `community-operators-prod` jobs (the latter only succeeded previously by luck of an already-synced fork).

After merge: re-run the workflow for `v0.36.2` (`workflow_dispatch`) to submit the bundle that the failed run never filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)