### PR TITLE
fix(statefulset): hash rendered ConfigMap data so config changes roll the pod

### DIFF
--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -4895,7 +4895,7 @@ func TestBuildInitScript_WithExternalFiles(t *testing.T) {
 	}
 }
 
-func TestConfigHash_StableWithExternalWorkspace(t *testing.T) {
+func TestConfigHash_ChangesWithExternalWorkspaceFiles(t *testing.T) {
 	instance := newTestInstance("hash-ext")
 
 	sts1 := BuildStatefulSet(instance, "", nil, nil, nil)
@@ -4907,8 +4907,87 @@ func TestConfigHash_StableWithExternalWorkspace(t *testing.T) {
 	sts2 := BuildStatefulSet(instance, "", nil, externalFiles, nil)
 	hash2 := sts2.Spec.Template.Annotations["openclaw.rocks/config-hash"]
 
+	if hash1 == hash2 {
+		t.Error("config hash must change when external workspace files are added (workspace-init only copies them at pod start)")
+	}
+
+	// Content-only change: the init script embeds file names but not contents,
+	// so the hash is the only thing that can trigger the rollout.
+	externalFiles["AGENT.md"] = "# Updated external agent content"
+	sts3 := BuildStatefulSet(instance, "", nil, externalFiles, nil)
+	hash3 := sts3.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	if hash2 == hash3 {
+		t.Error("config hash must change when external workspace file content changes")
+	}
+}
+
+func TestConfigHash_ChangesWithAdditionalExternalFiles(t *testing.T) {
+	instance := newTestInstance("hash-add-ext")
+
+	sts1 := BuildStatefulSet(instance, "", nil, nil, nil)
+	hash1 := sts1.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	additionalFiles := map[string]map[string]string{
+		"secondary": {"NOTES.md": "# Secondary workspace notes"},
+	}
+	sts2 := BuildStatefulSet(instance, "", nil, nil, additionalFiles)
+	hash2 := sts2.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	if hash1 == hash2 {
+		t.Error("config hash must change when additional-workspace external files change")
+	}
+}
+
+func TestConfigHash_ChangesWithControlUIOrigins(t *testing.T) {
+	instance := newTestInstance("hash-cui")
+
+	sts1 := BuildStatefulSet(instance, "", nil, nil, nil)
+	hash1 := sts1.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	instance.Spec.Gateway.ControlUIOrigins = []string{"https://claw.example.com"}
+
+	sts2 := BuildStatefulSet(instance, "", nil, nil, nil)
+	hash2 := sts2.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	if hash1 == hash2 {
+		t.Error("config hash must change when spec.gateway.controlUiOrigins changes (it re-renders gateway.controlUi.allowedOrigins)")
+	}
+}
+
+func TestConfigHash_ChangesWithIngressHosts(t *testing.T) {
+	instance := newTestInstance("hash-ingress")
+
+	sts1 := BuildStatefulSet(instance, "", nil, nil, nil)
+	hash1 := sts1.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	instance.Spec.Networking.Ingress.Hosts = []openclawv1alpha1.IngressHost{
+		{Host: "claw.example.com"},
+	}
+
+	sts2 := BuildStatefulSet(instance, "", nil, nil, nil)
+	hash2 := sts2.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	if hash1 == hash2 {
+		t.Error("config hash must change when ingress hosts change (they feed derived control UI origins)")
+	}
+}
+
+func TestConfigHash_StableWithUnrelatedSpecChange(t *testing.T) {
+	instance := newTestInstance("hash-unrelated")
+
+	sts1 := BuildStatefulSet(instance, "", nil, nil, nil)
+	hash1 := sts1.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
+	instance.Spec.Resources = openclawv1alpha1.ResourcesSpec{
+		Limits: openclawv1alpha1.ResourceList{Memory: "2Gi"},
+	}
+
+	sts2 := BuildStatefulSet(instance, "", nil, nil, nil)
+	hash2 := sts2.Spec.Template.Annotations["openclaw.rocks/config-hash"]
+
 	if hash1 != hash2 {
-		t.Error("config hash should not change for workspace-only changes (delivered via ConfigMap volume)")
+		t.Error("config hash must not change for spec changes that do not affect rendered config (resources roll the pod via the template itself)")
 	}
 }
 
@@ -13135,7 +13214,7 @@ func TestBuildInitScript_AdditionalWorkspaces(t *testing.T) {
 	}
 }
 
-func TestConfigHash_StableWithAdditionalWorkspace(t *testing.T) {
+func TestConfigHash_ChangesWithAdditionalWorkspaceExternalFiles(t *testing.T) {
 	instance := newTestInstance("ws-addl-hash")
 	instance.Spec.Workspace = &openclawv1alpha1.WorkspaceSpec{
 		AdditionalWorkspaces: []openclawv1alpha1.AdditionalWorkspace{
@@ -13146,15 +13225,16 @@ func TestConfigHash_StableWithAdditionalWorkspace(t *testing.T) {
 	sts1 := BuildStatefulSet(instance, "", nil, nil, nil)
 	hash1 := sts1.Spec.Template.Annotations["openclaw.rocks/config-hash"]
 
-	// Add additional external files — hash should remain stable
+	// Adding additional external files must change the hash: workspace-init
+	// only copies them into the workspace at pod start.
 	additionalExt := map[string]map[string]string{
 		"work": {"SOUL.md": "work soul"},
 	}
 	sts2 := BuildStatefulSet(instance, "", nil, nil, additionalExt)
 	hash2 := sts2.Spec.Template.Annotations["openclaw.rocks/config-hash"]
 
-	if hash1 != hash2 {
-		t.Error("config hash should not change for workspace-only changes (delivered via ConfigMap volume)")
+	if hash1 == hash2 {
+		t.Error("config hash must change when additional-workspace external files change")
 	}
 }
 

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -70,7 +70,7 @@ func BuildStatefulSet(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenS
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: buildPodAnnotations(instance, externalWorkspaceFiles, additionalExternalFiles),
+					Annotations: buildPodAnnotations(instance, skillPacks, externalWorkspaceFiles, additionalExternalFiles),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            ServiceAccountName(instance),
@@ -133,12 +133,12 @@ func BuildStatefulSet(instance *openclawv1alpha1.OpenClawInstance, gatewayTokenS
 }
 
 // buildPodAnnotations builds the pod annotations for the pod template
-func buildPodAnnotations(instance *openclawv1alpha1.OpenClawInstance, externalWorkspaceFiles map[string]string, additionalExternalFiles map[string]map[string]string) map[string]string {
+func buildPodAnnotations(instance *openclawv1alpha1.OpenClawInstance, skillPacks *ResolvedSkillPacks, externalWorkspaceFiles map[string]string, additionalExternalFiles map[string]map[string]string) map[string]string {
 	annotations := make(map[string]string, len(instance.Spec.PodAnnotations)+1)
 	for k, v := range instance.Spec.PodAnnotations {
 		annotations[k] = v
 	}
-	annotations["openclaw.rocks/config-hash"] = calculateConfigHash(instance, externalWorkspaceFiles, additionalExternalFiles)
+	annotations["openclaw.rocks/config-hash"] = calculateConfigHash(instance, skillPacks, externalWorkspaceFiles, additionalExternalFiles)
 	return annotations
 }
 
@@ -2924,13 +2924,42 @@ func getPullPolicy(instance *openclawv1alpha1.OpenClawInstance) corev1.PullPolic
 
 // calculateConfigHash computes a hash of the config, skills, plugins, and
 // runtime settings for rollout detection. Changes to any of these trigger a
-// pod restart. Workspace files are intentionally excluded because they are
-// delivered via a projected ConfigMap volume that the kubelet updates in-place
-// without requiring a pod restart.
-func calculateConfigHash(instance *openclawv1alpha1.OpenClawInstance, _ map[string]string, _ map[string]map[string]string) string {
+// pod restart.
+//
+// The hash covers the RENDERED ConfigMap data (the same openclaw.json/nginx/
+// tailscale/otel bytes produced by BuildConfigMap), not just selected spec
+// fields. This way every spec section the enrichment pipeline reads (e.g.
+// spec.gateway.controlUiOrigins, spec.networking.ingress hosts/TLS) rolls the
+// pod when it changes the config the pod actually consumes. Hashing only
+// hand-picked spec fields previously let the ConfigMap re-render while the
+// StatefulSet never rolled, so pods kept serving the stale config.
+//
+// External workspace files (spec.workspace.configMapRef and per-workspace
+// configMapRefs) are hashed too: the workspace-init container copies them into
+// the workspace at pod start, so content changes only take effect after a
+// restart. Inline spec.workspace.initialFiles remain excluded (unchanged
+// behavior; they are delivered via a projected ConfigMap volume).
+//
+// The gateway token is deliberately NOT part of the hash: BuildConfigMap is
+// invoked with an empty token here, so token rotation does not roll the pod
+// (same behavior as before).
+func calculateConfigHash(instance *openclawv1alpha1.OpenClawInstance, skillPacks *ResolvedSkillPacks, externalWorkspaceFiles map[string]string, additionalExternalFiles map[string]map[string]string) string {
 	h := sha256.New()
 	configData, _ := json.Marshal(instance.Spec.Config)
 	h.Write(configData)
+	// Rendered ConfigMap data: openclaw.json after the full enrichment
+	// pipeline plus the nginx/tailscale-serve/otel-collector companion keys.
+	// json.Marshal sorts map keys, so this is deterministic across reconciles.
+	renderedData, _ := json.Marshal(BuildConfigMap(instance, "", skillPacks).Data)
+	h.Write(renderedData)
+	if len(externalWorkspaceFiles) > 0 {
+		extData, _ := json.Marshal(externalWorkspaceFiles)
+		h.Write(extData)
+	}
+	if len(additionalExternalFiles) > 0 {
+		addExtData, _ := json.Marshal(additionalExternalFiles)
+		h.Write(addExtData)
+	}
 	if len(instance.Spec.Skills) > 0 {
 		skillsData, _ := json.Marshal(instance.Spec.Skills)
 		h.Write(skillsData)

--- a/internal/resources/workspace_skills_test.go
+++ b/internal/resources/workspace_skills_test.go
@@ -227,9 +227,9 @@ func TestCalculateConfigHash_WorkspaceSkillsKeyedByName(t *testing.T) {
 	}
 
 	skill := "pack:acme/skills/example@v1"
-	inFirst := calculateConfigHash(inWs("first", skill), nil, nil)
-	inSecond := calculateConfigHash(inWs("second", skill), nil, nil)
-	baseHash := calculateConfigHash(base, nil, nil)
+	inFirst := calculateConfigHash(inWs("first", skill), nil, nil, nil)
+	inSecond := calculateConfigHash(inWs("second", skill), nil, nil, nil)
+	baseHash := calculateConfigHash(base, nil, nil, nil)
 
 	if inFirst == inSecond {
 		t.Error("moving a skill between workspaces must change the config hash")
@@ -241,7 +241,7 @@ func TestCalculateConfigHash_WorkspaceSkillsKeyedByName(t *testing.T) {
 	// Top-level skill vs the same skill in a workspace must differ too.
 	topLevel := newTestInstance("hash-top")
 	topLevel.Spec.Skills = []string{skill}
-	if calculateConfigHash(topLevel, nil, nil) == inFirst {
+	if calculateConfigHash(topLevel, nil, nil, nil) == inFirst {
 		t.Error("workspace-scoped skill must hash differently from a top-level skill")
 	}
 }


### PR DESCRIPTION
## Problem

`calculateConfigHash` (internal/resources/statefulset.go) computed the `openclaw.rocks/config-hash` pod-template annotation from hand-picked spec fields only (`Spec.Config`, `Skills`, `Plugins`, `InitContainers`, `RuntimeDeps`, `Tailscale`) and discarded both of its `externalWorkspaceFiles` / `additionalExternalFiles` parameters with `_`.

Any spec section that the ConfigMap enrichment pipeline reads but the hash did not, re-rendered the ConfigMap **without rolling the StatefulSet**. Proven in production today: changing `spec.gateway.controlUiOrigins` re-rendered `gateway.controlUi.allowedOrigins` in the ConfigMap, but the pod kept serving the old config until a manual pod delete. The same gap covered ingress hosts/TLS (which feed the derived control UI origins) and external workspace file content (copied into the workspace by the init container only at pod start).

## Fix (approach chosen: hash the rendered config)

Instead of adding more hand-picked spec fields (which would recreate this bug class the next time the enrichment pipeline grows), `calculateConfigHash` now hashes the **rendered ConfigMap data**: the same `openclaw.json` / nginx / tailscale-serve / otel-collector bytes produced by `BuildConfigMap` that the pod actually consumes, plus the two resolved external workspace file maps.

Implementation detail: rather than threading the controller-rendered bytes through `reconcileStatefulSet` -> `BuildStatefulSet` (a signature change with ~200 call sites across controller and resources tests), the hash invokes the same `BuildConfigMap`/`BuildConfigMapFromBytes` enrichment pipeline in-package. `BuildStatefulSet` already receives `instance` and `skillPacks`, which are the pipeline's inputs, so the hashed bytes are the pipeline's output for the same reconcile. Two deliberate deltas from the deployed ConfigMap, both preserving current behavior:

- The gateway token is rendered empty for hashing, so token rotation still does not roll pods (and no secret material feeds the annotation hash).
- For `spec.config.configMapRef` instances, the external ConfigMap's *content* is still not hashed (its name/key are, via `Spec.Config`); same as before.

The existing spec-field hashing is kept as-is on top, preserving the workspace-scoped skills semantics from #568/#570. `spec.workspace.initialFiles` remain excluded (unchanged documented behavior). Annotation key and 8-byte hex truncation unchanged.

## Behavior changes

- `spec.gateway.*` (e.g. `controlUiOrigins`) changes now roll the pod.
- `spec.networking.ingress` hosts/TLS changes now roll the pod (they feed derived control UI origins and the tailscale serve config).
- External workspace file content changes (`spec.workspace.configMapRef` and per-workspace refs) now roll the pod; previously only adding/removing a file rolled it (via the init script's file name list), content-only edits never did. Two tests asserting the old stability were flipped accordingly.

## ⚠️ Expected one-time rollout on operator upgrade

**The hash formula changed, so every OpenClawInstance pod will roll exactly once when this operator version first reconciles it.** Plan the upgrade like a fleet-wide restart window. Subsequent reconciles are stable (rendering is deterministic; all hashed maps are marshaled with sorted keys).

## Tests

- `TestConfigHash_ChangesWithControlUIOrigins`: `spec.gateway.controlUiOrigins` change changes the hash.
- `TestConfigHash_ChangesWithIngressHosts`: ingress host change changes the hash.
- `TestConfigHash_ChangesWithExternalWorkspaceFiles`: adding a file and changing only its content both change the hash.
- `TestConfigHash_ChangesWithAdditionalExternalFiles` / `TestConfigHash_ChangesWithAdditionalWorkspaceExternalFiles`: per-workspace external file changes change the hash.
- `TestConfigHash_StableWithUnrelatedSpecChange`: a resources change does not change the hash.
- `make test` fully green (all packages), `make lint` (golangci-lint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)