### PR TITLE
fix: gate PhaseRunning on StatefulSetReady so consumers don't route to a not-ready instance

### DIFF
--- a/internal/controller/openclawinstance_controller.go
+++ b/internal/controller/openclawinstance_controller.go
@@ -61,6 +61,13 @@ const (
 
 	// RequeueAfter is the default requeue interval
 	RequeueAfter = 5 * time.Minute
+
+	// ProvisioningRequeueAfter is the requeue interval used while waiting for
+	// the StatefulSet's pod to become ready. It is shorter than RequeueAfter
+	// so the Phase flips to Running promptly once the pod reports ready,
+	// rather than waiting up to 5 minutes even though the StatefulSet watch
+	// should already trigger a reconcile on status change.
+	ProvisioningRequeueAfter = 10 * time.Second
 )
 
 // requeueError is a sentinel error used by reconcileResources to signal
@@ -259,9 +266,25 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{RequeueAfter: RequeueAfter}, nil
 	}
 
-	// Determine phase based on condition health
+	// Determine phase based on condition health. The StatefulSet's pod
+	// readiness takes precedence: downstream consumers (e.g. the hosted
+	// proxy) treat Phase==Running as "safe to route to the instance
+	// Service", so we must not report Running while the StatefulSet has
+	// zero ready replicas - that Service would have zero ready endpoints.
+	provisioningWait := false
+	stsReadyCondition := meta.FindStatusCondition(instance.Status.Conditions, openclawv1alpha1.ConditionTypeStatefulSetReady)
 	skillPacksCondition := meta.FindStatusCondition(instance.Status.Conditions, openclawv1alpha1.ConditionTypeSkillPacksReady)
-	if skillPacksCondition != nil && skillPacksCondition.Status == metav1.ConditionFalse {
+	switch {
+	case stsReadyCondition == nil || stsReadyCondition.Status != metav1.ConditionTrue:
+		instance.Status.Phase = openclawv1alpha1.PhaseProvisioning
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    openclawv1alpha1.ConditionTypeReady,
+			Status:  metav1.ConditionFalse,
+			Reason:  "StatefulSetNotReady",
+			Message: "Waiting for the StatefulSet pod to become ready",
+		})
+		provisioningWait = true
+	case skillPacksCondition != nil && skillPacksCondition.Status == metav1.ConditionFalse:
 		instance.Status.Phase = openclawv1alpha1.PhaseDegraded
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:    openclawv1alpha1.ConditionTypeReady,
@@ -269,7 +292,7 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			Reason:  "ReconcileSucceededDegraded",
 			Message: "Resources reconciled but skill packs unavailable - instance running without skill packs",
 		})
-	} else {
+	default:
 		instance.Status.Phase = openclawv1alpha1.PhaseRunning
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:    openclawv1alpha1.ConditionTypeReady,
@@ -303,8 +326,15 @@ func (r *OpenClawInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	updatePhaseMetric(instance.Name, instance.Namespace, instance.Status.Phase)
 	logger.Info("Reconciliation completed successfully")
 
-	// If auto-update needs a requeue, use its interval if shorter
+	// If auto-update needs a requeue, use its interval if shorter. While
+	// waiting for the StatefulSet's pod to become ready, requeue sooner than
+	// the default interval so Phase flips to Running promptly (the owned-
+	// StatefulSet watch should already trigger a reconcile on status change,
+	// but this is a cheap belt-and-suspenders backstop).
 	requeueAfter := RequeueAfter
+	if provisioningWait {
+		requeueAfter = ProvisioningRequeueAfter
+	}
 	if autoUpdateResult.Requeue {
 		return autoUpdateResult, nil
 	}

--- a/internal/controller/openclawinstance_controller_test.go
+++ b/internal/controller/openclawinstance_controller_test.go
@@ -277,6 +277,90 @@ var _ = Describe("OpenClawInstance Controller", func() {
 		})
 	})
 
+	Context("When the StatefulSet's pod is not yet ready", func() {
+		It("Should stay in Provisioning (not Running) until ReadyReplicas > 0, then flip to Running", func() {
+			instance := &openclawv1alpha1.OpenClawInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sts-readiness-test",
+					Namespace: "default",
+				},
+				Spec: openclawv1alpha1.OpenClawInstanceSpec{},
+			}
+			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+			instanceLookupKey := types.NamespacedName{Name: "sts-readiness-test", Namespace: "default"}
+			stsLookupKey := types.NamespacedName{Name: resources.StatefulSetName(instance), Namespace: "default"}
+
+			By("Waiting for the StatefulSet to be created")
+			Eventually(func() bool {
+				sts := &appsv1.StatefulSet{}
+				return k8sClient.Get(ctx, stsLookupKey, sts) == nil
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying the instance reports Provisioning (not Running) while the StatefulSet has zero ready replicas")
+			Eventually(func() string {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				if err := k8sClient.Get(ctx, instanceLookupKey, inst); err != nil {
+					return ""
+				}
+				return inst.Status.Phase
+			}, timeout, interval).Should(Equal(openclawv1alpha1.PhaseProvisioning))
+
+			Eventually(func() bool {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				if err := k8sClient.Get(ctx, instanceLookupKey, inst); err != nil {
+					return false
+				}
+				for _, cond := range inst.Status.Conditions {
+					if cond.Type == openclawv1alpha1.ConditionTypeReady &&
+						cond.Status == metav1.ConditionFalse &&
+						cond.Reason == "StatefulSetNotReady" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Simulating the StatefulSet's pod becoming ready (envtest has no kubelet to do this itself)")
+			Eventually(func() error {
+				sts := &appsv1.StatefulSet{}
+				if err := k8sClient.Get(ctx, stsLookupKey, sts); err != nil {
+					return err
+				}
+				sts.Status.Replicas = 1
+				sts.Status.ReadyReplicas = 1
+				return k8sClient.Status().Update(ctx, sts)
+			}, timeout, interval).Should(Succeed())
+
+			By("Verifying the instance flips to Running once the StatefulSet is ready")
+			Eventually(func() string {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				if err := k8sClient.Get(ctx, instanceLookupKey, inst); err != nil {
+					return ""
+				}
+				return inst.Status.Phase
+			}, timeout, interval).Should(Equal(openclawv1alpha1.PhaseRunning))
+
+			Eventually(func() bool {
+				inst := &openclawv1alpha1.OpenClawInstance{}
+				if err := k8sClient.Get(ctx, instanceLookupKey, inst); err != nil {
+					return false
+				}
+				for _, cond := range inst.Status.Conditions {
+					if cond.Type == openclawv1alpha1.ConditionTypeReady &&
+						cond.Status == metav1.ConditionTrue &&
+						cond.Reason == "ReconcileSucceeded" {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Cleaning up")
+			Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
+		})
+	})
+
 	Context("When NetworkPolicy is configured", func() {
 		It("Should create proper ingress and egress rules", func() {
 			instance := &openclawv1alpha1.OpenClawInstance{


### PR DESCRIPTION
## Problem

The controller set `Status.Phase = Running` as soon as resources reconciled successfully, without checking whether the StatefulSet pod was actually Ready. Downstream consumers (the hosted-OpenClaw proxy) treat `Phase == Running` as "safe to route to the instance Service" and connect immediately, but during provisioning that Service has zero ready endpoints, so the connection is rejected/times out until the pod finally serves.

## Fix

Gate the `Running` transition on the `StatefulSetReady` condition (already computed from `sts.Status.ReadyReplicas > 0` earlier in the same reconcile). Precedence is now: StatefulSet-not-ready → `Provisioning` (+ `Ready=False`, reason `StatefulSetNotReady`) > skill-packs-false → `Degraded` > `Running`. While waiting, the reconcile requeues after 10s (the owned-StatefulSet watch already re-triggers on status change; this is a cheap backstop) instead of the 5m default.

Suspended instances return before this block and are unaffected. No API/CRD/RBAC changes.

## Tests

New envtest drives `sts.Status.ReadyReplicas` (0 → `Provisioning`/`Ready=False`, then >0 → `Running`/`Ready=True`) and asserts both Phase and the Ready condition. Full suite green (53 passed), `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)