### PR TITLE
chore(deps): bump pymdown-extensions to 11.0.1 and mkdocs-material to 9.7.7

### DIFF
--- a/docs-site/requirements.txt
+++ b/docs-site/requirements.txt
@@ -1,10 +1,10 @@
 mkdocs==1.6.1
-mkdocs-material==9.5.49
+mkdocs-material==9.7.7
 mkdocs-include-markdown-plugin==7.1.8
 mkdocs-awesome-pages-plugin==2.9.3
 mkdocs-git-revision-date-localized-plugin==1.2.9
 mkdocs-minify-plugin==0.8.0
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1
 mike==2.1.3
 # Material social plugin (per-page OG cards) deps
 cairosvg==2.9.0


### PR DESCRIPTION
## Summary

Supersedes the standalone Dependabot bump. `pymdown-extensions` 11.0 cannot be installed on its own:

```
ERROR: Cannot install -r docs-site/requirements.txt and pymdown-extensions==11.0
because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

`mkdocs-material==9.5.49` declares `pymdown-extensions~=10.2`, which excludes 11.x. `mkdocs-material` 9.7.7 relaxes this to `pymdown-extensions>=10.2`, so the two must move together.

## Changes

- `mkdocs-material` 9.5.49 -> 9.7.7
- `pymdown-extensions` 10.21.3 -> 11.0.1 (11.0.1 is current)

## Verification

Clean venv install + strict build against the new pins, no theme override or plugin config changes required.

Strict build verified with the full plugin set (social/OG cards, minify, awesome-pages, git-revision-date, include-markdown, llms-txt).