### PR TITLE
test(e2e): make the forcePaths restart wait tolerant and legible

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,6 +235,10 @@ jobs:
     name: E2E Tests
     needs: [lint, test, security-scan]
     runs-on: ubuntu-latest
+    # Bounded well above the go test -timeout in `make test-e2e` so the Go
+    # binary is what reports a hang, with the failing spec named, rather than
+    # the job being cut off with no test output at all.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -263,8 +267,10 @@ jobs:
         run: |
           docker pull docker.io/chromedp/headless-shell:stable
           kind load docker-image docker.io/chromedp/headless-shell:stable --name e2e-test
-          docker pull curlimages/curl
-          kind load docker-image curlimages/curl --name e2e-test
+          # Must match the reference the CDP spec requests exactly, or the
+          # pre-load is a no-op and the test pulls from the network mid-run.
+          docker pull docker.io/curlimages/curl:8.11.1
+          kind load docker-image docker.io/curlimages/curl:8.11.1 --name e2e-test
 
       - name: Install CRDs
         run: make install

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,12 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests.
-	go test ./test/e2e/... -v -count=1
+# go test defaults to a 10 minute timeout for the WHOLE package. The suite
+# already runs 7-8 minutes on a healthy kind runner and has exceeded 10 on a
+# loaded one, where the binary is killed mid-spec and reports a goroutine dump
+# instead of the spec that was slow. The budget has to leave room for the
+# multi-minute pod-readiness waits these tests legitimately need.
+	go test ./test/e2e/... -v -count=1 -timeout 30m
 
 .PHONY: scorecard
 scorecard: operator-sdk ## Run operator-sdk scorecard tests.

--- a/test/e2e/e2e_force_paths_test.go
+++ b/test/e2e/e2e_force_paths_test.go
@@ -140,7 +140,7 @@ var _ = Describe("OpenClawInstance forcePaths (#500)", func() {
 				summarizeStatuses(pod.Status.InitContainerStatuses),
 				summarizeStatuses(pod.Status.ContainerStatuses))
 			return false
-		}, 5*time.Minute, 5*time.Second).Should(BeTrue(),
+		}, 10*time.Minute, 5*time.Second).Should(BeTrue(),
 			"openclaw container should be Running")
 
 		// Capture the operator-managed gateway.auth.token before tampering.
@@ -200,14 +200,26 @@ var _ = Describe("OpenClawInstance forcePaths (#500)", func() {
 		oldUID := oldPod.UID
 		Expect(k8sClient.Delete(ctx, oldPod)).To(Succeed())
 
+		// Every instance gets init-uv, init-pip and init-plugin-runtime-deps
+		// unconditionally, so a pod becoming Running is gated on three init
+		// containers doing network and filesystem work. On a loaded kind runner
+		// that has exceeded five minutes with init-uv not yet even started, so
+		// the ceiling is generous here -- a slow runner should not read as a
+		// broken forcePaths rebuild.
+		//
+		// The closure logs pod state so a timeout shows what was actually
+		// blocking (image pull, init container, scheduling) instead of a bare
+		// "expected true", matching the pre-restart wait above.
 		Eventually(func() bool {
 			pod := &corev1.Pod{}
 			if err := k8sClient.Get(ctx, types.NamespacedName{
 				Name: podName, Namespace: namespace,
 			}, pod); err != nil {
+				GinkgoWriter.Printf("post-restart pod get error: %v\n", err)
 				return false
 			}
 			if pod.UID == oldUID {
+				GinkgoWriter.Printf("post-restart pod %s still has the old UID\n", podName)
 				return false
 			}
 			for _, cs := range pod.Status.ContainerStatuses {
@@ -215,8 +227,12 @@ var _ = Describe("OpenClawInstance forcePaths (#500)", func() {
 					return true
 				}
 			}
+			GinkgoWriter.Printf("post-restart pod %s phase=%s init=%s containers=%s\n",
+				podName, pod.Status.Phase,
+				summarizeStatuses(pod.Status.InitContainerStatuses),
+				summarizeStatuses(pod.Status.ContainerStatuses))
 			return false
-		}, 5*time.Minute, 5*time.Second).Should(BeTrue(),
+		}, 10*time.Minute, 5*time.Second).Should(BeTrue(),
 			"new openclaw pod should be Running after restart")
 
 		// The contract: gateway.auth.token was under "gateway" (a forcePath),

--- a/test/e2e/e2e_force_paths_test.go
+++ b/test/e2e/e2e_force_paths_test.go
@@ -223,9 +223,19 @@ var _ = Describe("OpenClawInstance forcePaths (#500)", func() {
 				return false
 			}
 			for _, cs := range pod.Status.ContainerStatuses {
-				if cs.Name == "openclaw" && cs.State.Running != nil {
+				if cs.Name != "openclaw" {
+					continue
+				}
+				// Ready, not merely Running: a container that has just entered
+				// Running can still be replaced moments later, and the exec
+				// below then fails with container not found. With probes
+				// disabled Ready follows Running, so this costs nothing on a
+				// healthy pod while refusing a container that is cycling.
+				if cs.State.Running != nil && cs.Ready {
 					return true
 				}
+				GinkgoWriter.Printf("post-restart openclaw ready=%t restarts=%d state=%s\n",
+					cs.Ready, cs.RestartCount, summarizeStatuses([]corev1.ContainerStatus{cs}))
 			}
 			GinkgoWriter.Printf("post-restart pod %s phase=%s init=%s containers=%s\n",
 				podName, pod.Status.Phase,
@@ -233,7 +243,7 @@ var _ = Describe("OpenClawInstance forcePaths (#500)", func() {
 				summarizeStatuses(pod.Status.ContainerStatuses))
 			return false
 		}, 10*time.Minute, 5*time.Second).Should(BeTrue(),
-			"new openclaw pod should be Running after restart")
+			"new openclaw pod should be Ready after restart")
 
 		// The contract: gateway.auth.token was under "gateway" (a forcePath),
 		// so init-config deleted the gateway subtree before deep-merging the
@@ -260,7 +270,11 @@ var _ = Describe("OpenClawInstance forcePaths (#500)", func() {
 			// Suppress unused-variable lint if the original token capture
 			// was useful only for the pre-restart assertion above.
 			_ = originalToken
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
+			// Five minutes, not two: kubectl exec fails with container not
+			// found while the container is being replaced, so the window has
+			// to outlast a restart cycle on a loaded runner rather than
+			// reporting a transient exec failure as a broken rebuild.
+		}, 5*time.Minute, 5*time.Second).Should(Succeed())
 
 		Expect(k8sClient.Delete(ctx, instance)).Should(Succeed())
 	})


### PR DESCRIPTION
Unblocks #590, #593 and #594, all of which were failing CI on this test rather than on their own changes.

## What was happening

`OpenClawInstance forcePaths (#500) [It] Should rebuild a forcePath subtree from the CR after a pod restart` started failing across branches. The pod state at timeout:

```
pod forcepaths-e2e-0 phase=Pending
  init=[init-config=Terminated(Completed, exit=0)
        init-uv=Waiting(PodInitializing)
        init-pip=Waiting(PodInitializing)
        init-plugin-runtime-deps=Waiting(PodInitializing)]
```

`init-config` completed and `init-uv` had not yet **started**. Nothing about forcePaths was broken — the node was just saturated.

`init-uv`, `init-pip` and `init-plugin-runtime-deps` are appended to *every* instance unconditionally (`statefulset.go:618-623`), so any e2e wait for a pod to reach Running is gated on three init containers doing network and filesystem work. On a loaded kind runner that exceeds the five-minute ceiling. The suite took 460s on a failing run vs 318s on a passing one, which is the load showing up directly.

## Changes

- both pod-Running waits raised from 5 to 10 minutes, so a slow runner does not read as a broken forcePaths rebuild
- the **post-restart** wait had no diagnostic logging at all, so a timeout reported a bare `expected true` with nothing about what blocked. It now logs phase and init/container state like the pre-restart wait already did — same reasoning as #585

I confirmed this is not a regression from the PRs it was blocking: for #594 I diffed the rendered StatefulSet, NetworkPolicy, ConfigMap, Role and init script against `main` for this test's exact instance shape (`mergeMode: merge` + `forcePaths: [gateway]` + persistence) and they are byte-identical.

Not addressed here, but worth its own issue: three unconditional network-bound init containers on every pod start makes the whole e2e suite timing-sensitive. Gating `init-uv`/`init-pip` on whether anything actually needs them would remove a class of flake rather than widen its window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)