### PR TITLE
test(e2e): harden the flaky CDP reachability spec and cover ingress allowlists

### DIFF
--- a/test/e2e/e2e_chromium_cdp_test.go
+++ b/test/e2e/e2e_chromium_cdp_test.go
@@ -398,29 +398,45 @@ var _ = Describe("Chromium CDP Functional Tests", Ordered, func() {
 			"CDP headless Service should have at least one endpoint address")
 
 		By(fmt.Sprintf("Running curl from a temporary pod to %s", cdpURL))
-		// Chrome's DevTools HTTP server returns 500 for requests with long
-		// Host headers (like Kubernetes service DNS names). Override the
-		// Host header to localhost so Chrome handles the request correctly.
-		cmd := exec.Command("kubectl", "run", testPodName,
-			"--rm", "-i",
-			"--restart=Never",
-			"--timeout=60s",
-			"--namespace", namespace,
-			"--image=curlimages/curl",
-			"--", "curl", "-sf", "--max-time", "10",
-			"-H", "Host: localhost",
-			cdpURL,
-		)
+		// The endpoint gate above only proves the pod is Ready -- Chrome's
+		// DevTools HTTP server may still be starting, so the first attempt can
+		// legitimately fail. Retry rather than failing the spec on a race (#585).
+		//
+		// -sS keeps the progress meter quiet but still prints transport errors,
+		// and -f is deliberately absent: with it, a non-2xx produced an empty
+		// body and the assertion reported a missing webSocketDebuggerUrl when
+		// the real cause was an HTTP error. The status code is captured
+		// separately so a failure says what actually happened.
+		var outputStr string
+		attempt := 0
+		Eventually(func() string {
+			attempt++
+			// Chrome's DevTools HTTP server returns 500 for requests with long
+			// Host headers (like Kubernetes service DNS names). Override the
+			// Host header to localhost so Chrome handles the request correctly.
+			cmd := exec.Command("kubectl", "run", fmt.Sprintf("%s-%d", testPodName, attempt),
+				"--rm", "-i",
+				"--restart=Never",
+				"--timeout=60s",
+				"--namespace", namespace,
+				// Fully qualified: short names are ambiguous under CRI-O short
+				// name enforcing, same reason as #562.
+				"--image=docker.io/curlimages/curl:8.11.1",
+				"--", "curl", "-sS", "--max-time", "10",
+				"-w", "\nHTTP_STATUS:%{http_code}\n",
+				"-H", "Host: localhost",
+				cdpURL,
+			)
 
-		output, err := cmd.CombinedOutput()
-		outputStr := string(output)
-
-		GinkgoWriter.Printf("kubectl run output: %s\n", outputStr)
-
-		Expect(err).NotTo(HaveOccurred(),
-			"curl to CDP service should succeed, output: %s", outputStr)
-		Expect(outputStr).To(ContainSubstring("webSocketDebuggerUrl"),
+			output, err := cmd.CombinedOutput()
+			outputStr = string(output)
+			GinkgoWriter.Printf("kubectl run output (err=%v): %s\n", err, outputStr)
+			return outputStr
+		}, 90*time.Second, 5*time.Second).Should(ContainSubstring("webSocketDebuggerUrl"),
 			"response from CDP headless Service should contain webSocketDebuggerUrl")
+
+		Expect(outputStr).To(ContainSubstring("HTTP_STATUS:200"),
+			"CDP endpoint should return 200, output: %s", outputStr)
 	})
 })
 

--- a/test/e2e/e2e_networkpolicy_test.go
+++ b/test/e2e/e2e_networkpolicy_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026 Paperclip Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	openclawv1alpha1 "github.com/paperclipinc/openclaw-operator/api/v1alpha1"
+	"github.com/paperclipinc/openclaw-operator/internal/resources"
+)
+
+// Regression coverage for #587, which reported that
+// security.networkPolicy.allowedIngressNamespaces was accepted but never
+// applied. The builder and the reconcile path both handle the field and unit
+// tests cover the builder, so this asserts the same thing end-to-end on a real
+// cluster: the namespaces reach the generated NetworkPolicy, and they keep
+// reaching it after the field is edited on an existing instance.
+var _ = Describe("NetworkPolicy ingress allowlists", func() {
+	const (
+		timeout  = time.Second * 60
+		interval = time.Second * 1
+	)
+
+	var namespace string
+
+	BeforeEach(func() {
+		if os.Getenv("E2E_SKIP_RESOURCE_VALIDATION") == "true" {
+			Skip("Skipping resource validation in minimal mode")
+		}
+		namespace = "test-netpol-" + time.Now().Format("20060102150405")
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+		_ = k8sClient.Delete(ctx, ns)
+	})
+
+	// ingressNamespaces returns every namespace named by the policy's ingress peers.
+	ingressNamespaces := func(np *networkingv1.NetworkPolicy) []string {
+		var out []string
+		for _, rule := range np.Spec.Ingress {
+			for _, peer := range rule.From {
+				if peer.NamespaceSelector != nil {
+					if ns, ok := peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; ok {
+						out = append(out, ns)
+					}
+				}
+			}
+		}
+		return out
+	}
+
+	It("Should apply allowedIngressNamespaces to the generated NetworkPolicy", func() {
+		instanceName := "netpol-allowlist"
+		instance := &openclawv1alpha1.OpenClawInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instanceName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"openclaw.rocks/skip-backup": "true",
+				},
+			},
+			Spec: openclawv1alpha1.OpenClawInstanceSpec{
+				Image: openclawv1alpha1.ImageSpec{
+					Repository: "ghcr.io/openclaw/openclaw",
+					Tag:        "latest",
+				},
+			},
+		}
+		instance.Spec.Security.NetworkPolicy.AllowedIngressNamespaces = []string{"some-other-namespace"}
+		Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+		np := &networkingv1.NetworkPolicy{}
+		npKey := types.NamespacedName{
+			Name:      resources.NetworkPolicyName(instance),
+			Namespace: namespace,
+		}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, npKey, np)
+		}, timeout, interval).Should(Succeed())
+
+		Expect(ingressNamespaces(np)).To(ContainElement("some-other-namespace"),
+			"allowedIngressNamespaces should produce a namespaceSelector ingress peer")
+		Expect(ingressNamespaces(np)).To(ContainElement(namespace),
+			"the same-namespace default rule should still be present")
+	})
+
+	It("Should converge the NetworkPolicy when allowedIngressNamespaces is edited", func() {
+		instanceName := "netpol-allowlist-edit"
+		instance := &openclawv1alpha1.OpenClawInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instanceName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"openclaw.rocks/skip-backup": "true",
+				},
+			},
+			Spec: openclawv1alpha1.OpenClawInstanceSpec{
+				Image: openclawv1alpha1.ImageSpec{
+					Repository: "ghcr.io/openclaw/openclaw",
+					Tag:        "latest",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+		npKey := types.NamespacedName{
+			Name:      resources.NetworkPolicyName(instance),
+			Namespace: namespace,
+		}
+		np := &networkingv1.NetworkPolicy{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, npKey, np)
+		}, timeout, interval).Should(Succeed())
+		Expect(ingressNamespaces(np)).NotTo(ContainElement("added-later"))
+
+		By("adding a namespace to an existing instance")
+		Eventually(func() error {
+			current := &openclawv1alpha1.OpenClawInstance{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{
+				Name: instanceName, Namespace: namespace,
+			}, current); err != nil {
+				return err
+			}
+			current.Spec.Security.NetworkPolicy.AllowedIngressNamespaces = []string{"added-later"}
+			return k8sClient.Update(ctx, current)
+		}, timeout, interval).Should(Succeed())
+
+		Eventually(func() []string {
+			updated := &networkingv1.NetworkPolicy{}
+			if err := k8sClient.Get(ctx, npKey, updated); err != nil {
+				return nil
+			}
+			return ingressNamespaces(updated)
+		}, timeout, interval).Should(ContainElement("added-later"),
+			"editing allowedIngressNamespaces should be reflected in the NetworkPolicy")
+	})
+})


### PR DESCRIPTION
Closes #585. Refs #587.

## #585 - flaky CDP Tier 3 spec

All three contributing factors from the issue are addressed:

| Problem | Fix |
|---------|-----|
| `curl -sf` silent on failure — a non-2xx or connection error yielded an empty body, so the assertion blamed a missing `webSocketDebuggerUrl` when the real cause was an HTTP error | `-sS` without `-f`, plus `-w '\nHTTP_STATUS:%{http_code}\n'` so the status is asserted separately |
| The endpoint gate only waits for Service endpoints (pod-Ready), not for Chrome's DevTools HTTP server to accept connections — hence the 3.9s failure, too fast for a CDP timeout | the curl is retried under `Eventually` (90s / 5s) instead of failing the spec on that race |
| `--image=curlimages/curl` is an unqualified short name, ambiguous under CRI-O short name enforcing | qualified to `docker.io/curlimages/curl:8.11.1`, same reason as #562 |

The pod name now carries an attempt suffix so retries don't collide.

## #587 - allowedIngressNamespaces

I could not find a code defect. `BuildNetworkPolicy` has handled the field since the initial commit (`internal/resources/networkpolicy.go:148`), `resources_test.go:1875` already asserts the rule is generated, and `reconcileNetworkPolicy` writes the full spec through `CreateOrUpdate` — all true at the reported v0.38.3.

Rather than guess at a fix, this adds the end-to-end coverage that was missing: on a real cluster, `allowedIngressNamespaces` produces the `namespaceSelector` ingress peer, the same-namespace default rule survives, and editing the field on an existing instance converges the NetworkPolicy. If the report is real, this is the test that should have caught it — and if it starts failing in CI we'll have the reproduction.

Leaving #587 open pending the reporter's operator logs and full CR; commenting there separately.

## Testing

`go vet` and `make lint` pass. The e2e specs themselves run in CI against kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)