### PR TITLE
fix(probes): compare disk readiness free space as integer KiB

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -13274,7 +13274,7 @@ func TestBuildStatefulSet_DiskReadiness_EnabledRendersExec(t *testing.T) {
 	script := rp.Exec.Command[2]
 	for _, want := range []string{
 		WorkspaceDataMountPath, // default workspace path
-		"67108864",             // default 64Mi threshold in bytes
+		"65536",                // default 64Mi threshold in KiB
 		"/readyz",              // gateway readiness still checked
 		"df -Pk",               // free-space check
 		"-w \"$p\"",            // writability check
@@ -13315,7 +13315,47 @@ func TestBuildStatefulSet_DiskReadiness_CustomPathAndThreshold(t *testing.T) {
 	if !strings.Contains(script, "'/data/workspace'") {
 		t.Errorf("exec script should check custom path, got:\n%s", script)
 	}
-	if !strings.Contains(script, "1073741824") { // 1Gi in bytes
-		t.Errorf("exec script should use 1Gi threshold in bytes, got:\n%s", script)
+	if !strings.Contains(script, "1048576") { // 1Gi in KiB
+		t.Errorf("exec script should use 1Gi threshold in KiB, got:\n%s", script)
+	}
+}
+
+// Regression test for #567: awk arithmetic ($4 * 1024) renders large results in
+// scientific notation (e.g. 1.2642e+10) under busybox awk, which POSIX
+// [ -ge ] rejects with "Illegal number", leaving healthy instances NotReady.
+// The script must compare the df -Pk available column (an integer string) as
+// KiB and never perform awk arithmetic on it.
+func TestBuildStatefulSet_DiskReadiness_ScriptComparesIntegerKiB(t *testing.T) {
+	instance := newTestInstance("disk-readiness-int")
+	instance.Spec.Probes = &openclawv1alpha1.ProbesSpec{
+		DiskReadiness: &openclawv1alpha1.DiskReadinessSpec{
+			Enabled: Ptr(true),
+			MinFree: "512Mi",
+		},
+	}
+	main := BuildStatefulSet(instance, "", nil, nil, nil).Spec.Template.Spec.Containers[0]
+
+	script := main.ReadinessProbe.Exec.Command[2]
+	if strings.Contains(script, "* 1024") {
+		t.Errorf("exec script must not multiply in awk (scientific notation breaks [ -ge ]), got:\n%s", script)
+	}
+	if !strings.Contains(script, "524288") { // 512Mi = 524288 KiB
+		t.Errorf("exec script should compare against 524288 KiB, got:\n%s", script)
+	}
+}
+
+func TestBuildStatefulSet_DiskReadiness_MinFreeKiBRoundsUp(t *testing.T) {
+	instance := newTestInstance("disk-readiness-round")
+	instance.Spec.Probes = &openclawv1alpha1.ProbesSpec{
+		DiskReadiness: &openclawv1alpha1.DiskReadinessSpec{
+			Enabled: Ptr(true),
+			MinFree: "1025", // 1025 bytes -> must require 2 KiB, not truncate to 1
+		},
+	}
+	main := BuildStatefulSet(instance, "", nil, nil, nil).Spec.Template.Spec.Containers[0]
+
+	script := main.ReadinessProbe.Exec.Command[2]
+	if !strings.Contains(script, "-ge 2 ") && !strings.Contains(script, "-ge 2\n") {
+		t.Errorf("exec script should round the KiB threshold up to 2, got:\n%s", script)
 	}
 }

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -2596,24 +2596,29 @@ func buildDiskReadinessHandler(spec *openclawv1alpha1.DiskReadinessSpec, instanc
 		mountPath = WorkspaceDataMountPath
 	}
 	minFree := ParseQuantity(spec.MinFree, DefaultDiskReadinessMinFree)
-	minFreeBytes := minFree.Value()
+	// Compare in KiB, not bytes: df -Pk already reports integer 1K blocks, and
+	// any awk arithmetic on the column ($4 * 1024) can render the result in
+	// scientific notation (OFMT %.6g, e.g. 1.2642e+10 under busybox awk), which
+	// POSIX [ -ge ] rejects with "Illegal number" (#567). Round the threshold
+	// up so a fractional KiB still requires the full requested free space.
+	minFreeKiB := (minFree.Value() + 1023) / 1024
 	port := probeTargetPort(instance)
 
-	// POSIX sh: df -Pk reports 1K blocks; multiply the available column by 1024
-	// to get bytes. Quoting keeps paths with spaces safe. set -e propagates the
-	// first failing check as a non-zero exit (=> NotReady).
+	// POSIX sh: the available column from df -Pk is passed through verbatim as
+	// an integer string. Quoting keeps paths with spaces safe. set -e
+	// propagates the first failing check as a non-zero exit (=> NotReady).
 	script := fmt.Sprintf(`set -e
 p='%s'
 [ -w "$p" ] || exit 1
-avail=$(df -Pk "$p" 2>/dev/null | awk 'NR==2 {print $4 * 1024}')
-[ -n "$avail" ] || exit 1
-[ "$avail" -ge %d ] || exit 1
+avail_kib=$(df -Pk "$p" 2>/dev/null | awk 'NR==2 {print $4}')
+[ -n "$avail_kib" ] || exit 1
+[ "$avail_kib" -ge %d ] || exit 1
 if command -v curl >/dev/null 2>&1; then
   curl -fsS -o /dev/null --max-time 3 "http://127.0.0.1:%d/readyz"
 elif command -v wget >/dev/null 2>&1; then
   wget -q -O /dev/null -T 3 "http://127.0.0.1:%d/readyz"
 fi
-`, mountPath, minFreeBytes, port, port)
+`, mountPath, minFreeKiB, port, port)
 
 	return corev1.ProbeHandler{
 		Exec: &corev1.ExecAction{Command: []string{"sh", "-c", script}},

--- a/test/e2e/e2e_disk_readiness_test.go
+++ b/test/e2e/e2e_disk_readiness_test.go
@@ -104,7 +104,8 @@ var _ = Describe("Disk-aware readiness guard", func() {
 			Expect(script).To(ContainSubstring(resources.WorkspaceDataMountPath), "exec script should check the default workspace mount")
 			Expect(script).To(ContainSubstring("df -Pk"), "exec script should perform a free-space check")
 			Expect(script).To(ContainSubstring("-w \"$p\""), "exec script should perform a writability check")
-			Expect(script).To(ContainSubstring("134217728"), "exec script should embed the 128Mi threshold in bytes")
+			Expect(script).To(ContainSubstring("131072"), "exec script should embed the 128Mi threshold in KiB")
+			Expect(script).NotTo(ContainSubstring("* 1024"), "exec script must not do awk arithmetic - scientific notation breaks [ -ge ] (#567)")
 			Expect(script).To(ContainSubstring("/readyz"), "exec script should still defer to the gateway /readyz signal")
 
 			By("Verifying liveness and startup probes remain HTTP GET /healthz")


### PR DESCRIPTION
## Problem

The disk-aware readiness guard (#557) computes available bytes inside awk:

```sh
avail=$(df -Pk "$p" 2>/dev/null | awk 'NR==2 {print $4 * 1024}')
[ "$avail" -ge 536870912 ]
```

awk renders large arithmetic results via `OFMT` (`%.6g`), so with ~10GB+ free the output is scientific notation (`1.2642e+10`). POSIX `[ -ge ]` rejects that with `Illegal number`, the probe exits non-zero, and a healthy instance stays NotReady whenever `spec.probes.diskReadiness` is enabled. See #567 for the in-container reproduction.

## Fix

Remove the awk arithmetic entirely and compare in KiB:

- The script now passes the `df -Pk` available column through verbatim (`awk 'NR==2 {print $4}'`) — always a plain integer string, on busybox awk included.
- The `minFree` threshold is converted to KiB in Go, rounded **up**, so a fractional-KiB threshold still requires the full requested free space.

Behavior is otherwise unchanged: writability check, empty-output guard, and the `/readyz` deferral all stay as they were.

## Tests

- New unit regression tests: `TestBuildStatefulSet_DiskReadiness_ScriptComparesIntegerKiB` (no `* 1024` in the script, threshold rendered in KiB) and `TestBuildStatefulSet_DiskReadiness_MinFreeKiBRoundsUp`.
- Existing unit + e2e assertions updated from byte to KiB thresholds; the e2e rendering test now also asserts the script contains no awk multiplication.
- `go build ./...`, `go vet ./...`, `make lint`, `go test ./internal/resources/` all pass locally.

Fixes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
