### PR TITLE
fix(controller): treat optimistic-lock conflicts as retryable, not failed (#553)

### DIFF
--- a/internal/controller/conflict_handling.go
+++ b/internal/controller/conflict_handling.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// retryableConflictResult classifies an error returned from resource
+// reconciliation. A Kubernetes optimistic-lock conflict ("object has been
+// modified") is a benign, retryable controller-runtime race rather than a
+// terminal workload failure: it must be requeued promptly without producing a
+// failed-looking OpenClawInstance status or a ReconcileFailed event. When err
+// is such a conflict, it returns a prompt requeue and true; otherwise it
+// returns the zero result and false so the caller handles the error normally.
+//
+// apierrors.IsConflict unwraps errors joined with %w, so conflicts surfaced
+// through wrapped reconcile errors are still detected.
+func retryableConflictResult(err error) (ctrl.Result, bool) {
+	if apierrors.IsConflict(err) {
+		return ctrl.Result{Requeue: true}, true
+	}
+	return ctrl.Result{}, false
+}

--- a/internal/controller/conflict_handling_test.go
+++ b/internal/controller/conflict_handling_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Regression for the optimistic-lock race described in issue #553: a benign
+// "object has been modified" conflict during reconcile (for example a resume
+// that updates StatefulSet/status from a slightly stale resourceVersion) must
+// be treated as a retryable requeue, never as a terminal reconcile failure
+// that emits ReconcileFailed / PhaseFailed for a healthy workload.
+func TestRetryableConflictResult(t *testing.T) {
+	gr := schema.GroupResource{Group: "apps", Resource: "statefulsets"}
+	conflict := apierrors.NewConflict(gr, "test-instance", errors.New("object has been modified"))
+
+	t.Run("bare optimistic-lock conflict requeues without failing", func(t *testing.T) {
+		res, handled := retryableConflictResult(conflict)
+		if !handled {
+			t.Fatal("expected an optimistic-lock conflict to be handled as retryable")
+		}
+		if !res.Requeue {
+			t.Errorf("expected a prompt requeue (Requeue=true), got %+v", res)
+		}
+	})
+
+	t.Run("wrapped conflict is still detected", func(t *testing.T) {
+		wrapped := fmt.Errorf("reconcile statefulset: %w", conflict)
+		if _, handled := retryableConflictResult(wrapped); !handled {
+			t.Error("expected a wrapped conflict to be handled as retryable")
+		}
+	})
+
+	t.Run("non-conflict errors are not treated as retryable", func(t *testing.T) {
+		notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "missing")
+		if _, handled := retryableConflictResult(notFound); handled {
+			t.Error("a NotFound error must not be treated as a retryable conflict")
+		}
+		if _, handled := retryableConflictResult(errors.New("boom")); handled {
+			t.Error("a generic error must not be treated as a retryable conflict")
+		}
+	})
+}

--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -194,6 +194,18 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return rqErr.Result, nil
 		}
 
+		// A Kubernetes optimistic-lock conflict ("object has been modified") is a
+		// benign, retryable controller-runtime race (commonly seen on resume when
+		// StatefulSet/status are updated from a slightly stale resourceVersion),
+		// not a workload failure. Requeue promptly without emitting a failed-looking
+		// status or a ReconcileFailed event; the next reconcile runs against a fresh
+		// resourceVersion and succeeds (issue #553).
+		if res, ok := retryableConflictResult(err); ok {
+			logger.V(1).Info("Reconcile hit an optimistic-lock conflict; requeueing without marking failed", "error", err.Error())
+			reconcileTotal.WithLabelValues(instance.Name, instance.Namespace, "conflict").Inc()
+			return res, nil
+		}
+
 		logger.Error(err, "Failed to reconcile resources")
 		r.Recorder.Event(instance, corev1.EventTypeWarning, "ReconcileFailed", err.Error())
 


### PR DESCRIPTION
## Summary

Fixes #553. During resume, a normal Kubernetes optimistic-lock conflict (`object has been modified`) returned by `reconcileResources` fell through the generic reconcile-failure path, so the operator briefly emitted a `ReconcileFailed` event and set `Phase=Failed` / `Ready=False` for a workload that was actually healthy. The next reconcile succeeded immediately, but external pollers could observe a false terminal-looking state and the logs/events got noisy.

## Change

- New pure helper `retryableConflictResult(err)` (`internal/controller/conflict_handling.go`) classifies an error: an `apierrors.IsConflict` conflict returns a prompt requeue plus `true`; anything else returns `false`. `IsConflict` unwraps `%w`-wrapped errors, so conflicts surfaced through wrapped reconcile errors are still detected.
- `Reconcile` checks this immediately after the existing `requeueError` short-circuit, before the failure branch. On a conflict it logs at V(1), counts the requeue under a new `conflict` outcome on `reconcile_total` (instead of `error`), and returns `{Requeue: true}, nil` without setting any failed status or emitting an event.

This implements remediation items 1, 3, and 4 from the issue. Item 2 (wrapping individual updates in `retry.RetryOnConflict` to reduce conflict frequency at the source) is a complementary optimization that can follow separately; this change already guarantees a conflict never produces failed-looking state.

## Tests

- `TestRetryableConflictResult` covers a bare conflict (requeues, not failed), a `%w`-wrapped conflict (still detected), and non-conflict errors (NotFound and a generic error are not treated as retryable).
- Because the short-circuit returns before the `PhaseFailed` code, a conflict is structurally incapable of marking the instance failed.

## Verification

`go build ./...`, `go vet ./internal/controller/`, `make lint` (golangci-lint, rc=0), and `go test ./internal/controller/ -run TestRetryableConflictResult` all pass locally. The change is additive (a new helper plus an early return that only fires on `IsConflict`), so existing envtest behavior is unchanged; the CI `go-test` envtest suite covers the integration path.