### PR TITLE
fix(operatorhub): ship ci.yaml with updateGraph semver-mode

### DIFF
--- a/.github/workflows/operatorhub.yaml
+++ b/.github/workflows/operatorhub.yaml
@@ -96,8 +96,12 @@ jobs:
           # Copy prepared bundle (mkdir for first-time submissions)
           mkdir -p operators/openclaw-operator
           cp -r ../submission/operators/openclaw-operator/${VERSION} operators/openclaw-operator/${VERSION}
+          # Seed ci.yaml only when the catalog does not already have one. Overwriting
+          # it on every release is a privileged change that withholds the
+          # authorized-changes label and blocks auto-merge.
+          [ -f operators/openclaw-operator/ci.yaml ] || cp "${GITHUB_WORKSPACE}/bundle/ci.yaml" operators/openclaw-operator/ci.yaml
 
-          git add "operators/openclaw-operator/${VERSION}"
+          git add "operators/openclaw-operator/${VERSION}" operators/openclaw-operator/ci.yaml
           git commit -m "operator openclaw-operator (${VERSION})"
           git push --force origin "${BRANCH}"
 
@@ -214,8 +218,12 @@ jobs:
           # Copy prepared bundle (mkdir for first-time submissions)
           mkdir -p operators/openclaw-operator
           cp -r ../submission/operators/openclaw-operator/${VERSION} operators/openclaw-operator/${VERSION}
+          # Seed ci.yaml only when the catalog does not already have one. Overwriting
+          # it on every release is a privileged change that withholds the
+          # authorized-changes label and blocks auto-merge.
+          [ -f operators/openclaw-operator/ci.yaml ] || cp "${GITHUB_WORKSPACE}/bundle/ci.yaml" operators/openclaw-operator/ci.yaml
 
-          git add "operators/openclaw-operator/${VERSION}"
+          git add "operators/openclaw-operator/${VERSION}" operators/openclaw-operator/ci.yaml
           git commit -m "operator openclaw-operator (${VERSION})"
           git push --force origin "${BRANCH}"
 

--- a/bundle/ci.yaml
+++ b/bundle/ci.yaml
@@ -1,3 +1,6 @@
+---
+# opm catalog upgrade graph: order bundles by semver (our CSVs have no explicit `replaces`).
+updateGraph: semver-mode
+# A PR authored by a listed reviewer auto-gets the `authorized-changes` label (enables auto-merge).
 reviewers:
   - stubbi
-updateGraph: semver-mode


### PR DESCRIPTION
## Summary

- Creates `bundle/ci.yaml` with `updateGraph: semver-mode` and `reviewers: [stubbi]`.
- In **both** the `submit` (k8s community-operators) and `submit-redhat` (community-operators-prod) jobs, seeds `operators/openclaw-operator/ci.yaml` from `bundle/ci.yaml` if absent, and includes it in `git add`.
- Clears the `check_ci_upgrade_graph` OperatorHub CI warning so bundles are ordered by semver instead of requiring explicit `replaces:` chains.
- The seed is idempotent: once the file exists in the community-operators catalog, no further privileged changes are made.

## Test plan

- [ ] Trigger `OperatorHub Submission` workflow dispatch on a test tag — verify both jobs produce a PR that includes `operators/openclaw-operator/ci.yaml` with `updateGraph: semver-mode`.
- [ ] Confirm `yq '.updateGraph' bundle/ci.yaml` returns `semver-mode`.
- [ ] Confirm workflow YAML parses: `yq '.jobs|keys' .github/workflows/operatorhub.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)