### PR TITLE
fix(service): expose the managed metrics port alongside custom Service ports

### DIFF
--- a/internal/resources/common.go
+++ b/internal/resources/common.go
@@ -177,6 +177,12 @@ const (
 	// DefaultMetricsPort is the default port for the Prometheus metrics endpoint
 	DefaultMetricsPort int32 = 9090
 
+	// MetricsPortName is the named port the metrics endpoint is exposed under.
+	// The Service port, the container port and the ServiceMonitor endpoint must
+	// all agree on this name — a ServiceMonitor endpoint that names a port the
+	// Service does not expose resolves to no target and scrapes nothing.
+	MetricsPortName = "metrics"
+
 	// DefaultOTelCollectorImage is the default image for the OTel Collector sidecar.
 	// The core distribution is lightweight (~80MB) and includes the OTLP receiver
 	// and Prometheus exporter needed for the metrics pipeline.

--- a/internal/resources/resources_test.go
+++ b/internal/resources/resources_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -1512,10 +1513,13 @@ func TestBuildService_CustomPorts(t *testing.T) {
 
 	svc := BuildService(instance)
 
-	if len(svc.Spec.Ports) != 1 {
-		t.Fatalf("expected 1 port, got %d", len(svc.Spec.Ports))
+	// Custom ports plus the operator-managed metrics port, which is enabled by
+	// default and must be present for the ServiceMonitor endpoint to resolve.
+	if len(svc.Spec.Ports) != 2 {
+		t.Fatalf("expected 2 ports, got %d", len(svc.Spec.Ports))
 	}
 	assertServicePort(t, svc.Spec.Ports, "http", 3978)
+	assertServicePort(t, svc.Spec.Ports, "metrics", DefaultMetricsPort)
 }
 
 func TestBuildService_CustomPortsWithTargetPort(t *testing.T) {
@@ -1530,8 +1534,8 @@ func TestBuildService_CustomPortsWithTargetPort(t *testing.T) {
 
 	svc := BuildService(instance)
 
-	if len(svc.Spec.Ports) != 1 {
-		t.Fatalf("expected 1 port, got %d", len(svc.Spec.Ports))
+	if len(svc.Spec.Ports) != 2 {
+		t.Fatalf("expected 2 ports (custom + managed metrics), got %d", len(svc.Spec.Ports))
 	}
 	if svc.Spec.Ports[0].Port != 80 {
 		t.Errorf("port = %d, want 80", svc.Spec.Ports[0].Port)
@@ -1539,6 +1543,7 @@ func TestBuildService_CustomPortsWithTargetPort(t *testing.T) {
 	if svc.Spec.Ports[0].TargetPort.IntValue() != 3978 {
 		t.Errorf("targetPort = %d, want 3978", svc.Spec.Ports[0].TargetPort.IntValue())
 	}
+	assertServicePort(t, svc.Spec.Ports, "metrics", DefaultMetricsPort)
 }
 
 func TestBuildService_CustomPortsMultiple(t *testing.T) {
@@ -1558,11 +1563,12 @@ func TestBuildService_CustomPortsMultiple(t *testing.T) {
 
 	svc := BuildService(instance)
 
-	if len(svc.Spec.Ports) != 2 {
-		t.Fatalf("expected 2 ports, got %d", len(svc.Spec.Ports))
+	if len(svc.Spec.Ports) != 3 {
+		t.Fatalf("expected 3 ports (2 custom + managed metrics), got %d", len(svc.Spec.Ports))
 	}
 	assertServicePort(t, svc.Spec.Ports, "http", 3978)
 	assertServicePort(t, svc.Spec.Ports, "grpc", 50051)
+	assertServicePort(t, svc.Spec.Ports, "metrics", DefaultMetricsPort)
 }
 
 func TestBuildService_CustomPortsOverrideDefaults(t *testing.T) {
@@ -1577,10 +1583,132 @@ func TestBuildService_CustomPortsOverrideDefaults(t *testing.T) {
 
 	svc := BuildService(instance)
 
-	if len(svc.Spec.Ports) != 1 {
+	// Custom ports replace the workload defaults (gateway/canvas/chromium), but
+	// not the operator-managed metrics port, which the ServiceMonitor targets.
+	if len(svc.Spec.Ports) != 2 {
 		t.Fatalf("custom ports should replace defaults including chromium; got %d ports", len(svc.Spec.Ports))
 	}
 	assertServicePort(t, svc.Spec.Ports, "http", 8080)
+	assertServicePort(t, svc.Spec.Ports, "metrics", DefaultMetricsPort)
+	for _, p := range svc.Spec.Ports {
+		if p.Name == "chromium" || p.Name == "gateway" || p.Name == "canvas" {
+			t.Errorf("default port %q should have been replaced by custom ports", p.Name)
+		}
+	}
+}
+
+// Regression test for #577: custom Service ports combined with an
+// operator-managed ServiceMonitor produced a Service with no "metrics" port, so
+// the ServiceMonitor endpoint had nothing to resolve and Prometheus silently
+// scraped nothing.
+func TestBuildService_CustomPortsIncludesMetricsForServiceMonitor(t *testing.T) {
+	instance := newTestInstance("svc-custom-metrics")
+	instance.Spec.Networking.Service.Ports = []openclawv1alpha1.ServicePortSpec{
+		{Name: "http", Port: 3978},
+	}
+	enabled := true
+	instance.Spec.Observability.Metrics.Enabled = &enabled
+	instance.Spec.Observability.Metrics.ServiceMonitor = &openclawv1alpha1.ServiceMonitorSpec{
+		Enabled: &enabled,
+	}
+
+	svc := BuildService(instance)
+	sm := BuildServiceMonitor(instance)
+
+	endpoints, found, err := unstructured.NestedSlice(sm.Object, "spec", "endpoints")
+	if err != nil || !found {
+		t.Fatalf("could not read ServiceMonitor endpoints: found=%v err=%v", found, err)
+	}
+	if len(endpoints) == 0 {
+		t.Fatal("ServiceMonitor has no endpoints")
+	}
+
+	// Every ServiceMonitor endpoint port must exist as a named Service port,
+	// otherwise Prometheus has no target to resolve and scrapes nothing.
+	for _, raw := range endpoints {
+		ep, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("unexpected endpoint shape %T", raw)
+		}
+		portName, _ := ep["port"].(string)
+		matched := false
+		for _, p := range svc.Spec.Ports {
+			if p.Name == portName {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("ServiceMonitor endpoint port %q has no matching Service port; got %v", portName, svc.Spec.Ports)
+		}
+	}
+}
+
+func TestBuildService_CustomPortsMetricsDisabled(t *testing.T) {
+	instance := newTestInstance("svc-custom-no-metrics")
+	instance.Spec.Networking.Service.Ports = []openclawv1alpha1.ServicePortSpec{
+		{Name: "http", Port: 3978},
+	}
+	disabled := false
+	instance.Spec.Observability.Metrics.Enabled = &disabled
+
+	svc := BuildService(instance)
+
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("expected only the custom port when metrics are disabled, got %d", len(svc.Spec.Ports))
+	}
+	assertServicePort(t, svc.Spec.Ports, "http", 3978)
+}
+
+// A user-declared "metrics" port must win, otherwise the Service would carry a
+// duplicate port name and the API server would reject it outright.
+func TestBuildService_CustomPortsUserSuppliedMetricsNotDuplicated(t *testing.T) {
+	instance := newTestInstance("svc-custom-own-metrics")
+	instance.Spec.Networking.Service.Ports = []openclawv1alpha1.ServicePortSpec{
+		{Name: "http", Port: 3978},
+		{Name: "metrics", Port: 9999},
+	}
+
+	svc := BuildService(instance)
+
+	if len(svc.Spec.Ports) != 2 {
+		t.Fatalf("expected 2 ports, got %d", len(svc.Spec.Ports))
+	}
+	assertServicePort(t, svc.Spec.Ports, "metrics", 9999)
+	assertNoDuplicatePorts(t, svc.Spec.Ports)
+}
+
+// Same guard by port number rather than name: duplicate port numbers are also
+// rejected by the API server.
+func TestBuildService_CustomPortsCollidingMetricsPortNumber(t *testing.T) {
+	instance := newTestInstance("svc-custom-collide")
+	instance.Spec.Networking.Service.Ports = []openclawv1alpha1.ServicePortSpec{
+		{Name: "telemetry", Port: DefaultMetricsPort},
+	}
+
+	svc := BuildService(instance)
+
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(svc.Spec.Ports))
+	}
+	assertServicePort(t, svc.Spec.Ports, "telemetry", DefaultMetricsPort)
+	assertNoDuplicatePorts(t, svc.Spec.Ports)
+}
+
+func assertNoDuplicatePorts(t *testing.T, ports []corev1.ServicePort) {
+	t.Helper()
+	names := map[string]bool{}
+	numbers := map[int32]bool{}
+	for _, p := range ports {
+		if names[p.Name] {
+			t.Errorf("duplicate service port name %q", p.Name)
+		}
+		if numbers[p.Port] {
+			t.Errorf("duplicate service port number %d", p.Port)
+		}
+		names[p.Name] = true
+		numbers[p.Port] = true
+	}
 }
 
 func TestBuildService_CustomPortsDefaultProtocol(t *testing.T) {

--- a/internal/resources/service.go
+++ b/internal/resources/service.go
@@ -53,9 +53,15 @@ func BuildService(instance *openclawv1alpha1.OpenClawInstance) *corev1.Service {
 }
 
 // buildServicePorts returns custom ports if specified, otherwise default ports.
+//
+// The operator-managed metrics port is appended in both branches. It used to be
+// added only to the default ports, so an instance that set custom Service ports
+// and enabled observability.metrics.serviceMonitor got a ServiceMonitor whose
+// `port: metrics` endpoint had no matching Service port, and Prometheus silently
+// scraped nothing.
 func buildServicePorts(instance *openclawv1alpha1.OpenClawInstance) []corev1.ServicePort {
 	if len(instance.Spec.Networking.Service.Ports) > 0 {
-		ports := make([]corev1.ServicePort, 0, len(instance.Spec.Networking.Service.Ports))
+		ports := make([]corev1.ServicePort, 0, len(instance.Spec.Networking.Service.Ports)+1)
 		for _, p := range instance.Spec.Networking.Service.Ports {
 			protocol := p.Protocol
 			if protocol == "" {
@@ -72,7 +78,7 @@ func buildServicePorts(instance *openclawv1alpha1.OpenClawInstance) []corev1.Ser
 				Protocol:   protocol,
 			})
 		}
-		return ports
+		return appendMetricsPort(instance, ports)
 	}
 
 	// When the gateway proxy is enabled, route through the proxy ports.
@@ -117,17 +123,35 @@ func buildServicePorts(instance *openclawv1alpha1.OpenClawInstance) []corev1.Ser
 		})
 	}
 
-	if IsMetricsEnabled(instance) {
-		metricsPort := MetricsPort(instance)
-		ports = append(ports, corev1.ServicePort{
-			Name:       "metrics",
-			Port:       metricsPort,
-			TargetPort: intstr.FromInt32(metricsPort),
-			Protocol:   corev1.ProtocolTCP,
-		})
+	return appendMetricsPort(instance, ports)
+}
+
+// appendMetricsPort adds the operator-managed "metrics" port that
+// BuildServiceMonitor's endpoint resolves against.
+//
+// A user-supplied port takes precedence: if the instance already declares a port
+// named "metrics", or one occupying the managed metrics port number, the managed
+// port is skipped. Appending it anyway would produce a Service with duplicate
+// port names or numbers, which the API server rejects outright — turning a
+// silently-unscraped Service into a Service that will not admit at all.
+func appendMetricsPort(instance *openclawv1alpha1.OpenClawInstance, ports []corev1.ServicePort) []corev1.ServicePort {
+	if !IsMetricsEnabled(instance) {
+		return ports
 	}
 
-	return ports
+	metricsPort := MetricsPort(instance)
+	for _, p := range ports {
+		if p.Name == MetricsPortName || p.Port == metricsPort {
+			return ports
+		}
+	}
+
+	return append(ports, corev1.ServicePort{
+		Name:       MetricsPortName,
+		Port:       metricsPort,
+		TargetPort: intstr.FromInt32(metricsPort),
+		Protocol:   corev1.ProtocolTCP,
+	})
 }
 
 // BuildChromiumCDPService creates a headless Service for the Chromium CDP

--- a/internal/resources/servicemonitor.go
+++ b/internal/resources/servicemonitor.go
@@ -75,7 +75,7 @@ func BuildServiceMonitor(instance *openclawv1alpha1.OpenClawInstance) *unstructu
 				},
 				"endpoints": []interface{}{
 					map[string]interface{}{
-						"port":     "metrics",
+						"port":     MetricsPortName,
 						"interval": interval,
 						"path":     "/metrics",
 					},

--- a/internal/resources/statefulset.go
+++ b/internal/resources/statefulset.go
@@ -2248,7 +2248,7 @@ func buildOTelCollectorContainer(instance *openclawv1alpha1.OpenClawInstance) co
 		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "metrics",
+				Name:          MetricsPortName,
 				ContainerPort: MetricsPort(instance),
 				Protocol:      corev1.ProtocolTCP,
 			},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1070,9 +1070,12 @@ var _ = Describe("OpenClawInstance Controller", func() {
 				}, service)
 			}, timeout, interval).Should(Succeed())
 
-			Expect(service.Spec.Ports).To(HaveLen(2))
+			// Two custom ports plus the operator-managed metrics port, which is
+			// enabled by default and must stay present so the ServiceMonitor
+			// endpoint resolves (#577).
+			Expect(service.Spec.Ports).To(HaveLen(3))
 
-			var foundHTTP, foundGRPC bool
+			var foundHTTP, foundGRPC, foundMetrics bool
 			for _, p := range service.Spec.Ports {
 				if p.Name == "http" && p.Port == 3978 {
 					foundHTTP = true
@@ -1082,7 +1085,13 @@ var _ = Describe("OpenClawInstance Controller", func() {
 					foundGRPC = true
 					Expect(p.TargetPort.IntValue()).To(Equal(50051))
 				}
+				if p.Name == resources.MetricsPortName {
+					foundMetrics = true
+				}
+				// The workload defaults must still be replaced by the custom ports.
+				Expect(p.Name).NotTo(BeElementOf("gateway", "canvas", "chromium"))
 			}
+			Expect(foundMetrics).To(BeTrue(), "managed metrics port must survive custom ports")
 			Expect(foundHTTP).To(BeTrue(), "Service should have http port 3978")
 			Expect(foundGRPC).To(BeTrue(), "Service should have grpc port 50051")
 


### PR DESCRIPTION
Fixes #577. The report was accurate down to the function, including the pointer to the NetworkPolicy precedent.

## Root cause

`buildServicePorts()` appended the operator-managed `metrics` port only in the default-port branch. The custom-port branch returned early:

```go
if len(instance.Spec.Networking.Service.Ports) > 0 {
    ...
    return ports          // <- managed metrics port never appended
}
```

`networkpolicy.go` already gets this right in *both* branches (lines 75 and 118), so this aligns the Service with the existing design rather than inventing a new rule.

## Why it was silent

Every object reconciled successfully — the CR, the ServiceMonitor, the OTel sidecar. Only the join failed: the ServiceMonitor endpoint names `port: metrics`, and no such port existed on the Service, so Prometheus resolved zero targets and no series were produced.

## The duplicate-port guard

The managed port is skipped when the instance already declares a port named `metrics`, or one occupying the managed port number. This matters: a Service with duplicate port names or numbers is rejected by the API server, so appending unconditionally would convert a silently-unscraped Service into one that will not admit at all — strictly worse than the bug being fixed.

## MetricsPortName

The Service port, the container port and the ServiceMonitor endpoint all hardcoded the literal `"metrics"` independently. Their disagreement *is* this bug, so they now share `MetricsPortName`. (`goconst` also flagged the literal once the guard added a seventh occurrence.)

## Behaviour change

Metrics default to enabled (`Enabled == nil` -> true), so instances using custom Service ports now get an additional `metrics` port they did not have before. That is the intended fix, and it matches what the default-port branch has always done. Four existing custom-port tests asserted the old counts and are updated; `TestBuildService_CustomPortsOverrideDefaults` additionally now asserts that gateway/canvas/chromium are still replaced, so the "custom ports override defaults" contract stays pinned.

## Tests

New:
- `TestBuildService_CustomPortsIncludesMetricsForServiceMonitor` — walks the actual ServiceMonitor endpoints and asserts each resolves to a named Service port (the reported scenario)
- `TestBuildService_CustomPortsMetricsDisabled` — no managed port when metrics are off
- `TestBuildService_CustomPortsUserSuppliedMetricsNotDuplicated`
- `TestBuildService_CustomPortsCollidingMetricsPortNumber`

`make test` green across all packages, `make lint` clean, no `make api-docs` drift.