### PR TITLE
fix: scope the operator-namespace cache entry to Secrets in namespaced mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,10 @@ To run the operator with namespaced RBAC instead of cluster-wide permissions,
 list the namespaces it should watch. The chart switches the namespace-scoped
 permissions from a `ClusterRole`/`ClusterRoleBinding` to per-namespace
 `Role`/`RoleBinding`, and passes `--watch-namespaces` to the operator so its
-informer cache is scoped to that list (plus the operator's own namespace, for
-backup credentials). A small `ClusterRole`/`ClusterRoleBinding` is still created
+informer cache is scoped to that list. The operator's own namespace is added to
+the **Secret** informer only, so it can still read its backup credentials, and
+the chart renders a matching Secret-only `Role` there; no other resource type is
+watched or granted in the operator namespace. A `ClusterRole`/`ClusterRoleBinding` is still created
 for the cluster-scoped `OpenClawClusterDefaults` resource, which the operator
 watches regardless of namespace scoping -- a namespaced `Role` cannot grant
 access to a cluster-scoped resource.

--- a/charts/openclaw-operator/templates/rbac.yaml
+++ b/charts/openclaw-operator/templates/rbac.yaml
@@ -35,6 +35,42 @@ subjects:
     name: {{ $saName }}
     namespace: {{ $saNamespace }}
 {{- end }}
+{{- if not (has $saNamespace .Values.watchNamespaces) }}
+---
+# In namespaced mode the operator still reads its own backup credentials Secret
+# (s3-backup-credentials) from the release namespace, so the Secret informer is
+# scoped to the watched namespaces plus this one. Without a matching Role the
+# informer fails with Forbidden and the manager never starts (#586). Only
+# Secrets are granted here -- the operator manages no child resources in its own
+# namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $managerName }}-operator-ns
+  namespace: {{ $saNamespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $managerBinding }}-operator-ns
+  namespace: {{ $saNamespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $managerName }}-operator-ns
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $saNamespace }}
+{{- end }}
 ---
 # OpenClawClusterDefaults is cluster-scoped (#457). Even when watching specific
 # namespaces, the operator must be granted access via a ClusterRole -- a

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,11 +36,13 @@ import (
 	otelmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -147,17 +149,7 @@ func main() {
 
 	watchNamespaces := parseWatchNamespaces(watchNamespacesFlag)
 	if len(watchNamespaces) > 0 {
-		nsCfg := make(map[string]cache.Config, len(watchNamespaces)+1)
-		for _, ns := range watchNamespaces {
-			nsCfg[ns] = cache.Config{}
-		}
-		// Always include the operator's own namespace so it can read its
-		// backup credentials Secret and other operator-scoped resources
-		// (e.g. s3-backup-credentials).
-		if _, ok := nsCfg[operatorNamespace]; !ok {
-			nsCfg[operatorNamespace] = cache.Config{}
-		}
-		mgrOpts.Cache = cache.Options{DefaultNamespaces: nsCfg}
+		mgrOpts.Cache = buildCacheOptions(watchNamespaces, operatorNamespace)
 		setupLog.Info("restricting watch to namespaces", "namespaces", watchNamespaces, "operatorNamespace", operatorNamespace)
 	}
 
@@ -273,6 +265,32 @@ func parseWatchNamespaces(raw string) []string {
 		out = append(out, ns)
 	}
 	return out
+}
+
+// buildCacheOptions restricts the manager cache to the watched namespaces.
+//
+// The operator also reads its own backup credentials Secret from its release
+// namespace. That namespace used to be added to DefaultNamespaces, which
+// started an informer there for every watched type -- Deployments,
+// StatefulSets, Services and the rest. The chart only renders Roles in the
+// watched namespaces, so those informers failed with Forbidden and the manager
+// never started (#586). Only the Secret informer is widened instead, which is
+// all the credential read actually needs.
+func buildCacheOptions(watchNamespaces []string, operatorNamespace string) cache.Options {
+	defaultNamespaces := make(map[string]cache.Config, len(watchNamespaces))
+	secretNamespaces := make(map[string]cache.Config, len(watchNamespaces)+1)
+	for _, ns := range watchNamespaces {
+		defaultNamespaces[ns] = cache.Config{}
+		secretNamespaces[ns] = cache.Config{}
+	}
+	secretNamespaces[operatorNamespace] = cache.Config{}
+
+	return cache.Options{
+		DefaultNamespaces: defaultNamespaces,
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {Namespaces: secretNamespaces},
+		},
+	}
 }
 
 // setupOTLPMetrics configures an OTLP gRPC metrics exporter that bridges all

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -13,6 +13,9 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 )
 
 func TestParseWatchNamespaces(t *testing.T) {
@@ -36,5 +39,59 @@ func TestParseWatchNamespaces(t *testing.T) {
 				t.Fatalf("parseWatchNamespaces(%q) = %#v, want %#v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// Regression tests for #586: adding the operator namespace to DefaultNamespaces
+// started informers there for every watched type, which the chart's namespaced
+// Roles do not grant, so the manager failed to start.
+func TestBuildCacheOptions_DefaultNamespacesExcludeOperatorNamespace(t *testing.T) {
+	opts := buildCacheOptions([]string{"team-a", "team-b"}, "openclaw-operator-system")
+
+	if _, ok := opts.DefaultNamespaces["openclaw-operator-system"]; ok {
+		t.Error("operator namespace must not be in DefaultNamespaces - it would start an informer per watched type there")
+	}
+	for _, ns := range []string{"team-a", "team-b"} {
+		if _, ok := opts.DefaultNamespaces[ns]; !ok {
+			t.Errorf("watched namespace %q missing from DefaultNamespaces", ns)
+		}
+	}
+	if len(opts.DefaultNamespaces) != 2 {
+		t.Errorf("DefaultNamespaces = %d entries, want 2", len(opts.DefaultNamespaces))
+	}
+}
+
+func TestBuildCacheOptions_SecretsReachOperatorNamespace(t *testing.T) {
+	opts := buildCacheOptions([]string{"team-a"}, "openclaw-operator-system")
+
+	var secretCfg *cache.ByObject
+	for obj, cfg := range opts.ByObject {
+		if _, ok := obj.(*corev1.Secret); ok {
+			c := cfg
+			secretCfg = &c
+		}
+	}
+	if secretCfg == nil {
+		t.Fatal("expected a per-object cache config for Secrets")
+	}
+
+	// The backup credentials Secret lives in the operator namespace, and the
+	// watched namespaces still need their own Secret reads.
+	for _, ns := range []string{"team-a", "openclaw-operator-system"} {
+		if _, ok := secretCfg.Namespaces[ns]; !ok {
+			t.Errorf("Secret informer should cover namespace %q", ns)
+		}
+	}
+}
+
+// When the operator watches its own namespace, it must not appear twice.
+func TestBuildCacheOptions_OperatorNamespaceAlsoWatched(t *testing.T) {
+	opts := buildCacheOptions([]string{"openclaw-operator-system", "team-a"}, "openclaw-operator-system")
+
+	if len(opts.DefaultNamespaces) != 2 {
+		t.Errorf("DefaultNamespaces = %d entries, want 2", len(opts.DefaultNamespaces))
+	}
+	if _, ok := opts.DefaultNamespaces["openclaw-operator-system"]; !ok {
+		t.Error("an explicitly watched operator namespace should still be in DefaultNamespaces")
 	}
 }


### PR DESCRIPTION
Refs #586.

## What actually reproduces

The primary claim in #586 — that the default cluster-wide install ships a ClusterRole with only `get`/`list` on `openclawclusterdefaults` — **does not reproduce**. Rendering the chart at defaults produces `<release>-manager-role` carrying the full kubebuilder rule set:

```
$ helm template rel charts/openclaw-operator --set webhook.enabled=true --set metrics.serviceMonitor.enabled=true
# ClusterRole rel-openclaw-operator-manager-role: configmaps, secrets, services,
# serviceaccounts, pvcs, events, pods, statefulsets, deployments, jobs, cronjobs,
# roles/rolebindings, networkpolicies/ingresses, httproutes, poddisruptionbudgets,
# horizontalpodautoscalers, servicemonitors/prometheusrules, openclawinstances(+status,
# +finalizers), openclawselfconfigs(+status, +finalizers)
```

The `-manager-role-cluster` name in the report only renders on the `watchNamespaces`-non-empty path, which points at the reporter's "Related" section as the actual defect — and that one **does** reproduce.

## The real bug

`cmd/main.go` added the operator's own namespace to cache `DefaultNamespaces` so it could read `s3-backup-credentials`. `DefaultNamespaces` applies to *every* watched type, so it also started Deployment, StatefulSet, Service, ConfigMap and other informers in the operator namespace. The chart only renders Roles in the *watched* namespaces — the operator manages no child resources in its own namespace — so those informers failed with exactly the Forbidden error in the report and the manager never started.

Only the Secret informer is widened now (`cache.Options.ByObject`), which is all `getS3Credentials()` needs. The chart renders a matching Secret-only `Role` in the release namespace, skipped when that namespace is already in `watchNamespaces`.

## Testing

- `buildCacheOptions()` extracted from `main()` so the scoping is unit-tested: operator namespace absent from `DefaultNamespaces`, present in the Secret informer, and no duplication when it is itself watched
- chart rendering verified in both modes, including the dedup case
- `make test`, `make lint`, and the RBAC guard scripts pass

I'll follow up on the issue asking the reporter to confirm their `watchNamespaces` value, since that reconciles both halves of their report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)