### PR TITLE
docs(chart): list OpenClawClusterDefaults in artifacthub.io/crds

### DIFF
--- a/charts/openclaw-operator/Chart.yaml
+++ b/charts/openclaw-operator/Chart.yaml
@@ -52,6 +52,11 @@ annotations:
       name: openclawselfconfigs.openclaw.rocks
       displayName: OpenClaw Self-Config
       description: A request from an agent to modify its own OpenClawInstance spec
+    - kind: OpenClawClusterDefaults
+      version: v1alpha1
+      name: openclawclusterdefaults.openclaw.rocks
+      displayName: OpenClaw Cluster Defaults
+      description: Cluster-scoped defaults merged into every OpenClawInstance at reconcile time
   artifacthub.io/crdsExamples: |
     - apiVersion: openclaw.rocks/v1alpha1
       kind: OpenClawInstance


### PR DESCRIPTION
The chart installs the OpenClawClusterDefaults CRD and the CSV owns it, but the Helm chart's `artifacthub.io/crds` annotation only declared 2 of 3 CRDs. Adds the missing entry so Artifact Hub shows all three (matching hermes/paperclip).